### PR TITLE
use cloudflare public dns in microk8s addon

### DIFF
--- a/src/bootstrap/leader_bootstrap_cndi.sh.ts
+++ b/src/bootstrap/leader_bootstrap_cndi.sh.ts
@@ -41,7 +41,7 @@ echo "token registered"
 echo "enabling microk8s addons"
 
 echo "  dns"
-sudo microk8s enable dns
+sudo microk8s enable dns:1.1.1.1
 
 echo "  ingress"
 sudo microk8s enable ingress


### PR DESCRIPTION
By default the microk8s dns addon uses google's dns service, and DNS was being weird on google compute engine, so this PR swaps it out for [Cloudflare's DNS](https://microk8s.io/docs/addon-dns#:~:text=microk8s%20enable%20dns%3A1.1.1.1).

If ArgoCD in `gcp/airflow-tls` works without errors on this branch _and_ we can consistently reproduce them on the `main` branch, this should be a fix for #197 
