### PR TITLE
Gcp-vertical-scaling

### DIFF
--- a/src/outputs/data/terraform-root-file-data.ts
+++ b/src/outputs/data/terraform-root-file-data.ts
@@ -524,6 +524,12 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
           },
         ],
       },
+      google_project_services: {
+        cndi_enable_project_services: {
+          disable_on_destroy: false,
+          services: ["compute.googleapis.com"],
+        },
+      },
       google_compute_instance_group: {
         cndi_cluster: {
           description: "group of instances that form a cndi cluster",

--- a/src/outputs/data/terraform-root-file-data.ts
+++ b/src/outputs/data/terraform-root-file-data.ts
@@ -528,12 +528,14 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
         cndi_enable_cloudresourcemanager_service: {
           disable_on_destroy: false,
           service: "cloudresourcemanager.googleapis.com",
-          depends_on: []
+          depends_on: [],
         },
         cndi_enable_compute_service: {
           disable_on_destroy: false,
           service: "compute.googleapis.com",
-          depends_on: ["google_project_service.cndi_enable_cloudresourcemanager_service"]
+          depends_on: [
+            "google_project_service.cndi_enable_cloudresourcemanager_service",
+          ],
         },
       },
       google_compute_instance_group: {
@@ -552,7 +554,7 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
         cndi_vpc_network: {
           auto_create_subnetworks: false,
           name: "cndi-vpc-network",
-          depends_on: ["google_project_service.cndi_enable_compute_service"]
+          depends_on: ["google_project_service.cndi_enable_compute_service"],
         },
       },
       google_compute_subnetwork: {
@@ -621,7 +623,7 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
           name: "cndi-healthcheck",
           tcp_health_check: [{ port: 80 }],
           timeout_sec: 1,
-          depends_on: ["google_project_service.cndi_enable_compute_service"]
+          depends_on: ["google_project_service.cndi_enable_compute_service"],
         },
       },
       google_compute_region_backend_service: {

--- a/src/outputs/data/terraform-root-file-data.ts
+++ b/src/outputs/data/terraform-root-file-data.ts
@@ -524,10 +524,10 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
           },
         ],
       },
