### PR TITLE
if `terraform apply` fails, let it ride

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -58,9 +58,10 @@ const runFn = async ({
 
     const applyStatus = await ranTerraformApply.status();
 
+    // if `terraform apply` fails, exit the process and swallow the error
     if (applyStatus.code !== 0) {
       console.log(runLabel, brightRed("terraform apply failed"));
-      Deno.exit(1);
+      Deno.exit(0);
     }
 
     ranTerraformApply.close();


### PR DESCRIPTION
Before this PR, when `cndi run` failed to `terraform apply` we would throw the error with a non-zero exit status. This meant that if the apply fails in GitHub actions, we throw away the state.

By changing the exit status to `0` on a failed `terraform apply` we are signalling to the caller (currently only GitHub Actions) that the workflow should continue to run.