### PR TITLE
add test for "cndi init -t aws/basic -i"

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -448,16 +448,5 @@
     "https://esm.sh/v103/crypto-js@4.1.1?bundle": "afbdc1b85ef27a9d09993c960c12ad08f6b4180d94640b63ea9bdf7787efe323",
     "https://esm.sh/v103/simple-git@3.15.1/X-ZC9Aa3dzaXRlcy9maWxlLWV4aXN0c0AxLjEuMQ/deno/simple-git.bundle.js": "b5d668ac6f29b589a3bb3c17e01f21f0c78169bc764d6f2241c5d1340c321280",
     "https://esm.sh/v103/simple-git@3.15.1?no-dts&target=deno&deno-std=0.173.0&bundle&deps=@kwsites/file-exists@1.1.1": "4048581110ed20b4be2d1559a2a815caa0bf7a9c0484a8fa57266566e3c16c25"
-  },
-  "npm": {
-    "specifiers": {
-      "mock-stdin": "mock-stdin@1.0.0"
-    },
-    "packages": {
-      "mock-stdin@1.0.0": {
-        "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
-        "dependencies": {}
-      }
-    }
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -284,6 +284,7 @@
     "https://deno.land/std@0.173.0/types.d.ts": "220ed56662a0bd393ba5d124aa6ae2ad36a00d2fcbc0e8666a65f4606aaa9784",
     "https://deno.land/std@0.180.0/_util/asserts.ts": "178dfc49a464aee693a7e285567b3d0b555dc805ff490505a8aae34f9cfb1462",
     "https://deno.land/std@0.180.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
+    "https://deno.land/std@0.180.0/async/delay.ts": "73aa04cec034c84fc748c7be49bb15cac3dd43a57174bfdb7a4aec22c248f0dd",
     "https://deno.land/std@0.180.0/bytes/copy.ts": "939d89e302a9761dcf1d9c937c7711174ed74c59eef40a1e4569a05c9de88219",
     "https://deno.land/std@0.180.0/collections/_utils.ts": "5114abc026ddef71207a79609b984614e66a63a4bda17d819d56b0e72c51527e",
     "https://deno.land/std@0.180.0/collections/deep_merge.ts": "5a8ed29030f4471a5272785c57c3455fa79697b9a8f306013a8feae12bafc99a",
@@ -447,5 +448,16 @@
     "https://esm.sh/v103/crypto-js@4.1.1?bundle": "afbdc1b85ef27a9d09993c960c12ad08f6b4180d94640b63ea9bdf7787efe323",
     "https://esm.sh/v103/simple-git@3.15.1/X-ZC9Aa3dzaXRlcy9maWxlLWV4aXN0c0AxLjEuMQ/deno/simple-git.bundle.js": "b5d668ac6f29b589a3bb3c17e01f21f0c78169bc764d6f2241c5d1340c321280",
     "https://esm.sh/v103/simple-git@3.15.1?no-dts&target=deno&deno-std=0.173.0&bundle&deps=@kwsites/file-exists@1.1.1": "4048581110ed20b4be2d1559a2a815caa0bf7a9c0484a8fa57266566e3c16c25"
+  },
+  "npm": {
+    "specifiers": {
+      "mock-stdin": "mock-stdin@1.0.0"
+    },
+    "packages": {
+      "mock-stdin@1.0.0": {
+        "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
+        "dependencies": {}
+      }
+    }
   }
 }

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,15 +1,35 @@
-import { assert, beforeEach, describe, it, path } from "deps";
+// deno-lint-ignore-file
+
+import {
+  afterAll,
+  assert,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+  path,
+} from "deps";
 
 import { basicAWSCndiConfig } from "src/tests/mocks/cndiConfigs.ts";
 
 import { getPrettyJSONString } from "src/utils.ts";
 
-import { runCndi } from "src/tests/helpers/run-cndi.ts";
+import { getRunningCNDIProcess, runCndi } from "src/tests/helpers/run-cndi.ts";
+
+import processInteractiveEntries from "src/tests/helpers/processInteractiveEntries.ts";
 
 import {
   ensureResoureNamesMatchFileNames,
   hasSameFilesAfter,
 } from "src/tests/helpers/util.ts";
