### PR TITLE
Add_suffix_to_nodes

### DIFF
--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -105,6 +105,7 @@ const getGCPNodeResource = (
         },
       },
       google_compute_disk,
+      random_string,
     },
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,14 @@ interface GCPTerraformNodeResource {
       };
     };
     google_compute_disk: GCPTerraformDiskResource;
+interface GCPTerraformRandomStringResource {
+  [suffix: string]: {
+    keepers: {
+      size: string;
+    };
+    length: number;
+    special: boolean;
+    upper: boolean;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,10 @@ interface GCPTerraformNodeResource {
       };
     };
     google_compute_disk: GCPTerraformDiskResource;
+    random_string: GCPTerraformRandomStringResource;
+  };
+}
+
 interface GCPTerraformRandomStringResource {
   [suffix: string]: {
     keepers: {


### PR DESCRIPTION
Triggers a new suffix for the instance if the disk size  on the instance is changed  this allow for the instance to join the instance group without having to terraform apply twice

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk