### PR TITLE
install.sh: more automation and functioning windows exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ To install CNDI we just need to download the binary and add it to our PATH. This
 can be done using the script below:
 
 ```bash
-# if you are on windows you should run this in 'git bash' with Windows Terminal
 curl -fsSL https://raw.githubusercontent.com/polyseam/cndi/main/install.sh | sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ can be done using the script below:
 ```bash
 # if you are on windows you should run this in 'git bash'
 curl -fsSL https://raw.githubusercontent.com/polyseam/cndi/main/install.sh | sh
-# now add the binary to your PATH such that it is executable in your shell
 ```
 
 ## usage

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install CNDI we just need to download the binary and add it to our PATH. This
 can be done using the script below:
 
 ```bash
-# if you are on windows you should run this in 'git bash'
+# if you are on windows you should run this in 'git bash' with Windows Terminal
 curl -fsSL https://raw.githubusercontent.com/polyseam/cndi/main/install.sh | sh
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -37,8 +37,8 @@ main() {
     chmod +x "$exe"
     
     echo "cndi was downloaded successfully to $exe"
-
-	# set shell profile for user shell
+    
+    # set shell profile for user shell
     case "$SHELL" in
         /bin/zsh) shell_profile=".zshrc" ;;
         *) shell_profile=".bash_profile" ;;
@@ -46,7 +46,7 @@ main() {
     
     # append or create alias in $shell_profile
     if [ "$OS" = "Windows_NT" ]; then
-        windows_alias = "alias cndi='winpty $exe'"
+        windows_alias="alias cndi='winpty $exe'"
         # if $windows_alias is not in $shell_profile then append it
         if ! grep -q "$windows_alias" "$HOME/$shell_profile"; then
             echo "creating alias for Windows..."

--- a/install.sh
+++ b/install.sh
@@ -3,72 +3,74 @@
 set -e
 
 main() {
-	cndi_install="${CNDI_INSTALL:-$HOME/bin}"
-	bin_suffix=""
-	if [ "$OS" = "Windows_NT" ]; then
-		bin_suffix=".exe"
-		target="win.exe"
-	else
-		case $(uname -sm) in
-		"Darwin x86_64") target="mac" ;;
-		"Darwin arm64") target="mac" ;;
-		"Linux aarch64")
-			echo "Error: Official CNDI builds for Linux aarch64 are not available" 1>&2
-			exit 1
-			;;
-		"Linux x86_64")
-			target="linux"
-			;;
-		*)
-			target="linux"
-		esac
-	fi
+    cndi_install="${CNDI_INSTALL:-$HOME/bin}"
+    bin_suffix=""
+    if [ "$OS" = "Windows_NT" ]; then
+        bin_suffix=".exe"
+        target="win.exe"
+    else
+        case $(uname -sm) in
+            "Darwin x86_64") target="mac" ;;
+            "Darwin arm64") target="mac" ;;
+            "Linux aarch64")
+                echo "Error: Official CNDI builds for Linux aarch64 are not available" 1>&2
+                exit 1
+            ;;
+            "Linux x86_64")
+                target="linux"
+            ;;
+            *)
+                target="linux"
+        esac
+    fi
+    
+    cndi_uri="https://github.com/polyseam/cndi/releases/latest/download/cndi-${target}"
+    
+    exe="$cndi_install/cndi$bin_suffix"
+    
+    if [ ! -d "$cndi_install" ]; then
+        mkdir -p "$cndi_install"
+    fi
+    
+    echo "$cndi_uri"
+    curl --fail --location --progress-bar --output "$exe" "$cndi_uri"
+    chmod +x "$exe"
+    
+    echo "cndi was downloaded successfully to $exe"
 