+
+// Key codes
+const keys = {
+  up: "\x1B\x5B\x41",
+  down: "\x1B\x5B\x42",
+  enter: "\x0D",
+  space: "\x20",
+};
 
 beforeEach(() => {
   // initialize sandbox
@@ -70,171 +90,26 @@ describe("cndi", () => {
       assert(readme.startsWith(`# ${project_name}`));
     });
 
-    describe("config validation", () => {
-      it(`should fail if a config file is supplied without a "project_name"`, async () => {
-        Deno.writeTextFileSync(
-          path.join(Deno.cwd(), `cndi-config.jsonc`),
-          getPrettyJSONString({
-            ...basicAWSCndiConfig,
-            project_name: undefined,
-          }),
+    it(
+      "'cndi init -i -t aws/basic' should create all cndi project files and directories",
+      async () => {
+        const p = getRunningCNDIProcess("init", "-i", "-t", "aws/basic");
+
+        const status = await processInteractiveEntries(
+          p,
+          {
+            project_name: "acme-project",
+            GIT_USERNAME: "acmefella",
+            GIT_PASSWORD: "ghp_1234567890",
+            GIT_REPO: "https://github.com/acmeorg/acme-project",
+            AWS_REGION: "us-east-1",
+            AWS_ACCESS_KEY_ID: "AKIA1234567890",
+            AWS_SECRET_ACCESS_KEY: "1234567890",
+            argocdDomainName: "argocd.acme.org",
+            letsEncryptClusterIssuerEmailAddress: "acmefella@acme.org",
+          },
         );
 
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init");
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should fail if a config file is supplied with no nodes`, async () => {
-        const nodelessCndiConfig = {
-          ...basicAWSCndiConfig,
-          infrastructure: { cndi: { nodes: [] } },
-        };
-        Deno.writeTextFileSync(
-          path.join(Deno.cwd(), `cndi-config.jsonc`),
-          getPrettyJSONString(nodelessCndiConfig),
-        );
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init");
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should fail if a config file is supplied with multiple node kinds`, async () => {
-        const nodes = [
-          { kind: "gcp", name: "cndi" },
-          { kind: "aws", name: "foo" },
-        ];
-
-        const multikindNodesConfig = {
-          ...basicAWSCndiConfig,
-          infrastructure: { cndi: { nodes } },
-        };
-
-        Deno.writeTextFileSync(
-          path.join(Deno.cwd(), `cndi-config.jsonc`),
-          getPrettyJSONString(multikindNodesConfig),
-        );
-
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init");
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should fail if a config file is supplied with no node of role leader`, async () => {
-        const nodes = [
-          { kind: "gcp", name: "cndi" },
-          { kind: "gcp", name: "foo" },
-        ];
-
-        const noLeaderConfig = {
-          ...basicAWSCndiConfig,
-          infrastructure: { cndi: { nodes } },
-        };
-
-        Deno.writeTextFileSync(
-          path.join(Deno.cwd(), `cndi-config.jsonc`),
-          getPrettyJSONString(noLeaderConfig),
-        );
-
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init");
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should fail if a config file is supplied with multiple leaders`, async () => {
-        const nodes = [
-          { kind: "gcp", name: "cndi", role: "leader" },
-          { kind: "gcp", name: "foo", role: "leader" },
-        ];
-
-        const multipleLeaderConfig = {
-          ...basicAWSCndiConfig,
-          infrastructure: { cndi: { nodes } },
-        };
-
-        Deno.writeTextFileSync(
-          path.join(Deno.cwd(), `cndi-config.jsonc`),
-          getPrettyJSONString(multipleLeaderConfig),
-        );
-
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init");
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should fail if a config file is supplied with multiple nodes of the same name`, async () => {
-        const nodes = [
-          { kind: "gcp", name: "foo", role: "leader" },
-          { kind: "gcp", name: "foo" },
-        ];
-
-        const duplicateNodeNameConfig = {
-          ...basicAWSCndiConfig,
-          infrastructure: { cndi: { nodes } },
-        };
-
-        Deno.writeTextFileSync(
-          path.join(Deno.cwd(), `cndi-config.jsonc`),
-          getPrettyJSONString(duplicateNodeNameConfig),
-        );
-
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init");
-            assert(!status.success);
-          }),
-        );
-      });
-    });
-
-    describe("templates", () => {
-      it(`should throw an error if the template is unavailable`, async () => {
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init -t foo"); // cndi init -t foo
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should throw an error if a named template does not exist`, async () => {
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi("init -t aws/foo"); // cndi init -t aws/foo
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should throw an error if a template url 404s`, async () => {
-        assert(
-          await hasSameFilesAfter(async () => {
-            const { status } = await runCndi(
-              "init",
-              "-t",
-              "https://example.com/does-not-exist.jsonc",
-            );
-            assert(!status.success);
-          }),
-        );
-      });
-
-      it(`should successfully execute remote templates`, async () => {
         const initFileList = new Set([
           "cndi-config.jsonc",
           "README.md",
@@ -245,115 +120,300 @@ describe("cndi", () => {
           "cndi",
         ]);
 
-        // cndi init should fail because there is no config file
-        const { status } = await runCndi(
-          "init",
-          "-t",
-          "https://raw.githubusercontent.com/polyseam/example-cndi-templates/main/azure/airflow-tls.jsonc",
-        );
-
         // read the current directory entries after "cndi init" has ran
-        for await (const afterDirEntry of Deno.readDir(".")) {
+        for (const afterDirEntry of Deno.readDirSync(".")) {
           initFileList.delete(afterDirEntry.name); // remove the file from the set if it exists
         }
 
-        assert(initFileList.size === 0); // if the set is empty, all files were created
         assert(status.success);
-      });
+        assert(initFileList.size === 0); // if the set is empty, all files were created
+      },
+    );
+  });
 
-      it("should add an template specific readme section", async () => {
+  describe("config validation", () => {
+    it(`should fail if a config file is supplied without a "project_name"`, async () => {
+      Deno.writeTextFileSync(
+        path.join(Deno.cwd(), `cndi-config.jsonc`),
+        getPrettyJSONString({
+          ...basicAWSCndiConfig,
+          project_name: undefined,
+        }),
+      );
+
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init");
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should fail if a config file is supplied with no nodes`, async () => {
+      const nodelessCndiConfig = {
+        ...basicAWSCndiConfig,
+        infrastructure: { cndi: { nodes: [] } },
+      };
+      Deno.writeTextFileSync(
+        path.join(Deno.cwd(), `cndi-config.jsonc`),
+        getPrettyJSONString(nodelessCndiConfig),
+      );
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init");
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should fail if a config file is supplied with multiple node kinds`, async () => {
+      const nodes = [
+        { kind: "gcp", name: "cndi" },
+        { kind: "aws", name: "foo" },
+      ];
+
+      const multikindNodesConfig = {
+        ...basicAWSCndiConfig,
+        infrastructure: { cndi: { nodes } },
+      };
+
+      Deno.writeTextFileSync(
+        path.join(Deno.cwd(), `cndi-config.jsonc`),
+        getPrettyJSONString(multikindNodesConfig),
+      );
+
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init");
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should fail if a config file is supplied with no node of role leader`, async () => {
+      const nodes = [
+        { kind: "gcp", name: "cndi" },
+        { kind: "gcp", name: "foo" },
+      ];
+
+      const noLeaderConfig = {
+        ...basicAWSCndiConfig,
+        infrastructure: { cndi: { nodes } },
+      };
+
+      Deno.writeTextFileSync(
+        path.join(Deno.cwd(), `cndi-config.jsonc`),
+        getPrettyJSONString(noLeaderConfig),
+      );
+
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init");
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should fail if a config file is supplied with multiple leaders`, async () => {
+      const nodes = [
+        { kind: "gcp", name: "cndi", role: "leader" },
+        { kind: "gcp", name: "foo", role: "leader" },
+      ];
+
+      const multipleLeaderConfig = {
+        ...basicAWSCndiConfig,
+        infrastructure: { cndi: { nodes } },
+      };
+
+      Deno.writeTextFileSync(
+        path.join(Deno.cwd(), `cndi-config.jsonc`),
+        getPrettyJSONString(multipleLeaderConfig),
+      );
+
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init");
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should fail if a config file is supplied with multiple nodes of the same name`, async () => {
+      const nodes = [
+        { kind: "gcp", name: "foo", role: "leader" },
+        { kind: "gcp", name: "foo" },
+      ];
+
+      const duplicateNodeNameConfig = {
+        ...basicAWSCndiConfig,
+        infrastructure: { cndi: { nodes } },
+      };
+
+      Deno.writeTextFileSync(
+        path.join(Deno.cwd(), `cndi-config.jsonc`),
+        getPrettyJSONString(duplicateNodeNameConfig),
+      );
+
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init");
+          assert(!status.success);
+        }),
+      );
+    });
+  });
+
+  describe("templates", () => {
+    it(`should throw an error if the template is unavailable`, async () => {
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init -t foo"); // cndi init -t foo
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should throw an error if a named template does not exist`, async () => {
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi("init -t aws/foo"); // cndi init -t aws/foo
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should throw an error if a template url 404s`, async () => {
+      assert(
+        await hasSameFilesAfter(async () => {
+          const { status } = await runCndi(
+            "init",
+            "-t",
+            "https://example.com/does-not-exist.jsonc",
+          );
+          assert(!status.success);
+        }),
+      );
+    });
+
+    it(`should successfully execute remote templates`, async () => {
+      const initFileList = new Set([
+        "cndi-config.jsonc",
+        "README.md",
+        ".github",
+        ".gitignore",
+        ".env",
+        ".vscode",
+        "cndi",
+      ]);
+
+      // cndi init should fail because there is no config file
+      const { status } = await runCndi(
+        "init",
+        "-t",
+        "https://raw.githubusercontent.com/polyseam/example-cndi-templates/main/azure/airflow-tls.jsonc",
+      );
+
+      // read the current directory entries after "cndi init" has ran
+      for await (const afterDirEntry of Deno.readDir(".")) {
+        initFileList.delete(afterDirEntry.name); // remove the file from the set if it exists
+      }
+
+      assert(initFileList.size === 0); // if the set is empty, all files were created
+      assert(status.success);
+    });
+
+    it("should add an template specific readme section", async () => {
+      const { status } = await runCndi("init", "-t", "aws/airflow-tls");
+      const readme = Deno.readTextFileSync(
+        path.join(Deno.cwd(), `README.md`),
+      );
+      assert(readme.indexOf(`## airflow-tls`) > -1);
+      assert(status.success);
+    });
+
+    describe("aws", () => {
+      it("should add an aws specific readme section", async () => {
         const { status } = await runCndi("init", "-t", "aws/airflow-tls");
         const readme = Deno.readTextFileSync(
           path.join(Deno.cwd(), `README.md`),
         );
-        assert(readme.indexOf(`## airflow-tls`) > -1);
+        assert(readme.indexOf(`## aws`) > -1);
         assert(status.success);
       });
 
-      describe("aws", () => {
-        it("should add an aws specific readme section", async () => {
-          const { status } = await runCndi("init", "-t", "aws/airflow-tls");
-          const readme = Deno.readTextFileSync(
-            path.join(Deno.cwd(), `README.md`),
-          );
-          assert(readme.indexOf(`## aws`) > -1);
-          assert(status.success);
-        });
-
-        it("should add a .env file containing AWS env var keys", async () => {
-          const { status } = await runCndi("init", "-t", "aws/airflow-tls");
-          const dotenv = Deno.readTextFileSync(
-            path.join(Deno.cwd(), `.env`),
-          );
-          assert(dotenv.indexOf(`# AWS`) > -1);
-          assert(dotenv.indexOf(`AWS_REGION`) > -1);
-          assert(dotenv.indexOf(`AWS_SECRET_ACCESS_KEY`) > -1);
-          assert(dotenv.indexOf(`AWS_ACCESS_KEY_ID`) > -1);
-          assert(status.success);
-        });
-
-        it(`should create a set of terraform files where the resource name is the filename for aws`, async () => {
-          const { status } = await runCndi("init", "-t", "aws/airflow-tls");
-          assert(status.success);
-          await ensureResoureNamesMatchFileNames();
-        });
+      it("should add a .env file containing AWS env var keys", async () => {
+        const { status } = await runCndi("init", "-t", "aws/airflow-tls");
+        const dotenv = Deno.readTextFileSync(
+          path.join(Deno.cwd(), `.env`),
+        );
+        assert(dotenv.indexOf(`# AWS`) > -1);
+        assert(dotenv.indexOf(`AWS_REGION`) > -1);
+        assert(dotenv.indexOf(`AWS_SECRET_ACCESS_KEY`) > -1);
+        assert(dotenv.indexOf(`AWS_ACCESS_KEY_ID`) > -1);
+        assert(status.success);
       });
 
-      describe("gcp", () => {
-        it("should add an gcp specific readme section", async () => {
-          const { status } = await runCndi("init", "-t", "gcp/airflow-tls");
-          const readme = Deno.readTextFileSync(
-            path.join(Deno.cwd(), `README.md`),
-          );
-          assert(readme.indexOf(`## gcp`) > -1);
-          assert(status.success);
-        });
+      it(`should create a set of terraform files where the resource name is the filename for aws`, async () => {
+        const { status } = await runCndi("init", "-t", "aws/airflow-tls");
+        assert(status.success);
+        await ensureResoureNamesMatchFileNames();
+      });
+    });
 
-        it("should add a .env file containing GCP env var keys", async () => {
-          const { status } = await runCndi("init", "-t", "gcp/airflow-tls");
-          const dotenv = Deno.readTextFileSync(
-            path.join(Deno.cwd(), `.env`),
-          );
-          assert(dotenv.indexOf(`# GCP`) > -1);
-          assert(dotenv.indexOf(`GCP_REGION`) > -1);
-          assert(dotenv.indexOf(`GOOGLE_CREDENTIALS`) > -1);
-          assert(status.success);
-        });
-        it(`should create a set of terraform files where the resource name is the filename for gcp`, async () => {
-          const { status } = await runCndi("init", "-t", "gcp/airflow-tls");
-          assert(status.success);
-          await ensureResoureNamesMatchFileNames();
-        });
+    describe("gcp", () => {
+      it("should add an gcp specific readme section", async () => {
+        const { status } = await runCndi("init", "-t", "gcp/airflow-tls");
+        const readme = Deno.readTextFileSync(
+          path.join(Deno.cwd(), `README.md`),
+        );
+        assert(readme.indexOf(`## gcp`) > -1);
+        assert(status.success);
       });
 
-      describe("azure", () => {
-        it("should add an azure specific readme section", async () => {
-          const { status } = await runCndi("init", "-t", "azure/airflow-tls");
-          const readme = Deno.readTextFileSync(
-            path.join(Deno.cwd(), `README.md`),
-          );
-          assert(readme.indexOf(`## azure`) > -1);
-          assert(status.success);
-        });
+      it("should add a .env file containing GCP env var keys", async () => {
+        const { status } = await runCndi("init", "-t", "gcp/airflow-tls");
+        const dotenv = Deno.readTextFileSync(
+          path.join(Deno.cwd(), `.env`),
+        );
+        assert(dotenv.indexOf(`# GCP`) > -1);
+        assert(dotenv.indexOf(`GCP_REGION`) > -1);
+        assert(dotenv.indexOf(`GOOGLE_CREDENTIALS`) > -1);
+        assert(status.success);
+      });
+      it(`should create a set of terraform files where the resource name is the filename for gcp`, async () => {
+        const { status } = await runCndi("init", "-t", "gcp/airflow-tls");
+        assert(status.success);
+        await ensureResoureNamesMatchFileNames();
+      });
+    });
 
-        it("should add a .env file containing Azure env var keys", async () => {
-          const { status } = await runCndi("init", "-t", "azure/airflow-tls");
-          const dotenv = Deno.readTextFileSync(
-            path.join(Deno.cwd(), `.env`),
-          );
-          assert(dotenv.indexOf(`# Azure Resource Manager`) > -1);
-          assert(dotenv.indexOf(`ARM_REGION`) > -1);
-          assert(dotenv.indexOf(`ARM_CLIENT_SECRET`) > -1);
-          assert(dotenv.indexOf(`ARM_CLIENT_ID`) > -1);
-          assert(dotenv.indexOf(`ARM_TENANT_ID`) > -1);
-          assert(dotenv.indexOf(`ARM_SUBSCRIPTION_ID`) > -1);
-          assert(status.success);
-        });
-        it(`should create a set of terraform files where the resource name is the filename for azure`, async () => {
-          const { status } = await runCndi("init", "-t", "azure/airflow-tls");
-          assert(status.success);
-          await ensureResoureNamesMatchFileNames();
-        });
+    describe("azure", () => {
+      it("should add an azure specific readme section", async () => {
+        const { status } = await runCndi("init", "-t", "azure/airflow-tls");
+        const readme = Deno.readTextFileSync(
+          path.join(Deno.cwd(), `README.md`),
+        );
+        assert(readme.indexOf(`## azure`) > -1);
+        assert(status.success);
+      });
+
+      it("should add a .env file containing Azure env var keys", async () => {
+        const { status } = await runCndi("init", "-t", "azure/airflow-tls");
+        const dotenv = Deno.readTextFileSync(
+          path.join(Deno.cwd(), `.env`),
+        );
+        assert(dotenv.indexOf(`# Azure Resource Manager`) > -1);
+        assert(dotenv.indexOf(`ARM_REGION`) > -1);
+        assert(dotenv.indexOf(`ARM_CLIENT_SECRET`) > -1);
+        assert(dotenv.indexOf(`ARM_CLIENT_ID`) > -1);
+        assert(dotenv.indexOf(`ARM_TENANT_ID`) > -1);
+        assert(dotenv.indexOf(`ARM_SUBSCRIPTION_ID`) > -1);
+        assert(status.success);
+      });
+      it(`should create a set of terraform files where the resource name is the filename for azure`, async () => {
+        const { status } = await runCndi("init", "-t", "azure/airflow-tls");
+        assert(status.success);
+        await ensureResoureNamesMatchFileNames();
       });
     });
   });

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,14 +1,4 @@
-// deno-lint-ignore-file
-
-import {
-  afterAll,
-  assert,
-  beforeAll,
-  beforeEach,
-  describe,
-  it,
-  path,
-} from "deps";
+import { assert, beforeEach, describe, it, path } from "deps";
 
 import { basicAWSCndiConfig } from "src/tests/mocks/cndiConfigs.ts";
 
@@ -24,7 +14,7 @@ import {
 } from "src/tests/helpers/util.ts";
 
 // Key codes
-const keys = {
+const _keys = {
   up: "\x1B\x5B\x41",
   down: "\x1B\x5B\x42",
   enter: "\x0D",

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -10,9 +10,11 @@ export { deepMerge } from "https://deno.land/std@0.180.0/collections/deep_merge.
 export { platform } from "https://deno.land/std@0.173.0/node/os.ts";
 export { walk } from "https://deno.land/std@0.180.0/fs/mod.ts";
 export * as JSONC from "https://deno.land/std@0.180.0/encoding/jsonc.ts";
-
+export { delay } from "https://deno.land/std@0.180.0/async/delay.ts";
 //  - testing
 export {
+  afterAll,
+  beforeAll,
   beforeEach,
   describe,
   it,

--- a/src/tests/helpers/processInteractiveEntries.ts
+++ b/src/tests/helpers/processInteractiveEntries.ts
@@ -1,0 +1,36 @@
+import { delay } from "deps";
+
+// This object needs to be ordered, and the number of keys needs to be exactly the number of prompts
+type InteractiveEntries = Record<string, string>;
+
+type InteractiveProcess = Deno.Process<
+  { stdout: "piped"; stdin: "piped"; stderr: "piped"; cmd: string[] }
+>;
+
+/**
+ * Processes a list of inputs and writes them to a series of prompts
+ * @param p The interactive Deno.Process with piped stdin, stdout, and stderr
+ * @param entries An ordered object of entries to be written to the process' stdin
+ * @returns status of the process after entries have been written
+ */
+export default async function processInteractiveEntries(
+  p: InteractiveProcess,
+  entries: InteractiveEntries,
+  secondsBetweenEntries = 1,
+) {
+  const encoder = new TextEncoder();
+
+  for (const [_, value] of Object.entries(entries)) {
+    await p.stdin.write(encoder.encode(`${value}\n`));
+    await delay(1000 * secondsBetweenEntries);
+  }
+
+  p.stdin.close();
+  p.stdout.close();
+  p.stderr.close();
+
+  const status = await p.status();
+
+  p.close();
+  return status;
+}

--- a/src/tests/helpers/run-cndi.ts
+++ b/src/tests/helpers/run-cndi.ts
@@ -15,6 +15,16 @@ const cmd = [
   path.join(srcDir, "main.ts"),
 ];
 
+function getRunningCNDIProcess(...args: string[]) {
+  const p = Deno.run({
+    cmd: [...cmd, ...args],
+    stdout: "piped",
+    stderr: "piped",
+    stdin: "piped",
+  });
+  return p;
+}
+
 async function runCndi(...args: string[]) {
   const decoder = new TextDecoder("utf-8");
   const lastIndex = args.length - 1;
@@ -62,4 +72,4 @@ async function runCndiLoud(...args: string[]) {
   return { status };
 }
 
-export { runCndi, runCndiLoud };
+export { getRunningCNDIProcess, runCndi, runCndiLoud };


### PR DESCRIPTION
This PR adds a test for the `cndi init --interactive -t aws/basic`, there will be more tests soon but this single test proves the model for how our test suite can mock user interactions.