-      google_project_services: {
-        cndi_enable_project_services: {
+      google_project_service: {
+        cndi_enable_project_service: {
           disable_on_destroy: false,
-          services: ["compute.googleapis.com"],
+          service: "compute.googleapis.com"
         },
       },
       google_compute_instance_group: {

--- a/src/outputs/data/terraform-root-file-data.ts
+++ b/src/outputs/data/terraform-root-file-data.ts
@@ -527,12 +527,14 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
       google_project_service: {
         cndi_enable_cloudresourcemanager_service: {
           disable_on_destroy: false,
-          service: "cloudresourcemanager.googleapis.com"
-        }, 
+          service: "cloudresourcemanager.googleapis.com",
+          depends_on: []
+        },
         cndi_enable_compute_service: {
           disable_on_destroy: false,
-          service: "compute.googleapis.com"
-        }, 
+          service: "compute.googleapis.com",
+          depends_on: ["google_project_service.cndi_enable_cloudresourcemanager_service"]
+        },
       },
       google_compute_instance_group: {
         cndi_cluster: {
@@ -550,6 +552,7 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
         cndi_vpc_network: {
           auto_create_subnetworks: false,
           name: "cndi-vpc-network",
+          depends_on: ["google_project_service.cndi_enable_compute_service"]
         },
       },
       google_compute_subnetwork: {
@@ -618,6 +621,7 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
           name: "cndi-healthcheck",
           tcp_health_check: [{ port: 80 }],
           timeout_sec: 1,
+          depends_on: ["google_project_service.cndi_enable_compute_service"]
         },
       },
       google_compute_region_backend_service: {

--- a/src/outputs/data/terraform-root-file-data.ts
+++ b/src/outputs/data/terraform-root-file-data.ts
@@ -525,10 +525,14 @@ const gcpTerraformRootFileData: GCPTerraformRootFileData = {
         ],
       },
       google_project_service: {
-        cndi_enable_project_service: {
+        cndi_enable_cloudresourcemanager_service: {
+          disable_on_destroy: false,
+          service: "cloudresourcemanager.googleapis.com"
+        }, 
+        cndi_enable_compute_service: {
           disable_on_destroy: false,
           service: "compute.googleapis.com"
-        },
+        }, 
       },
       google_compute_instance_group: {
         cndi_cluster: {

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -59,9 +59,7 @@ const getGCPNodeResource = (
   const machine_type = entry?.machine_type || entry?.instance_type ||
     deploymentTargetConfiguration?.machine_type || DEFAULT_MACHINE_TYPE;
   const allow_stopping_for_update = true; // If true, allows Terraform to stop the instance to update its properties.
-  const auto_delete = true; // Whether the disk will be auto-deleted when the instance is deleted. Defaults to true.
-  // The size of the image in gigabytes
-  const DEFAULT_SIZE = 100;
+  const DEFAULT_SIZE = 100; // The size of the image in gigabytes
   const size = entry?.size || entry?.volume_size || DEFAULT_SIZE;
   const type = "pd-ssd"; //  The GCE disk type. Such as pd-standard, pd-balanced or pd-ssd.
   const network_tier = "STANDARD";

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -67,7 +67,7 @@ const getGCPNodeResource = (
   const subnetwork =
     "${google_compute_subnetwork.cndi_vpc_subnetwork.self_link}"; //The name or self_link of the subnetwork to attach this interface to.
   const access_config = [{ network_tier }]; //Access config that set whether the instance can be accessed via the Internet. Omitting = not accessible from the Internet.
-  const source = `google_compute_disk.${name}-cndi-disk.self_link`;
+  const source = `\${google_compute_disk.${name}-cndi-disk.self_link}`;
   const boot_disk = [
     {
       source,

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -69,13 +69,10 @@ const getGCPNodeResource = (
   const subnetwork =
     "${google_compute_subnetwork.cndi_vpc_subnetwork.self_link}"; //The name or self_link of the subnetwork to attach this interface to.
   const access_config = [{ network_tier }]; //Access config that set whether the instance can be accessed via the Internet. Omitting = not accessible from the Internet.
-
+  const source = `google_compute_disk.${name}-cndi-disk.self_link`;
   const boot_disk = [
     {
-      auto_delete,
-      initialize_params: [
-        { image, size, type },
-      ],
+      source,
     },
   ];
 

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -83,7 +83,7 @@ const getGCPNodeResource = (
   ];
   const google_compute_disk = {
     [`${name}-cndi-disk`]: {
-      name,
+      name: `${name}-cndi-disk`,
       image,
       size,
       type,

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -87,7 +87,7 @@ const getGCPNodeResource = (
       image,
       size,
       type,
-      depends_on: ["google_project_service.cndi_enable_compute_service"]
+      depends_on: ["google_project_service.cndi_enable_compute_service"],
     },
   };
   const nodeResource: GCPTerraformNodeResource = {
@@ -186,19 +186,19 @@ const getAWSNodeResource = (
   const target_id = `\${aws_instance.${name}.id}`;
   const aws_lb_target_group_attachment:
     AWSTerraformTargetGroupAttachmentResource = {
-    [`tg-https-target-${name}`]: [
-      {
-        target_group_arn: target_group_arn_https,
-        target_id,
-      },
-    ],
-    [`tg-http-target-${name}`]: [
-      {
-        target_group_arn: target_group_arn_http,
-        target_id,
-      },
-    ],
-  };
+      [`tg-https-target-${name}`]: [
+        {
+          target_group_arn: target_group_arn_https,
+          target_id,
+        },
+      ],
+      [`tg-http-target-${name}`]: [
+        {
+          target_group_arn: target_group_arn_http,
+          target_id,
+        },
+      ],
+    };
 
   const nodeResource: AWSTerraformNodeResource = {
     resource: {

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -87,6 +87,7 @@ const getGCPNodeResource = (
       image,
       size,
       type,
+      depends_on: ["google_project_service.cndi_enable_compute_service"]
     },
   };
   const nodeResource: GCPTerraformNodeResource = {
@@ -185,19 +186,19 @@ const getAWSNodeResource = (
   const target_id = `\${aws_instance.${name}.id}`;
   const aws_lb_target_group_attachment:
     AWSTerraformTargetGroupAttachmentResource = {
-      [`tg-https-target-${name}`]: [
-        {
-          target_group_arn: target_group_arn_https,
-          target_id,
-        },
-      ],
-      [`tg-http-target-${name}`]: [
-        {
-          target_group_arn: target_group_arn_http,
-          target_id,
-        },
-      ],
-    };
+    [`tg-https-target-${name}`]: [
+      {
+        target_group_arn: target_group_arn_https,
+        target_id,
+      },
+    ],
+    [`tg-http-target-${name}`]: [
+      {
+        target_group_arn: target_group_arn_http,
+        target_id,
+      },
+    ],
+  };
 
   const nodeResource: AWSTerraformNodeResource = {
     resource: {

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -83,7 +83,14 @@ const getGCPNodeResource = (
       subnetwork,
     },
   ];
-
+  const google_compute_disk = {
+    [`${name}-cndi-disk`]: {
+      name,
+      image,
+      size,
+      type,
+    },
+  };
   const nodeResource: GCPTerraformNodeResource = {
     resource: {
       google_compute_instance: {
@@ -98,6 +105,7 @@ const getGCPNodeResource = (
           tags: [name],
         },
       },
+      google_compute_disk,
     },
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,13 @@ interface GCPTerraformNodeResource {
   };
 }
 
+
+interface GCPTerraformProjectServicesResource {
+  cndi_enable_project_services: {
+    disable_on_destroy: boolean;
+    services: Array<string>;
+  };
+}
 interface GCPTerraformInstanceGroupResource {
   cndi_cluster: {
     description: string;
@@ -511,6 +518,7 @@ interface GCPTerraformRootFileData {
       google_compute_region_health_check: GCPTerraformRegionHealthcheckResource;
       google_compute_region_backend_service:
         GCPTerraformRegionBackendServiceResource;
+      google_project_services: GCPTerraformProjectServicesResource;
     },
   ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,9 +88,18 @@ interface GCPTerraformNodeResource {
         tags: Array<string>;
       };
     };
+    google_compute_disk: GCPTerraformDiskResource;
   };
 }
 
+interface GCPTerraformDiskResource {
+  [cndi_disk: string]: {
+    name: string;
+    size: number;
+    type: string;
+    image: string;
+  };
+}
 
 interface GCPTerraformProjectServicesResource {
   cndi_enable_project_services: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,12 +65,7 @@ interface GCPTerraformNodeResource {
       [name: string]: {
         allow_stopping_for_update: boolean;
         boot_disk: Array<{
-          auto_delete: boolean;
-          initialize_params: Array<{
-            image: string;
-            size: number;
-            type: string;
-          }>;
+          source: string;
         }>;
         depends_on?: Array<string>;
         machine_type: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ interface GCPTerraformProjectServiceResource {
     disable_on_destroy: boolean;
     service: string;
     depends_on?: Array<string>;
-  }
+  };
 }
 interface GCPTerraformInstanceGroupResource {
   cndi_cluster: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -522,7 +522,7 @@ interface GCPTerraformRootFileData {
       google_compute_region_health_check: GCPTerraformRegionHealthcheckResource;
       google_compute_region_backend_service:
         GCPTerraformRegionBackendServiceResource;
-      google_project_services: GCPTerraformProjectServiceResource;
+      google_project_service: GCPTerraformProjectServiceResource;
     },
   ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,10 +96,10 @@ interface GCPTerraformDiskResource {
   };
 }
 
-interface GCPTerraformProjectServicesResource {
-  cndi_enable_project_services: {
+interface GCPTerraformProjectServiceResource {
+  cndi_enable_project_service: {
     disable_on_destroy: boolean;
-    services: Array<string>;
+    service: string;
   };
 }
 interface GCPTerraformInstanceGroupResource {
@@ -522,7 +522,7 @@ interface GCPTerraformRootFileData {
       google_compute_region_health_check: GCPTerraformRegionHealthcheckResource;
       google_compute_region_backend_service:
         GCPTerraformRegionBackendServiceResource;
-      google_project_services: GCPTerraformProjectServicesResource;
+      google_project_services: GCPTerraformProjectServiceResource;
     },
   ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,10 +97,10 @@ interface GCPTerraformDiskResource {
 }
 
 interface GCPTerraformProjectServiceResource {
-  cndi_enable_project_service: {
+  [cndi_enable_project_service: string]: {
     disable_on_destroy: boolean;
     service: string;
-  };
+  }
 }
 interface GCPTerraformInstanceGroupResource {
   cndi_cluster: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,7 @@ interface GCPTerraformProjectServiceResource {
   [cndi_enable_project_service: string]: {
     disable_on_destroy: boolean;
     service: string;
+    depends_on?: Array<string>;
   }
 }
 interface GCPTerraformInstanceGroupResource {
@@ -119,6 +120,7 @@ interface GCPTerraformNetworkResource {
   cndi_vpc_network: {
     auto_create_subnetworks: boolean;
     name: string;
+    depends_on?: Array<string>;
   };
 }
 
@@ -166,6 +168,7 @@ interface GCPTerraformRegionHealthcheckResource {
       port: number;
     }>;
     timeout_sec: number;
+    depends_on?: Array<string>;
   };
 }
 interface GCPTerraformRegionBackendServiceResource {


### PR DESCRIPTION
added a persistent disk independent from virtual machine instance that can resize without triggering the vms to be recreated