### PR TITLE
only get leader_node_name once, store in a local

### DIFF
--- a/src/outputs/terraform/aws/cndi_aws_instance.tf.json.ts
+++ b/src/outputs/terraform/aws/cndi_aws_instance.tf.json.ts
@@ -1,16 +1,10 @@
-import {
-  getLeaderNodeNameFromConfig,
-  getPrettyJSONString,
-  getTFResource,
-} from "src/utils.ts";
-import { AWSNodeItemSpec, CNDIConfig } from "src/types.ts";
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { AWSNodeItemSpec } from "src/types.ts";
 
 export default function getAWSComputeInstanceTFJSON(
   node: AWSNodeItemSpec,
-  config: CNDIConfig,
 ): string {
   const { name, role } = node;
-  const leaderNodeName = getLeaderNodeNameFromConfig(config);
   const DEFAULT_AMI = "ami-0c1704bac156af62c";
   const DEFAULT_INSTANCE_TYPE = "m5a.large";
   const DEFAULT_VOLUME_SIZE = 100;
@@ -33,7 +27,8 @@ export default function getAWSComputeInstanceTFJSON(
       delete_on_termination,
     },
   ];
-  const leaderAWSInstance = `aws_instance.cndi_aws_instance_${leaderNodeName}`;
+  const leaderAWSInstance =
+    "aws_instance.cndi_aws_instance_${local.leader_node_name}";
   const leader_user_data =
     '${templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argo_ui_admin_password": "${var.argo_ui_admin_password}" })}';
   const controller_user_data =

--- a/src/outputs/terraform/aws/stageAll.ts
+++ b/src/outputs/terraform/aws/stageAll.ts
@@ -1,11 +1,7 @@
 import { ccolors, path } from "deps";
 
 import { AWSNodeItemSpec, CNDIConfig } from "src/types.ts";
-import {
-  emitExitEvent,
-  getLeaderNodeNameFromConfig,
-  stageFile,
-} from "src/utils.ts";
+import { emitExitEvent, stageFile } from "src/utils.ts";
 
 import data from "./data.tf.json.ts";
 import provider from "./provider.tf.json.ts";
@@ -31,9 +27,8 @@ export default async function stageTerraformResourcesForAWS(
   config: CNDIConfig,
 ) {
   const aws_region = (Deno.env.get("AWS_REGION") as string) || "us-east-1";
-  const leaderName = getLeaderNodeNameFromConfig(config);
   const leader_node_ip =
-    `\${aws_instance.cndi_aws_instance_${leaderName}.private_ip}`;
+    "aws_instance.cndi_aws_instance_${local.leader_node_name}.private_ip";
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) =>
     stageFile(
@@ -42,7 +37,7 @@ export default async function stageTerraformResourcesForAWS(
         "terraform",
         `cndi_aws_instance_${node.name}.tf.json`,
       ),
-      cndi_aws_instance(node, config),
+      cndi_aws_instance(node),
     )
   );
 

