### PR TITLE
install microk8s in packer, then microk8s leave at run-time

### DIFF
--- a/cndi-config.jsonc
+++ b/cndi-config.jsonc
@@ -6,8 +6,7 @@
       "nodes": [
         {
           "name": "x-node",
-          "kind": "remote",
-          "host": "localhost:3000",
+          "kind": "aws",
           "role": "leader",
           "instance_type": "m5a.2xlarge",
           "volume_size": 128

--- a/cndi-config.jsonc
+++ b/cndi-config.jsonc
@@ -6,7 +6,8 @@
       "nodes": [
         {
           "name": "x-node",
-          "kind": "aws",
+          "kind": "remote",
+          "host": "localhost:3000",
           "role": "leader",
           "instance_type": "m5a.2xlarge",
           "volume_size": 128

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "2",
   "remote": {
+    "https://deno.land/std@0.158.0/fmt/colors.ts": "ff7dc9c9f33a72bd48bc24b21bbc1b4545d8494a431f17894dbc5fe92a938fc4",
     "https://deno.land/std@0.161.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
     "https://deno.land/std@0.161.0/_util/os.ts": "8a33345f74990e627b9dfe2de9b040004b08ea5146c7c9e8fe9a29070d193934",
     "https://deno.land/std@0.161.0/encoding/base64.ts": "c57868ca7fa2fbe919f57f88a623ad34e3d970d675bdc1ff3a9d02bba7409db2",

--- a/src/bootstrap/controller_bootstrap_cndi.sh.ts
+++ b/src/bootstrap/controller_bootstrap_cndi.sh.ts
@@ -6,22 +6,16 @@ const bootstrapShellScript = `
 
 echo "bootstrapping controller"
 
-echo "Installing nfs-common"
-sudo apt-get install nfs-common -y
-
-echo "Installing microk8s"
-
-while ! sudo snap install microk8s --classic --channel=1.26/stable
-do
-    echo 'microk8s failed to install, retrying in 180 seconds'
-    sleep 180
-done
-
 echo "Adding user to group"
 sudo usermod -a -G microk8s ubuntu
 
 echo "granting access to ~/.kube"
 sudo chown -f -R ubuntu ~/.kube
+
+# in order to get a fresh install we need to leave the og packer cluster
+echo "running microk8s leave"
+sudo microk8s leave
+echo "packer microk8s cluster was left"
 
 echo "awaiting microk8s to be ready"
 

--- a/src/bootstrap/controller_bootstrap_cndi.sh.ts
+++ b/src/bootstrap/controller_bootstrap_cndi.sh.ts
@@ -4,6 +4,12 @@ const bootstrapShellScript = `
 
 # Controller Bootstrap Template
 
+# build-time packer:
+# sudo apt-get install nfs-common -y
+# sudo snap install microk8s --classic --channel=1.26/stable
+
+# run-time cloud-init: 
+
 echo "bootstrapping controller"
 
 echo "Adding user to group"

--- a/src/bootstrap/leader_bootstrap_cndi.sh.ts
+++ b/src/bootstrap/leader_bootstrap_cndi.sh.ts
@@ -6,22 +6,16 @@ const bootstrapShellScript = `
 
 echo "bootstrapping leader"
 
-echo "Installing nfs-common"
-sudo apt-get install nfs-common -y
-
-echo "Installing microk8s"
-
-while ! sudo snap install microk8s --classic --channel=1.26/stable
-do
-    echo 'microk8s failed to install, retrying in 180 seconds'
-    sleep 180
-done
-
 echo "Adding user to group"
 sudo usermod -a -G microk8s ubuntu
 
 echo "granting access to ~/.kube"
 sudo chown -f -R ubuntu ~/.kube
+
+# in order to get a fresh install we need to leave the og packer cluster
+echo "running microk8s leave"
+sudo microk8s leave
+echo "packer microk8s cluster was left"
 
 echo "awaiting microk8s to be ready"
 sudo microk8s status --wait-ready

--- a/src/bootstrap/leader_bootstrap_cndi.sh.ts
+++ b/src/bootstrap/leader_bootstrap_cndi.sh.ts
@@ -4,6 +4,12 @@ const bootstrapShellScript = `
 
 # Leader Bootstrap Template
 
+# build-time packer:
+# sudo apt-get install nfs-common -y
+# sudo snap install microk8s --classic --channel=1.26/stable
+
+# run-time cloud-init: 
+
 echo "bootstrapping leader"
 
 echo "Adding user to group"

--- a/src/outputs/terraform-node-resource.ts
+++ b/src/outputs/terraform-node-resource.ts
@@ -330,7 +330,7 @@ const getAWSNodeResource = (
   deployment_target_configuration: AWSDeploymentTargetConfiguration,
   leaderName: string,
 ) => {
-  const DEFAULT_AMI = "ami-0c1704bac156af62c";
+  const DEFAULT_AMI = "ami-0dfb83551482f2819"; // PACKER AMI
   const DEFAULT_INSTANCE_TYPE = "m5a.large";
   const { name } = node;
   const role = node.role as NodeRole;


### PR DESCRIPTION
This is a proof-of-concept that we can install `microk8s` in a packer image to ensure that part is reliable, then we can leave  the old cluster from the packer build during cloud-init.