### PR TITLE
ARGOCD_ADMIN_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ resources. Some of our templates setup Ingress for ArgoCD automatically, if you
 don't have an Ingress you can still access it by following our
 [port-forwarding doc](docs/port-forwarding.md). Once you can see the login
 screen for ArgoCD you can login with the username `admin` and the password we
-set for you in your `.env` file under the key `ARGO_UI_ADMIN_PASSWORD`.
+set for you in your `.env` file under the key `ARGOCD_ADMIN_PASSWORD`.
 
 ### dns 🌐
 

--- a/docs/error-code-reference.json
+++ b/docs/error-code-reference.json
@@ -17,7 +17,7 @@
   },
   {
     "code": 103,
-    "message": "'ARGO_UI_ADMIN_PASSWORD' env var is not set for terraform"
+    "message": "'ARGOCD_ADMIN_PASSWORD' env var is not set for terraform"
   },
   {
     "code": 104,
@@ -77,7 +77,7 @@
   },
   {
     "code": 502,
-    "message": "'ARGO_UI_ADMIN_PASSWORD' env var is not set during overwrite"
+    "message": "'ARGOCD_ADMIN_PASSWORD' env var is not set during overwrite"
   },
   {
     "code": 503,
@@ -101,7 +101,7 @@
   },
   {
     "code": 603,
-    "message": "'ARGO_UI_ADMIN_PASSWORD' env var is not set during initialization"
+    "message": "'ARGOCD_ADMIN_PASSWORD' env var is not set during initialization"
   },
   {
     "code": 604,

--- a/docs/port-forwarding.md
+++ b/docs/port-forwarding.md
@@ -109,4 +109,4 @@ eg: `http://127.0.0.1:50445`
 
 You should now see a login page for argo, and a place to enter a username and
 password. The username is `admin` and the password is available in the `.env`
-file we created for you under the key `ARGO_UI_ADMIN_PASSWORD`.
+file we created for you under the key `ARGOCD_ADMIN_PASSWORD`.

--- a/src/bootstrap/leader_bootstrap_cndi.sh.ts
+++ b/src/bootstrap/leader_bootstrap_cndi.sh.ts
@@ -138,7 +138,7 @@ EOF
 echo "argo configured"
 echo "patching argocd-secret"
 
-sudo microk8s kubectl -n argocd patch secret argocd-secret -p "{\\"stringData\\": {\\"admin.password\\":\\"$(htpasswd -bnBC 10 \"\" \${argo_ui_admin_password} | tr -d ':\\n')\\",\\"admin.passwordMtime\\": \\"$(date +%FT%T%Z)\\"}}"
+sudo microk8s kubectl -n argocd patch secret argocd-secret -p "{\\"stringData\\": {\\"admin.password\\":\\"$(htpasswd -bnBC 10 \"\" \${argocd_admin_password} | tr -d ':\\n')\\",\\"admin.passwordMtime\\": \\"$(date +%FT%T%Z)\\"}}"
 
 echo "leader bootstrap complete"
 

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -51,7 +51,7 @@ const destroyCommand = new Command()
     { required: true },
   )
   .env(
-    "ARGO_UI_ADMIN_PASSWORD=<value:string>",
+    "ARGOCD_ADMIN_PASSWORD=<value:string>",
     "Password used to authenticate to the ArgoCD UI.",
     { required: true },
   )

--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -91,7 +91,7 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
   if (!argoUIAdminPassword) {
     console.error(
       owLabel,
-      ccolors.key_name(`"ARGO_UI_ADMIN_PASSWORD"`),
+      ccolors.key_name(`"ARGOCD_ADMIN_PASSWORD"`),
       ccolors.error(`is not set in environment`),
     );
     await emitExitEvent(502);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -52,7 +52,7 @@ const runCommand = new Command()
     { required: true },
   )
   .env(
-    "ARGO_UI_ADMIN_PASSWORD=<value:string>",
+    "ARGOCD_ADMIN_PASSWORD=<value:string>",
     "Password used to authenticate to the ArgoCD UI.",
     { required: true },
   )