-	cndi_uri="https://github.com/polyseam/cndi/releases/latest/download/cndi-${target}"
-
-	exe="$cndi_install/cndi$bin_suffix"
-
-	if [ ! -d "$cndi_install" ]; then
-		mkdir -p "$cndi_install"
-	fi
-
-	echo "$cndi_uri"
-	curl --fail --location --progress-bar --output "$exe" "$cndi_uri"
-	chmod +x "$exe"
-
-	echo "cndi was downloaded successfully to $exe"
-
-	if ! command -v cndi >/dev/null; then
-		case "$SHELL" in
-		/bin/zsh) shell_profile=".zshrc" ;;
-		*) shell_profile=".bash_profile" ;;
-		esac
-
-		# append or create alias in $shell_profile
-		if [ "$OS" = "Windows_NT" ]; then
-			windows_alias = "alias cndi='winpty $exe'"
-			# if $windows_alias is not in $shell_profile then append it
-			if ! grep -q "$windows_alias" "$HOME/$shell_profile"; then
-				echo "creating alias for Windows..."
-				echo "$windows_alias" | tee -a "$HOME/$shell_profile"
-			fi
-		fi
-
-		# if ~/bin is not in $PATH then append it
-		if ! grep -q "$cndi_install" "$HOME/$shell_profile"; then
-			echo "adding $cndi_install to \$PATH"
-			command printf '\nexport PATH="%s:$PATH"' "$cndi_install" >>"$HOME/$shell_profile"
-			echo "Please restart your terminal then run 'cndi --help' to get started!"
-			exit 0 # exit early because sourcing $shell_profile will not work in this shell (probably macOS)
-		fi
-
-		# source $shell_profile
-		if [ -f "$HOME/$shell_profile" ]; then
-			echo "sourcing $HOME/$shell_profile"
-			. "$HOME/$shell_profile"
-		fi
-	fi
-	echo "Run 'cndi --help' to get started!"
+	# set shell profile for user shell
+    case "$SHELL" in
+        /bin/zsh) shell_profile=".zshrc" ;;
+        *) shell_profile=".bash_profile" ;;
+    esac
+    
+    # append or create alias in $shell_profile
+    if [ "$OS" = "Windows_NT" ]; then
+        windows_alias = "alias cndi='winpty $exe'"
+        # if $windows_alias is not in $shell_profile then append it
+        if ! grep -q "$windows_alias" "$HOME/$shell_profile"; then
+            echo "creating alias for Windows..."
+            echo "$windows_alias" | tee -a "$HOME/$shell_profile" # log alias and write to $shell_profile
+        fi
+    fi
+    
+    if ! command -v cndi >/dev/null; then
+        # if ~/bin is not in $PATH then append it
+        if ! grep -q "$cndi_install" "$HOME/$shell_profile"; then
+            echo "adding $cndi_install to \$PATH"
+            command printf '\nexport PATH="%s:$PATH"' "$cndi_install" >>"$HOME/$shell_profile"
+            echo "Please restart your terminal then run 'cndi --help' to get started!"
+            exit 0 # exit early because sourcing $shell_profile will not work in this shell (probably macOS)
+        fi
+    fi
+    
+    # source $shell_profile
+    if [ -f "$HOME/$shell_profile" ]; then
+        echo "sourcing $HOME/$shell_profile"
+        . "$HOME/$shell_profile"
+    fi
+    
+    echo "Run 'cndi --help' to get started!"
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,9 @@ set -e
 
 main() {
 	cndi_install="${CNDI_INSTALL:-$HOME/bin}"
-
+	bin_suffix=""
 	if [ "$OS" = "Windows_NT" ]; then
+		bin_suffix=".exe"
 		target="win.exe"
 	else
 		case $(uname -sm) in
@@ -25,7 +26,7 @@ main() {
 
 	cndi_uri="https://github.com/polyseam/cndi/releases/latest/download/cndi-${target}"
 
-	exe="$cndi_install/cndi"
+	exe="$cndi_install/cndi$bin_suffix"
 
 	if [ ! -d "$cndi_install" ]; then
 		mkdir -p "$cndi_install"
@@ -37,20 +38,37 @@ main() {
 
 	echo "cndi was downloaded successfully to $exe"
 
-	if command -v cndi >/dev/null; then
-		echo "Run 'cndi --help' to get started"
-	else
-    
+	if ! command -v cndi >/dev/null; then
 		case "$SHELL" in
 		/bin/zsh) shell_profile=".zshrc" ;;
-		*) shell_profile=".bashrc" ;;
+		*) shell_profile=".bash_profile" ;;
 		esac
 
