### PR TITLE
multiline env strings and improved gcp creds

### DIFF
--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -43,7 +43,6 @@ export default async function main(args: string[]) {
   const pathToOpenSSL = getPathToOpenSSLForPlatform();
   const executionDirectory = Deno.cwd();
 
-  console.log("Deno.env.nla", Deno.env.get("SEALED_SECRETS_PRIVATE_KEY"));
   // CNDI_SRC is determined at compile time, that's no good
   const CNDI_SRC = path.join(CNDI_HOME, "src");
   const pathToKubeseal = path.join(

--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -43,6 +43,7 @@ export default async function main(args: string[]) {
   const pathToOpenSSL = getPathToOpenSSLForPlatform();
   const executionDirectory = Deno.cwd();
 
+  console.log("Deno.env.nla", Deno.env.get("SEALED_SECRETS_PRIVATE_KEY"));
   // CNDI_SRC is determined at compile time, that's no good
   const CNDI_SRC = path.join(CNDI_HOME, "src");
   const pathToKubeseal = path.join(

--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -28,8 +28,6 @@ import { loadTerraformStatePassphrase } from "../initialize/terraformStatePassph
 
 import { loadArgoUIAdminPassword } from "../initialize/argoUIAdminPassword.ts";
 
-import { getEnvStringWithGoogleCredentials } from "../deployment-targets/gcp.ts";
-
 import {
   brightRed,
   cyan,
@@ -221,22 +219,6 @@ const overwriteWithFn = async (context: CNDIContext, initializing = false) => {
     });
     console.log();
     Deno.exit(1);
-  }
-
-  if (requiredProviders.has("gcp")) {
-    // if there is a service account key path
-    // read the contents and create a string of .env contents with the key
-    // caution: this needs to run before the terraform root file is created
-    const envStringIncludingGCPCreds = getEnvStringWithGoogleCredentials(
-      context,
-    );
-    if (envStringIncludingGCPCreds) {
-      await stageFile(
-        context.stagingDirectory,
-        ".env",
-        envStringIncludingGCPCreds,
-      );
-    }
   }
 
   // generate setup-cndi.tf.json which depends on which kind of nodes are being deployed

--- a/src/deployment-targets/gcp.ts
+++ b/src/deployment-targets/gcp.ts
@@ -1,130 +1,18 @@
 import {
   brightRed,
   cyan,
-  green,
   white,
-  yellow,
 } from "https://deno.land/std@0.173.0/fmt/colors.ts";
-import { homedir } from "https://deno.land/std@0.173.0/node/os.ts?s=homedir";
-import * as path from "https://deno.land/std@0.173.0/path/mod.ts";
-import { CNDIContext, EnvObject } from "../types.ts";
+import { EnvObject } from "../types.ts";
 import { Input } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
+import { homedir } from "https://deno.land/std@0.173.0/node/os.ts?s=homedir";
+// import { wrapMultilineEnv } from "../utils.ts";
 
 const deploymentTargetsLabel = white("deployment-targets/gcp:");
 
-const GCP_PATH_TO_SERVICE_ACCOUNT_KEY_ENVKEY =
-  "GCP_PATH_TO_SERVICE_ACCOUNT_KEY";
-const GOOGLE_CREDENTIALS_ENVKEY = "GOOGLE_CREDENTIALS";
-
-// pull contents of the gcp service account key file into the env, and write them to .env
-const getEnvStringWithGoogleCredentials = (
-  context: CNDIContext,
-): string | void => {
-  const { projectDirectory } = context;
-
-  const dotEnvPath = path.join(projectDirectory, ".env");
-
-  const gcp_path_to_service_account_key = Deno.env.get(
-    GCP_PATH_TO_SERVICE_ACCOUNT_KEY_ENVKEY,
-  );
-
-  const google_credentials = Deno.env.get(GOOGLE_CREDENTIALS_ENVKEY);
-
-  const shouldAttemptToLoadKey = !google_credentials &&
-    gcp_path_to_service_account_key;
-  const pathToKeyAndCredentialsMissing = !gcp_path_to_service_account_key &&
-    !google_credentials;
-
-  // if the user interactively provides a path to a service account key, we copy it to `.env` and discard the path
-  if (shouldAttemptToLoadKey) {
-    try {
-      const keyText = Deno.readTextFileSync(
-        gcp_path_to_service_account_key.replace("~", homedir() || "~"),
-      );
-
-      // we were successfully able to read a file at the path provided by the user
-      if (keyText) {
-        // load the contents of `.env`
-        const dotEnvContents = Deno.readTextFileSync(dotEnvPath);
-
-        // break the file into an array of lines
-        const dotEnvLines = dotEnvContents.split("\n");
-
-        // find the line where the "GCP_PATH_TO_SERVICE_ACCOUNT_KEY" is defined eg. "GCP_PATH_TO_SERVICE_ACCOUNT_KEY=/path/to/key.json"
-        // and replace the line that has the path with the a line that has the contents of the service account key
-        const newDotEnvLines = dotEnvLines.map((line) => {
-          if (line.indexOf(GCP_PATH_TO_SERVICE_ACCOUNT_KEY_ENVKEY) === 0) {
-            const keyTextMinified = keyText.replaceAll("\n", " ");
-            Deno.env.set(GOOGLE_CREDENTIALS_ENVKEY, keyTextMinified);
-            return `# ${GCP_PATH_TO_SERVICE_ACCOUNT_KEY_ENVKEY}=${gcp_path_to_service_account_key}\n${GOOGLE_CREDENTIALS_ENVKEY}=${keyTextMinified}`; // eg. GOOGLE_CREDENTIALS="{"project_id":"my-project-id"...}"
-          }
-          return line;
-        });
-
-        // join the array of lines back into a string
-        const newDotEnvContents = newDotEnvLines.join("\n");
-        return newDotEnvContents;
-      }
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        // if the user provided a path to a service account key, but we couldn't find a file at that path
-
-        const PLACEHOLDER_SUFFIX = "_PLACEHOLDER__";
-        const placeholderPathVal =
-          `${GCP_PATH_TO_SERVICE_ACCOUNT_KEY_ENVKEY}${PLACEHOLDER_SUFFIX}`;
-
-        // check if the value is the default value uninitialized variables
-        if (gcp_path_to_service_account_key === placeholderPathVal) {
-          console.log(
-            yellow(
-              `\n\n${
-                brightRed(
-                  "ERROR",
-                )
-              }: ${GCP_PATH_TO_SERVICE_ACCOUNT_KEY_ENVKEY} not found in environment`,
-            ),
-          );
-          console.log(
-            `You need to replace `,
-            cyan(placeholderPathVal),
-            `with the desired value in "${dotEnvPath}"\nthen run ${
-              green("cndi ow")
-            }\n`,
-          );
-        } else {
-          // if the path was provided by the user, but we couldn't find a file at that path and it was not the default value
-          // raise the error
-          console.log(
-            deploymentTargetsLabel,
-            brightRed(`GCP Service Account Key not found at path:`),
-            `"${gcp_path_to_service_account_key}"`,
-          );
-        }
-      } else {
-        console.log(
-          deploymentTargetsLabel,
-          brightRed(`Unhandled error reading GCP Service Account Key:`),
-        );
-        console.log(error);
-      }
-    }
-  } else if (pathToKeyAndCredentialsMissing) {
-    console.log(
-      deploymentTargetsLabel,
-      brightRed(`you need to have either`),
-      `\"${GCP_PATH_TO_SERVICE_ACCOUNT_KEY_ENVKEY}\"`,
-      brightRed("or"),
-      `\"${GOOGLE_CREDENTIALS_ENVKEY}\"`,
-      brightRed(
-        `defined in the environment when deploying to ${cyan('"gcp"')}\n`,
-      ),
-    );
-  }
-};
-
 const prepareGCPEnv = async (interactive: boolean): Promise<EnvObject> => {
   const GCP_REGION = "us-central1";
-  const GCP_PATH_TO_SERVICE_ACCOUNT_KEY = "";
+  let GOOGLE_CREDENTIALS = "";
 
   const gcpEnvObject: EnvObject = {};
 
@@ -138,16 +26,58 @@ const prepareGCPEnv = async (interactive: boolean): Promise<EnvObject> => {
       : GCP_REGION,
   };
 
-  gcpEnvObject.GCP_PATH_TO_SERVICE_ACCOUNT_KEY = {
-    value: interactive
-      ? ((await Input.prompt({
-        message: cyan("Enter the path to your GCP service account key json:"),
-        default: GCP_PATH_TO_SERVICE_ACCOUNT_KEY,
-      })) as string)
-      : GCP_PATH_TO_SERVICE_ACCOUNT_KEY,
-  };
+  if (interactive) {
+    let credentials_string;
+
+    const google_credentials_path = (
+      (await Input.prompt({
+        message: cyan("Enter the path to your GCP credentials JSON:"),
+      })) as string
+    ).replace("~", homedir() || "~");
+
+    // if path to google json key is invalid, throw an error
+    try {
+      credentials_string = await Deno.readTextFile(google_credentials_path);
+    } catch {
+      console.log(
+        `${deploymentTargetsLabel} ${
+          brightRed(
+            `No GCP JSON key file found at the provided path ${
+              white(
+                `\"${google_credentials_path}\"`,
+              )
+            }`,
+          )
+        }`,
+      );
+      Deno.exit(1);
+    }
+
+    // if the path to google json key is valid, but the file is not a valid json, throw an error
+    try {
+      JSON.parse(credentials_string);
+    } catch {
+      console.log(
+        `${deploymentTargetsLabel} ${
+          brightRed(
+            `Invalid GCP JSON key file found at the provided path ${
+              white(
+                `\"${google_credentials_path}\"`,
+              )
+            }`,
+          )
+        }`,
+      );
+      Deno.exit(1);
+    }
+
+    // if the path to google json key is valid, and the file is a valid json, write the GOOGLE_CREDENTIALS env variable
+    GOOGLE_CREDENTIALS = credentials_string;
+  }
+
+  gcpEnvObject.GOOGLE_CREDENTIALS = { value: GOOGLE_CREDENTIALS };
 
   return gcpEnvObject;
 };
 
-export { getEnvStringWithGoogleCredentials, prepareGCPEnv };
+export { prepareGCPEnv };

--- a/src/deployment-targets/shared.ts
+++ b/src/deployment-targets/shared.ts
@@ -6,7 +6,6 @@ import {
 } from "../types.ts";
 import { Secret } from "https://deno.land/x/cliffy@v0.25.4/prompt/secret.ts";
 import { Input } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
-import { trimPemString } from "../utils.ts";
 
 import { prepareAWSEnv } from "../deployment-targets/aws.ts";
 import { prepareGCPEnv } from "../deployment-targets/gcp.ts";
@@ -16,6 +15,8 @@ import {
   cyan,
   white,
 } from "https://deno.land/std@0.173.0/fmt/colors.ts";
+
+// import { wrapMultilineEnv } from "../utils.ts";
 
 const deploymentTargetsSharedLabel = white("deployment-targets/shared:");
 
@@ -68,21 +69,13 @@ const getCoreEnvObject = async (
     Deno.exit(1);
   }
 
-  const SEALED_SECRETS_PUBLIC_KEY_MATERIAL = trimPemString(
-    sealedSecretsKeys.sealed_secrets_public_key,
-  ).replaceAll("\n", "_");
-
-  const SEALED_SECRETS_PRIVATE_KEY_MATERIAL = trimPemString(
-    sealedSecretsKeys.sealed_secrets_private_key,
-  ).replaceAll("\n", "_");
-
   const coreEnvObject: EnvObject = {
-    SEALED_SECRETS_PUBLIC_KEY_MATERIAL: {
+    SEALED_SECRETS_PUBLIC_KEY: {
       comment: "Sealed Secrets keys for Kubeseal",
-      value: SEALED_SECRETS_PUBLIC_KEY_MATERIAL,
+      value: sealedSecretsKeys.sealed_secrets_public_key,
     },
-    SEALED_SECRETS_PRIVATE_KEY_MATERIAL: {
-      value: SEALED_SECRETS_PRIVATE_KEY_MATERIAL,
+    SEALED_SECRETS_PRIVATE_KEY: {
+      value: sealedSecretsKeys.sealed_secrets_private_key,
     },
     ARGO_UI_ADMIN_PASSWORD: {
       comment: "ArgoUI",

--- a/src/initialize/sealedSecretsKeys.ts
+++ b/src/initialize/sealedSecretsKeys.ts
@@ -1,4 +1,3 @@
-import { padPrivatePem, padPublicPem } from "../utils.ts";
 import * as path from "https://deno.land/std@0.173.0/path/mod.ts";
 
 import { CNDIContext, SealedSecretsKeys } from "../types.ts";
@@ -58,28 +57,23 @@ const createSealedSecretsKeys = async ({
 };
 
 const loadSealedSecretsKeys = (): SealedSecretsKeys | null => {
-  const sealed_secrets_public_key_material = Deno.env
-    .get("SEALED_SECRETS_PUBLIC_KEY_MATERIAL")
-    ?.trim()
-    .replaceAll("_", "\n");
-  const sealed_secrets_private_key_material = Deno.env
-    .get("SEALED_SECRETS_PRIVATE_KEY_MATERIAL")
-    ?.trim()
-    .replaceAll("_", "\n");
+  const sealed_secrets_public_key = Deno.env
+    .get("SEALED_SECRETS_PUBLIC_KEY") as string;
 
-  if (!sealed_secrets_public_key_material) {
+  const sealed_secrets_private_key = Deno.env
+    .get("SEALED_SECRETS_PRIVATE_KEY") as string;
+
+  if (!sealed_secrets_public_key) {
     return null;
   }
 
-  if (!sealed_secrets_private_key_material) {
+  if (!sealed_secrets_private_key) {
     return null;
   }
 
   const sealedSecrets = {
-    sealed_secrets_private_key: padPrivatePem(
-      sealed_secrets_private_key_material,
-    ),
-    sealed_secrets_public_key: padPublicPem(sealed_secrets_public_key_material),
+    sealed_secrets_private_key,
+    sealed_secrets_public_key,
   };
 
   return sealedSecrets;

--- a/src/outputs/env.ts
+++ b/src/outputs/env.ts
@@ -5,15 +5,15 @@ const PLACEHOLDER_SUFFIX = "_PLACEHOLDER__";
 const writeEnvObject = (envObj: EnvObject): string => {
   const dotEnvString = Object.keys(envObj)
     .map((key) => {
-      const val = (
+      const val = ((
         envObj[key]?.value ? envObj[key].value : `${key}${PLACEHOLDER_SUFFIX}`
-      ) as string;
+      ) as string).trim();
 
       const comment = envObj[key]?.comment ? `\n# ${envObj[key].comment}` : "";
 
       Deno.env.set(key, val);
 
-      return `${comment}\n${key}=${val}`;
+      return `${comment}\n${key}='${val}'`;
     })
     .join("\n")
     .trim();

--- a/src/outputs/terraform-root-file.ts
+++ b/src/outputs/terraform-root-file.ts
@@ -63,12 +63,17 @@ const getTerraformRootFile = ({
   if (requiredProviders.has("gcp")) {
     const gcpMainTerraformFileObject = { ...gcpTerraformRootFileData };
     const googleCredentials = Deno.env.get("GOOGLE_CREDENTIALS") as string;
+    console.log("googleCredentials: ", googleCredentials);
     if (!googleCredentials) {
+      console.log("google credentials are missing");
       // the message about missing credentials should have already been printed
       Deno.exit(1);
     }
 
     const region = (Deno.env.get("GCP_REGION") as string) || DEFAULT_GCP_REGION;
+
+    // we parse the key to extract the project_id for use in terraform
+    // the json key is only used for auth within `cndi run`
     let parsedJSONServiceAccountKey: { project_id: string };
     try {
       parsedJSONServiceAccountKey = JSON.parse(googleCredentials);

--- a/src/setTF_VARs.ts
+++ b/src/setTF_VARs.ts
@@ -1,4 +1,3 @@
-import { padPrivatePem, padPublicPem } from "./utils.ts";
 import { brightRed, white } from "https://deno.land/std@0.173.0/fmt/colors.ts";
 
 const setTF_VARsLabel = white("setTF_VARs:");
@@ -31,39 +30,29 @@ export default function setTF_VARs() {
     Deno.exit(1);
   }
 
-  const sealed_secrets_private_key_material = Deno.env
-    .get("SEALED_SECRETS_PRIVATE_KEY_MATERIAL")
-    ?.trim()
-    .replaceAll("_", "\n");
+  const sealed_secrets_private_key = Deno.env
+    .get("SEALED_SECRETS_PRIVATE_KEY")
+    ?.trim();
 
-  if (!sealed_secrets_private_key_material) {
+  if (!sealed_secrets_private_key) {
     console.log(
       setTF_VARsLabel,
-      brightRed("SEALED_SECRETS_PRIVATE_KEY_MATERIAL env var is not set"),
+      brightRed("SEALED_SECRETS_PRIVATE_KE env var is not set"),
     );
     Deno.exit(1);
   }
 
-  const sealed_secrets_public_key_material = Deno.env
-    .get("SEALED_SECRETS_PUBLIC_KEY_MATERIAL")
-    ?.trim()
-    .replaceAll("_", "\n");
+  const sealed_secrets_public_key = Deno.env
+    .get("SEALED_SECRETS_PUBLIC_KEY")
+    ?.trim();
 
-  if (!sealed_secrets_public_key_material) {
+  if (!sealed_secrets_public_key) {
     console.log(
       setTF_VARsLabel,
-      brightRed("SEALED_SECRETS_PUBLIC_KEY_MATERIAL env var is not set"),
+      brightRed("SEALED_SECRETS_PUBLIC_KEY env var is not set"),
     );
     Deno.exit(1);
   }
-
-  const sealed_secrets_private_key = padPrivatePem(
-    sealed_secrets_private_key_material,
-  );
-
-  const sealed_secrets_public_key = padPublicPem(
-    sealed_secrets_public_key_material,
-  );
 
   Deno.env.set("TF_VAR_git_username", git_username);
   Deno.env.set("TF_VAR_git_password", git_password);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,21 +142,6 @@ function getSecretOfLength(len = 32): string {
   return Array.from(values, base10intToHex).join("");
 }
 
-// /**
-//  * Wraps a multiline string in quotes and newlines for use in env files
-//  * @param multilineString the multiline env string to wrap
-//  * @returns formatted env block string
-//  */
-// function wrapMultilineEnv(multilineString: string): string {
-//   return `'${multilineString.trim()}'`;
-// }
-
-// function unwrapMultilineEnv(envBlockString: string): string {
-//   const unwrapped = envBlockString.trim().slice(1, -1);
-//   console.log("unwrapped", unwrapped);
-//   return unwrapped.trim();
-// }
-
 export {
   checkInitialized,
   checkInstalled,
@@ -169,6 +154,4 @@ export {
   persistStagedFiles,
   stageFile,
   stageFileSync,
-  // wrapMultilineEnv,
-  // unwrapMultilineEnv,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,13 +3,8 @@ import * as path from "https://deno.land/std@0.173.0/path/mod.ts";
 import { platform } from "https://deno.land/std@0.173.0/node/os.ts";
 import { walk } from "https://deno.land/std@0.173.0/fs/mod.ts";
 import { CNDIContext, NODE_KIND, NodeKind } from "./types.ts";
+
 // helper function to load a JSONC file
-
-const CERT_TOP = "-----BEGIN CERTIFICATE-----\n";
-const CERT_BOTTOM = "\n-----END CERTIFICATE-----\n";
-const PRIVATE_KEY_TOP = "-----BEGIN PRIVATE KEY-----\n";
-const PRIVATE_KEY_BOTTOM = "\n-----END PRIVATE KEY-----\n";
-
 const loadJSONC = async (path: string) => {
   return JSONC.parse(await Deno.readTextFile(path));
 };
@@ -106,26 +101,6 @@ const getFileSuffixForPlatform = () => {
   return fileSuffixForPlatform[currentPlatform];
 };
 
-const trimPemString = (key: string): string => {
-  const trimmedKey = key
-    .replace(CERT_TOP, "")
-    .replace(CERT_BOTTOM, "")
-    .replace(PRIVATE_KEY_BOTTOM, "")
-    .replace(PRIVATE_KEY_TOP, "");
-  return trimmedKey;
-};
-
-const padPrivatePem = (keyMaterial: string): string => {
-  const paddedPrivateKey =
-    `${PRIVATE_KEY_TOP}${keyMaterial}${PRIVATE_KEY_BOTTOM}`;
-  return paddedPrivateKey;
-};
-
-const padPublicPem = (keyMaterial: string): string => {
-  const paddedPublicKey = `${CERT_TOP}${keyMaterial}${CERT_BOTTOM}`;
-  return paddedPublicKey;
-};
-
 const getPathToOpenSSLForPlatform = () => {
   const currentPlatform = platform() as "linux" | "darwin" | "win32";
 
@@ -167,6 +142,21 @@ function getSecretOfLength(len = 32): string {
   return Array.from(values, base10intToHex).join("");
 }
 
+// /**
+//  * Wraps a multiline string in quotes and newlines for use in env files
+//  * @param multilineString the multiline env string to wrap
+//  * @returns formatted env block string
+//  */
+// function wrapMultilineEnv(multilineString: string): string {
+//   return `'${multilineString.trim()}'`;
+// }
+
+// function unwrapMultilineEnv(envBlockString: string): string {
+//   const unwrapped = envBlockString.trim().slice(1, -1);
+//   console.log("unwrapped", unwrapped);
+//   return unwrapped.trim();
+// }
+
 export {
   checkInitialized,
   checkInstalled,
@@ -176,10 +166,9 @@ export {
   getPrettyJSONString,
   getSecretOfLength,
   loadJSONC,
-  padPrivatePem,
-  padPublicPem,
   persistStagedFiles,
   stageFile,
   stageFileSync,
-  trimPemString,
+  // wrapMultilineEnv,
+  // unwrapMultilineEnv,
 };


### PR DESCRIPTION
Now that we are going to be able to use multiline environment variables we can greatly simplify a lot of code, especially around keys for GCP and Sealed Secrets

- [x] simplify google credentials
- [x] multiline keys in `.env`