--- a/src/commands/terraform.ts
+++ b/src/commands/terraform.ts
@@ -50,7 +50,7 @@ const terraformCommand = new Command()
     { required: true },
   )
   .env(
-    "ARGO_UI_ADMIN_PASSWORD=<value:string>",
+    "ARGOCD_ADMIN_PASSWORD=<value:string>",
     "Password used to authenticate to the ArgoCD UI.",
     { required: true },
   )

--- a/src/deployment-targets/shared.ts
+++ b/src/deployment-targets/shared.ts
@@ -59,12 +59,12 @@ const getCoreEnvLines = async (
     : GIT_REPO;
 
   const TERRAFORM_STATE_PASSPHRASE = terraformStatePassphrase;
-  const ARGO_UI_ADMIN_PASSWORD = argoUIAdminPassword;
+  const ARGOCD_ADMIN_PASSWORD = argoUIAdminPassword;
 
-  if (!ARGO_UI_ADMIN_PASSWORD) {
+  if (!ARGOCD_ADMIN_PASSWORD) {
     console.log(
       deploymentTargetsSharedLabel,
-      ccolors.key_name(`"ARGO_UI_ADMIN_PASSWORD"`),
+      ccolors.key_name(`"ARGOCD_ADMIN_PASSWORD"`),
       ccolors.error(`is not set in environment`),
     );
     await emitExitEvent(603);
@@ -106,7 +106,7 @@ const getCoreEnvLines = async (
       },
     },
     { comment: "ArgoCD" },
-    { value: { ARGO_UI_ADMIN_PASSWORD } },
+    { value: { ARGOCD_ADMIN_PASSWORD } },
     { comment: "Passphrase for encrypting/decrypting terraform state" },
     { value: { TERRAFORM_STATE_PASSPHRASE } },
     { comment: "git credentials" },

--- a/src/initialize/argoUIAdminPassword.ts
+++ b/src/initialize/argoUIAdminPassword.ts
@@ -1,15 +1,15 @@
 import { getSecretOfLength } from "src/utils.ts";
 
 const loadArgoUIAdminPassword = (): string | null => {
-  const argo_ui_admin_password = Deno.env
-    .get("ARGO_UI_ADMIN_PASSWORD")
+  const argocd_admin_password = Deno.env
+    .get("ARGOCD_ADMIN_PASSWORD")
     ?.trim();
 
-  if (!argo_ui_admin_password) {
+  if (!argocd_admin_password) {
     return null;
   }
 
-  return argo_ui_admin_password;
+  return argocd_admin_password;
 };
 
 const createArgoUIAdminPassword = (): string => {

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -42,7 +42,7 @@ const cndiWorkflowObj = {
               "${{ secrets.SEALED_SECRETS_PRIVATE_KEY }}",
             SEALED_SECRETS_PUBLIC_KEY:
               "${{ secrets.SEALED_SECRETS_PUBLIC_KEY }}",
-            ARGO_UI_ADMIN_PASSWORD: "${{ secrets.ARGO_UI_ADMIN_PASSWORD }}",
+            ARGOCD_ADMIN_PASSWORD: "${{ secrets.ARGOCD_ADMIN_PASSWORD }}",
             AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}",
             AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
             AWS_REGION: "${{ secrets.AWS_REGION }}",

--- a/src/outputs/readme.ts
+++ b/src/outputs/readme.ts
@@ -73,19 +73,19 @@ export default function getReadmeForProject({
       "[Azure Portal](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachines)",
   };
 
+  const linkToLoadBalancers = {
+    aws:
+      "[AWS Load Balancers Page](https://console.aws.amazon.com/ec2/v2/home?#LoadBalancers)",
+    gcp:
+      "[GCP Load Balancers Page](https://console.cloud.google.com/net-services/loadbalancing)",
+    azure:
+      "[Azure Load Balancers Page](https://portal.azure.com/#blade/HubsExtension/BrowseResource/resourceType/Microsoft.Network%2FloadBalancers)",
+  };
+
   const loggingIntoArgoCDSection = `
 ### logging into argocd
 
-When the \`cndi run\` command is finished, you should have a leader vm spinning up in the ${
-    linkToDashboards[deploymentTarget]
-  }, by connecting to this node you should be able to get the new [ArgoCD](https://argo-cd.readthedocs.io) password.
-
-\`\`\`bash
-# print the argocd default admin password by running this on the controller node in EC2
-microk8s kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" --insecure-skip-tls-verify| base64 -d; echo
-\`\`\`
-
-Now to login to ArgoCD you can visit that controller's public IP address, and login with the username \`"admin"\` and the password you just printed.
+Once your cluster is deployed, you can log into ArgoCD to see the status of your cluster. This can be done by logging into the ArgoCD UI with the username "admin" and the password that has been set for you in the [.env](/.env) file as \`ARGOCD_ADMIN_PASSWORD\` at the domain name you configured for Argo's ingress above.
 `.trim();
 
   const readmeSectionsForDeploymentTarget = {
@@ -93,30 +93,36 @@ Now to login to ArgoCD you can visit that controller's public IP address, and lo
 ## aws
 
 This cluster will be deployed on [Amazon Web Services](https://aws.com).
-When your cluster is initialized the next step is to go to your domain registrar and create an CNAME record for your Airflow instance, and another for ArgoCD.
-Both entries should point to the single load balancer that was created for your cluster.
+When your cluster is initialized the next step is to go to your domain registrar and create an CNAME record for ArgoCD.
+Both entries should point to the single load balancer that was created for your cluster found on the ${linkToLoadBalancers.aws}.
+
+You can visit the ${linkToDashboards.aws} to see the status of the nodes that make up your cluster.
 `.trim(),
     gcp: `
 ## gcp
 
 This cluster will be deployed on [Google Cloud Platform](https://cloud.google.com/gcp).
-When your cluster is initialized the next step is to go to your domain registrar and create an A record for your Airflow instance, and another for ArgoCD.
-Both entries should point to the single load balancer that was created for your cluster.
+When your cluster is initialized the next step is to go to your domain registrar and create an A record for ArgoCD.
+Both entries should point to the single load balancer that was created for your cluster found on the ${linkToLoadBalancers.gcp}.
+
+You can visit the ${linkToDashboards.gcp} to see the status of the nodes that make up your cluster.
 `.trim(),
     azure: `
 ## azure
 
 This cluster will be deployed on [Microsoft Azure](https://azure.microsoft.com/en-ca/).
-When your cluster is initialized the next step is to go to your domain registrar and create an A record for your Airflow instance, and another for ArgoCD.
-Both entries should point to the single load balancer that was created for your cluster.
+When your cluster is initialized the next step is to go to your domain registrar and create an A record for ArgoCD.
+Both entries should point to the single load balancer that was created for your cluster found on the ${linkToLoadBalancers.azure}.
+
+You can visit the ${linkToDashboards.azure} to see the status of the nodes that make up your cluster.
 `.trim(),
   };
 
   const readmeContent = [
     `# ${project_name || "my-cndi-project"}`,
     coreReadmeSection,
-    loggingIntoArgoCDSection,
     readmeSectionsForDeploymentTarget[deploymentTarget],
+    loggingIntoArgoCDSection,
   ].join("\n\n");
 
   return readmeContent;

--- a/src/outputs/terraform/aws/cndi_aws_instance.tf.json.ts
+++ b/src/outputs/terraform/aws/cndi_aws_instance.tf.json.ts
@@ -35,7 +35,7 @@ export default function getAWSComputeInstanceTFJSON(
   ];
   const leaderAWSInstance = `aws_instance.cndi_aws_instance_${leaderNodeName}`;
   const leader_user_data =
-    '${templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argo_ui_admin_password": "${var.argo_ui_admin_password}" })}';
+    '${templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argocd_admin_password": "${var.argocd_admin_password}" })}';
   const controller_user_data =
     '${templatefile("controller_bootstrap_cndi.sh.tftpl",{"bootstrap_token": "${local.bootstrap_token}", "leader_node_ip": "${local.leader_node_ip}"})}';
   const user_data = role === "leader" ? leader_user_data : controller_user_data;

--- a/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
@@ -67,7 +67,7 @@ export default function getAzureComputeInstanceTFJSON(
   };
 
   const leader_user_data =
-    '${base64encode(templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argo_ui_admin_password": "${var.argo_ui_admin_password}" }))}';
+    '${base64encode(templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argocd_admin_password": "${var.argocd_admin_password}" }))}';
   const controller_user_data =
     '${base64encode(templatefile("controller_bootstrap_cndi.sh.tftpl",{"bootstrap_token": "${local.bootstrap_token}", "leader_node_ip": "${local.leader_node_ip}"}))}';
 

--- a/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
+++ b/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
@@ -39,7 +39,7 @@ export default function getGCPComputeInstanceTFJSON(
   ];
 
   const leader_user_data =
-    '${templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argo_ui_admin_password": "${var.argo_ui_admin_password}" })}';
+    '${templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argocd_admin_password": "${var.argocd_admin_password}" })}';
   const controller_user_data =
     '${templatefile("controller_bootstrap_cndi.sh.tftpl",{"bootstrap_token": "${local.bootstrap_token}", "leader_node_ip": "${local.leader_node_ip}"})}';
 

--- a/src/outputs/terraform/shared/variable.tf.json.ts
+++ b/src/outputs/terraform/shared/variable.tf.json.ts
@@ -21,7 +21,7 @@ export default function getVariablesTFJSON(): string {
           type: "string",
         },
       ],
-      argo_ui_admin_password: [
+      argocd_admin_password: [
         {
           description: "password for accessing the argo ui",
           type: "string",

--- a/src/setTF_VARs.ts
+++ b/src/setTF_VARs.ts
@@ -36,11 +36,11 @@ export default async function setTF_VARs() {
     Deno.exit(102);
   }
 
-  const argo_ui_admin_password = Deno.env.get("ARGO_UI_ADMIN_PASSWORD");
-  if (!argo_ui_admin_password) {
+  const argocd_admin_password = Deno.env.get("ARGOCD_ADMIN_PASSWORD");
+  if (!argocd_admin_password) {
     console.error(
       setTF_VARsLabel,
-      ccolors.key_name(`"ARGO_UI_ADMIN_PASSWORD"`),
+      ccolors.key_name(`"ARGOCD_ADMIN_PASSWORD"`),
       ccolors.error("env var is not set"),
     );
     await emitExitEvent(103);
@@ -78,7 +78,7 @@ export default async function setTF_VARs() {
   Deno.env.set("TF_VAR_git_username", git_username);
   Deno.env.set("TF_VAR_git_password", git_password);
   Deno.env.set("TF_VAR_git_repo", git_repo);
-  Deno.env.set("TF_VAR_argo_ui_admin_password", argo_ui_admin_password);
+  Deno.env.set("TF_VAR_argocd_admin_password", argocd_admin_password);
   Deno.env.set("TF_VAR_sealed_secrets_public_key", sealed_secrets_public_key);
   Deno.env.set("TF_VAR_sealed_secrets_private_key", sealed_secrets_private_key);
 }


### PR DESCRIPTION
The environment variable `ARGO_UI_ADMIN_PASSWORD` was not really exclusively scoped to the UI, this admin password can be used anywhere so the name should be updated to reflect that.
Additionally our documentation was not properly updated to reflect the usage of this value when logging into the Argo UI, and the instructions about  providing a domain name for ingress has some room for improvement.

This PR:
- [x] removes all references to `ARGO_UI_ADMIN_PASSWORD` and replaces them with the more correct `ARGOCD_ADMIN_PASSWORD`
- [x] updates documentation to reference how this value can be used from `.env` instead of pulling the secret from a node at runtime
- [x] adds a bit more detail about where to find the load balancers in each cloud
- [x] removes erroneous references to Airflow in the basic template