-		echo "Run the following to make cndi accessible globally:"
-		echo "  sudo cp $exe /usr/local/bin/"
-		echo "Run '$exe --help' to get started"
-	fi
+		# append or create alias in $shell_profile
+		if [ "$OS" = "Windows_NT" ]; then
+			windows_alias = "alias cndi='winpty $exe'"
+			# if $windows_alias is not in $shell_profile then append it
+			if ! grep -q "$windows_alias" "$HOME/$shell_profile"; then
+				echo "creating alias for Windows..."
+				echo "$windows_alias" | tee -a "$HOME/$shell_profile"
+			fi
+		fi
 
+		# if ~/bin is not in $PATH then append it
+		if ! grep -q "$cndi_install" "$HOME/$shell_profile"; then
+			echo "adding $cndi_install to \$PATH"
+			command printf '\nexport PATH="%s:$PATH"' "$cndi_install" >>"$HOME/$shell_profile"
+			echo "Please restart your terminal then run 'cndi --help' to get started!"
+			exit 0 # exit early because sourcing $shell_profile will not work in this shell (probably macOS)
+		fi
+
+		# source $shell_profile
+		if [ -f "$HOME/$shell_profile" ]; then
+			echo "sourcing $HOME/$shell_profile"
+			. "$HOME/$shell_profile"
+		fi
+	fi
+	echo "Run 'cndi --help' to get started!"
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,7 @@ main() {
     # append or create alias in $shell_profile
     if [ "$OS" = "Windows_NT" ]; then
         windows_alias="alias cndi='winpty $exe'"
+        shell_profile=".bashrc" # use .bashrc on Windows, so that the alias is prioritised over path
         # if $windows_alias is not in $shell_profile then append it
         if ! grep -q "$windows_alias" "$HOME/$shell_profile"; then
             echo "creating alias for Windows..."

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ main() {
     cndi_install="${CNDI_INSTALL:-$HOME/bin}"
     bin_suffix=""
     if [ "$OS" = "Windows_NT" ]; then
-        bin_suffix="-win.exe"
+        bin_suffix=".exe"
         target="win.exe"
     else
         case $(uname -sm) in
@@ -43,17 +43,7 @@ main() {
         /bin/zsh) shell_profile=".zshrc" ;;
         *) shell_profile=".bash_profile" ;;
     esac
-    
-    # append or create alias in $shell_profile
-    if [ "$OS" = "Windows_NT" ]; then
-        windows_alias="alias cndi='winpty $exe'"
-        # if $windows_alias is not in $shell_profile then append it
-        if ! grep -q "$windows_alias" "$HOME/$shell_profile"; then
-            echo "creating alias for Windows..."
-            echo "$windows_alias" | tee -a "$HOME/$shell_profile" # log alias and write to $shell_profile
-        fi
-    fi
-    
+
     if ! command -v cndi >/dev/null; then
         # if ~/bin is not in $PATH then append it
         if ! grep -q "$cndi_install" "$HOME/$shell_profile"; then

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ main() {
     cndi_install="${CNDI_INSTALL:-$HOME/bin}"
     bin_suffix=""
     if [ "$OS" = "Windows_NT" ]; then
-        bin_suffix=".exe"
+        bin_suffix="-win.exe"
         target="win.exe"
     else
         case $(uname -sm) in
@@ -47,7 +47,6 @@ main() {
     # append or create alias in $shell_profile
     if [ "$OS" = "Windows_NT" ]; then
         windows_alias="alias cndi='winpty $exe'"
-        shell_profile=".bashrc" # use .bashrc on Windows, so that the alias is prioritised over path
         # if $windows_alias is not in $shell_profile then append it
         if ! grep -q "$windows_alias" "$HOME/$shell_profile"; then
             echo "creating alias for Windows..."


### PR DESCRIPTION
The install command now handles MacOS more reliably, and the installer will now yield a proper user experience on windows too!

- [x] macOS: if `~/bin` is not in $PATH it is updated to include it
- [x] if the macOS $PATH it is updated we recommend a new terminal session
- [x] windows:  install command creates an `alias` for git bash, including `winpty` prefix [used in the gh cli](https://github.com/git-for-windows/git/wiki/FAQ#some-native-console-programs-dont-work-when-run-from-git-bash-how-to-fix-it)