--- a/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
@@ -1,15 +1,9 @@
-import {
-  getLeaderNodeNameFromConfig,
-  getPrettyJSONString,
-  getTFResource,
-} from "src/utils.ts";
-import { AzureNodeItemSpec, CNDIConfig } from "src/types.ts";
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { AzureNodeItemSpec } from "src/types.ts";
 
 export default function getAzureComputeInstanceTFJSON(
   node: AzureNodeItemSpec,
-  config: CNDIConfig,
 ): string {
-  const leaderNodeName = getLeaderNodeNameFromConfig(config);
   const { name, role } = node;
   const DEFAULT_IMAGE = "0001-com-ubuntu-server-focal"; // The image from which to initialize this disk
   const DEFAULT_MACHINE_TYPE = "Standard_DC2s_v2"; // The machine type to create.Standard_DC2s_v2 has 2cpu and 8g of ram
@@ -19,7 +13,7 @@ export default function getAzureComputeInstanceTFJSON(
     DEFAULT_MACHINE_TYPE;
   let disk_size_gb = node?.disk_size_gb || node?.volume_size || DEFAULT_SIZE;
   const leaderComputeInstance =
-    `azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${leaderNodeName}`;
+    "azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${local.leader_node_name}";
   if (node?.size && typeof node.size === "string") {
     machine_type = node.size;
   }

--- a/src/outputs/terraform/azure/stageAll.ts
+++ b/src/outputs/terraform/azure/stageAll.ts
@@ -1,11 +1,7 @@
 import { ccolors, path } from "deps";
 
 import { CNDIConfig } from "src/types.ts";
-import {
-  emitExitEvent,
-  getLeaderNodeNameFromConfig,
-  stageFile,
-} from "src/utils.ts";
+import { emitExitEvent, stageFile } from "src/utils.ts";
 
 import provider from "./provider.tf.json.ts";
 import terraform from "./terraform.tf.json.ts";
@@ -32,10 +28,8 @@ export default async function stageTerraformResourcesForAzure(
 ) {
   const azure_location = (Deno.env.get("ARM_REGION") as string) || "eastus";
 
-  const leaderName = getLeaderNodeNameFromConfig(config);
-
   const leader_node_ip =
-    `\${azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${leaderName}.private_ip_address}`;
+    "azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${local.leader_node_name}.private_ip_address";
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) =>
     stageFile(
@@ -44,7 +38,7 @@ export default async function stageTerraformResourcesForAzure(
         "terraform",
         `cndi_azurerm_linux_virtual_machine_${node.name}.tf.json`,
       ),
-      cndi_azurerm_linux_virtual_machine(node, config),
+      cndi_azurerm_linux_virtual_machine(node),
     )
   );
 

--- a/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
+++ b/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
@@ -1,15 +1,9 @@
-import {
-  getLeaderNodeNameFromConfig,
-  getPrettyJSONString,
-  getTFResource,
-} from "src/utils.ts";
-import { CNDIConfig, GCPNodeItemSpec } from "src/types.ts";
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { GCPNodeItemSpec } from "src/types.ts";
 
 export default function getGCPComputeInstanceTFJSON(
   node: GCPNodeItemSpec,
-  config: CNDIConfig,
 ): string {
-  const leaderNodeName = getLeaderNodeNameFromConfig(config);
   const { name, role } = node;
   const DEFAULT_MACHINE_TYPE = "n2-standard-2"; // The machine type to create.
   const machine_type = node?.machine_type || node?.instance_type ||
@@ -24,7 +18,7 @@ export default function getGCPComputeInstanceTFJSON(
   const source =
     `\${google_compute_disk.cndi_google_compute_disk_${name}.self_link}`;
   const leaderComputeInstance =
-    `google_compute_instance.cndi_google_compute_instance_${leaderNodeName}`;
+    "google_compute_instance.cndi_google_compute_instance_${local.leader_node_name}";
   const boot_disk = [
     {
       source,

--- a/src/outputs/terraform/gcp/stageAll.ts
+++ b/src/outputs/terraform/gcp/stageAll.ts
@@ -1,11 +1,7 @@
 import { ccolors, path } from "deps";
 
 import { CNDIConfig } from "src/types.ts";
-import {
-  emitExitEvent,
-  getLeaderNodeNameFromConfig,
-  stageFile,
-} from "src/utils.ts";
+import { emitExitEvent, stageFile } from "src/utils.ts";
 
 import provider from "./provider.tf.json.ts";
 import terraform from "./terraform.tf.json.ts";
@@ -38,10 +34,8 @@ export default async function stageTerraformResourcesForGCP(
   const gcp_region = (Deno.env.get("GCP_REGION") as string) || "us-central1";
   const googleCredentials = Deno.env.get("GOOGLE_CREDENTIALS") as string; // project_id
 
-  const leaderName = getLeaderNodeNameFromConfig(config);
-
   const leader_node_ip =
-    `\${google_compute_instance.cndi_google_compute_instance_${leaderName}.network_interface.0.network_ip}`;
+    "google_compute_instance.cndi_google_compute_instance_${local.leader_node_name}.network_interface.0.network_ip";
 
   if (!googleCredentials) {
     console.error(
@@ -107,7 +101,7 @@ export default async function stageTerraformResourcesForGCP(
         "terraform",
         `cndi_google_compute_instance_${node.name}.tf.json`,
       ),
-      cndi_google_compute_instance(node, config),
+      cndi_google_compute_instance(node),
     )
   );
 

--- a/src/outputs/terraform/shared/global.locals.tf.json.ts
+++ b/src/outputs/terraform/shared/global.locals.tf.json.ts
@@ -1,11 +1,17 @@
 import { getPrettyJSONString } from "src/utils.ts";
 
-export default function getVariablesTFJSON(
-  { cndi_project_name }: { cndi_project_name: string },
+type GetLocalsTFJSONArgs = {
+  cndi_project_name: string;
+  leader_node_name: string;
+};
+
+export default function getLocalsTFJSON(
+  { cndi_project_name, leader_node_name }: GetLocalsTFJSONArgs,
 ): string {
   return getPrettyJSONString({
     locals: {
       cndi_project_name,
+      leader_node_name,
     },
   });
 }

--- a/src/outputs/terraform/stageTerraformResourcesForConfig.ts
+++ b/src/outputs/terraform/stageTerraformResourcesForConfig.ts
@@ -1,6 +1,10 @@
 import { path } from "deps";
 import { CNDIConfig } from "src/types.ts";
-import { patchAndStageTerraformFilesWithConfig, stageFile } from "src/utils.ts";
+import {
+  getLeaderNodeNameFromConfig,
+  patchAndStageTerraformFilesWithConfig,
+  stageFile,
+} from "src/utils.ts";
 import stageTerraformResourcesForAWS from "src/outputs/terraform/aws/stageAll.ts";
 import stageTerraformResourcesForGCP from "src/outputs/terraform/gcp/stageAll.ts";
 import stageTerraformResourcesForAzure from "src/outputs/terraform/azure/stageAll.ts";
@@ -17,6 +21,8 @@ export default async function stageTerraformResourcesForConfig(
   options: { output: string; initializing: boolean },
 ) {
   const cndi_project_name = config.project_name!;
+
+  const leader_node_name = await getLeaderNodeNameFromConfig(config);
 
   const kind = config.infrastructure.cndi.nodes[0].kind;
   switch (kind) {
@@ -39,7 +45,7 @@ export default async function stageTerraformResourcesForConfig(
     // add global locals
     stageFile(
       path.join("cndi", "terraform", "global.locals.tf.json"),
-      global_locals({ cndi_project_name }),
+      global_locals({ cndi_project_name, leader_node_name }),
     ),
     // write the microk8s join token generator
     stageFile(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,11 +38,24 @@ function getPrettyJSONString(object: unknown) {
   return JSON.stringify(object, null, 2);
 }
 
-function getLeaderNodeNameFromConfig(config: CNDIConfig): string | undefined {
+async function getLeaderNodeNameFromConfig(
+  config: CNDIConfig,
+): Promise<string> {
   const leaderNode = config.infrastructure.cndi.nodes.find(
     (node: BaseNodeItemSpec) => node.role === "leader",
   );
-  return leaderNode?.name;
+
+  if (!leaderNode) {
+    await emitExitEvent(200);
+    Deno.exit(200);
+  }
+
+  if (!leaderNode?.name) {
+    await emitExitEvent(201);
+    Deno.exit(201);
+  }
+
+  return leaderNode.name;
 }
 
 function getDeploymentTargetFromConfig(config: CNDIConfig): DeploymentTarget {


### PR DESCRIPTION
There was a potential issue where if cndi-config validation code changed there was potential for the leader node name to be missing, resulting in a broken cluster. We moved the logic that pulls the node name up to the root stage function because all providers require it and that function is async which keeps the check clean.