### PR TITLE
add "cndi destroy" command

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "2",
   "remote": {
+    "https://deno.land/std@0.158.0/fmt/colors.ts": "ff7dc9c9f33a72bd48bc24b21bbc1b4545d8494a431f17894dbc5fe92a938fc4",
     "https://deno.land/std@0.161.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
     "https://deno.land/std@0.161.0/_util/os.ts": "8a33345f74990e627b9dfe2de9b040004b08ea5146c7c9e8fe9a29070d193934",
     "https://deno.land/std@0.161.0/encoding/base64.ts": "c57868ca7fa2fbe919f57f88a623ad34e3d970d675bdc1ff3a9d02bba7409db2",

--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -9,6 +9,7 @@ import {
   loadJSONC,
 } from "./utils.ts";
 import { COMMAND } from "./types.ts";
+
 import {
   brightRed,
   cyan,
@@ -22,6 +23,7 @@ import overwriteFn from "./commands/overwrite.ts";
 import helpFn from "./commands/help.ts";
 import installFn from "./commands/install.ts";
 import terraformFn from "./commands/terraform.ts";
+import destroyFn from "./commands/destroy.ts";
 
 const cndiLabel = white("src/cndi:");
 
@@ -153,6 +155,7 @@ export default async function main(args: string[]) {
     [COMMAND.help]: helpFn,
     [COMMAND.install]: installFn,
     [COMMAND.terraform]: terraformFn,
+    [COMMAND.destroy]: destroyFn,
     [COMMAND.default]: (c: string) => {
       console.log(
         `Command "${c}" not found. Use "cndi --help" for more information.`,
@@ -214,6 +217,9 @@ export default async function main(args: string[]) {
         break;
       case COMMAND.run:
         await commands[COMMAND.run](context);
+        break;
+      case COMMAND.destroy:
+        await commands[COMMAND.destroy](context);
         break;
       case COMMAND.overwrite:
         await commands[COMMAND.overwrite](context);

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -1,0 +1,80 @@
+import "https://deno.land/std@0.173.0/dotenv/load.ts";
+import { copy } from "https://deno.land/std@0.173.0/streams/copy.ts";
+
+import pullStateForRun from "../tfstate/git/read-state.ts";
+import pushStateFromRun from "../tfstate/git/write-state.ts";
+
+import { brightRed, white } from "https://deno.land/std@0.173.0/fmt/colors.ts";
+import setTF_VARs from "../setTF_VARs.ts";
+import { CNDIContext } from "../types.ts";
+
+const destroyLabel = white("destroy:");
+
+/**
+ * COMMAND fn: cndi destroy
+ * Destroys the CNDI cluster that was created with this repo
+ */
+const destroyFn = async ({
+  pathToTerraformBinary,
+  pathToTerraformResources,
+}: CNDIContext) => {
+  const cmd = "cndi destroy";
+  console.log(`${cmd}\n`);
+  try {
+    setTF_VARs(); // set TF_VARs using CNDI's .env variables
+
+    await pullStateForRun({ pathToTerraformResources, cmd });
+
+    // terraform.tfstate will be in this folder after the first run
+    const ranTerraformInit = Deno.run({
+      cmd: [
+        pathToTerraformBinary,
+        `-chdir=${pathToTerraformResources}`,
+        "init",
+      ],
+      stderr: "piped",
+      stdout: "piped",
+    });
+
+    copy(ranTerraformInit.stdout, Deno.stdout);
+    copy(ranTerraformInit.stderr, Deno.stderr);
+
+    const initStatus = await ranTerraformInit.status();
+
+    if (initStatus.code !== 0) {
+      console.log(destroyLabel, brightRed("terraform init failed"));
+      Deno.exit(initStatus.code);
+    }
+
+    ranTerraformInit.close();
+
+    const ranTerraformDestroy = Deno.run({
+      cmd: [
+        pathToTerraformBinary,
+        `-chdir=${pathToTerraformResources}`,
+        "destroy",
+        // "-auto-approve" is an option, but I don't think we want it for destroy calls
+      ],
+      stderr: "piped",
+      stdout: "piped",
+    });
+
+    copy(ranTerraformDestroy.stdout, Deno.stdout);
+    copy(ranTerraformDestroy.stderr, Deno.stderr);
+
+    const applyStatus = await ranTerraformDestroy.status();
+
+    await pushStateFromRun({ pathToTerraformResources, cmd });
+
+    // if `terraform apply` fails, exit with the code
+    if (applyStatus.code !== 0) {
+      Deno.exit(applyStatus.code);
+    }
+
+    ranTerraformDestroy.close();
+  } catch (err) {
+    console.log(destroyLabel, brightRed("unhandled error"), err);
+  }
+};
+
+export default destroyFn;

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -25,7 +25,6 @@ const destroyFn = async ({
 
     await pullStateForRun({ pathToTerraformResources, cmd });
 
-    // terraform.tfstate will be in this folder after the first run
     const ranTerraformInit = Deno.run({
       cmd: [
         pathToTerraformBinary,
@@ -62,13 +61,13 @@ const destroyFn = async ({
     copy(ranTerraformDestroy.stdout, Deno.stdout);
     copy(ranTerraformDestroy.stderr, Deno.stderr);
 
-    const applyStatus = await ranTerraformDestroy.status();
+    const destroyStatus = await ranTerraformDestroy.status();
 
     await pushStateFromRun({ pathToTerraformResources, cmd });
 
-    // if `terraform apply` fails, exit with the code
-    if (applyStatus.code !== 0) {
-      Deno.exit(applyStatus.code);
+    // if `terraform destroy` fails, exit with the code
+    if (destroyStatus.code !== 0) {
+      Deno.exit(destroyStatus.code);
     }
 
     ranTerraformDestroy.close();

--- a/src/deployment-targets/azure.ts
+++ b/src/deployment-targets/azure.ts
@@ -1,5 +1,5 @@
 import { EnvObject } from "../types.ts";
-import { cyan } from "https://deno.land/std@0.158.0/fmt/colors.ts";
+import { cyan } from "https://deno.land/std@0.173.0/fmt/colors.ts";
 import { Secret } from "https://deno.land/x/cliffy@v0.25.4/prompt/secret.ts";
 import { Input } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
 

--- a/src/doc/help-strings.ts
+++ b/src/doc/help-strings.ts
@@ -4,6 +4,7 @@ type HelpStrings = {
   install: string;
   overwrite: string;
   terraform: string;
+  destroy: string;
   ow: string;
   run: string;
   help: string;
@@ -76,6 +77,14 @@ SYNOPSIS
         cndi run
 DESCRIPTION
         Reads files in the user's cndi directory and deploys as a cndi cluster
+  `.trim(),
+  destroy: `
+NAME
+        cndi-destroy - destroys the CNDI cluster associated with the cndi project in the target directory
+SYNOPSIS
+        cndi destroy
+DESCRIPTION
+        Calls "terraform destroy" on the cndi project in the target directory
   `.trim(),
   install: `
 NAME

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export const COMMAND = {
   install: "install",
   terraform: "terraform",
   ow: "ow",
+  destroy: "destroy",
 } as const;
 
 export const NODE_ROLE = {


### PR DESCRIPTION
Now that terraform state is managed within CNDI we are able to provide a `cndi destroy` command for use by humans on their machines.