### PR TITLE
$.cndi.secrets.FOO -> $.cndi.secrets.seal(FOO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,8 @@ and `"GIT_PASSWORD"`, into the destination secret key names
         "namespace": "airflow"
       },
       "stringData": {
-        "GIT_SYNC_USERNAME": "$.cndi.secrets.GIT_USERNAME",
-        "GIT_SYNC_PASSWORD": "$.cndi.secrets.GIT_PASSWORD"
+        "GIT_SYNC_USERNAME": "$.cndi.secrets.seal(GIT_USERNAME)",
+        "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_PASSWORD)"
       }
     }
   }

--- a/src/outputs/sealed-secret-manifest.ts
+++ b/src/outputs/sealed-secret-manifest.ts
@@ -6,7 +6,7 @@ import {
   getPrettyJSONString,
 } from "src/utils.ts";
 
-const CNDI_SECRETS_PREFIX = "$.cndi.secrets.";
+const CNDI_SECRETS_PREFIX = "$.cndi.secrets.seal(";
 const PLACEHOLDER_SUFFIX = "_PLACEHOLDER__";
 
 const sealedSecretManifestLabel = ccolors.faded(
@@ -34,7 +34,8 @@ const parseCndiSecret = async (
 
       // if we recognize our special token we use the value from the environment
       if (dataEntryValue.indexOf(CNDI_SECRETS_PREFIX) === 0) {
-        const secretEnvName = dataEntryValue.replace(CNDI_SECRETS_PREFIX, "");
+        const secretEnvName = dataEntryValue.replace(CNDI_SECRETS_PREFIX, "")
+          .replace(")", "");
         const placeholder = `${secretEnvName}${PLACEHOLDER_SUFFIX}`;
         const secretEnvVal = Deno.env.get(secretEnvName);
 
@@ -96,7 +97,8 @@ const parseCndiSecret = async (
       const [dataEntryKey, dataEntryValue] = dataEntry;
 
       if (dataEntryValue.indexOf(CNDI_SECRETS_PREFIX) === 0) {
-        const secretEnvName = dataEntryValue.replace(CNDI_SECRETS_PREFIX, "");
+        const secretEnvName = dataEntryValue.replace(CNDI_SECRETS_PREFIX, "")
+          .replace(")", "");
         const placeholder = `${secretEnvName}${PLACEHOLDER_SUFFIX}`;
         const secretEnvVal = Deno.env.get(secretEnvName);
 
@@ -131,7 +133,7 @@ const parseCndiSecret = async (
         console.error(
           sealedSecretManifestLabel,
           ccolors.error("Secret string literals are not supported\nUse"),
-          ccolors.key_name(`"${CNDI_SECRETS_PREFIX}"`),
+          ccolors.key_name(`"${CNDI_SECRETS_PREFIX}YOUR_SECRET_ENV_VAR_NAME)"`),
           ccolors.error("prefix to reference environment variables at"),
           ccolors.key_name(
             `"cndi-config.cluster_manifests.${inputSecret.metadata.name}.stringData.${dataEntryKey}"`,

--- a/src/schemas/examples/valid-cndi-config.jsonc
+++ b/src/schemas/examples/valid-cndi-config.jsonc
@@ -34,8 +34,8 @@
         "namespace": "airflow"
       },
       "stringData": {
-        "GIT_SYNC_USERNAME": "$.cndi.secrets.GIT_SYNC_USERNAME",
-        "GIT_SYNC_PASSWORD": "$.cndi.secrets.GIT_SYNC_PASSWORD"
+        "GIT_SYNC_USERNAME": "$.cndi.secrets.seal(GIT_SYNC_USERNAME)",
+        "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_SYNC_PASSWORD)"
       }
     },
     "cert-manager-cluster-issuer": {

--- a/src/templates/aws/airflow-tls.json
+++ b/src/templates/aws/airflow-tls.json
@@ -59,8 +59,8 @@
             "namespace": "airflow"
           },
           "stringData": {
-            "GIT_SYNC_USERNAME": "$.cndi.secrets.GIT_SYNC_USERNAME",
-            "GIT_SYNC_PASSWORD": "$.cndi.secrets.GIT_SYNC_PASSWORD"
+            "GIT_SYNC_USERNAME": "$.cndi.secrets.seal(GIT_SYNC_USERNAME)",
+            "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_SYNC_PASSWORD)"
           }
         },
         "cert-manager-cluster-issuer": {

--- a/src/templates/azure/airflow-tls.json
+++ b/src/templates/azure/airflow-tls.json
@@ -59,8 +59,8 @@
             "namespace": "airflow"
           },
           "stringData": {
-            "GIT_SYNC_USERNAME": "$.cndi.secrets.GIT_SYNC_USERNAME",
-            "GIT_SYNC_PASSWORD": "$.cndi.secrets.GIT_SYNC_PASSWORD"
+            "GIT_SYNC_USERNAME": "$.cndi.secrets.seal(GIT_SYNC_USERNAME)",
+            "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_SYNC_PASSWORD)"
           }
         },
         "cert-manager-cluster-issuer": {

--- a/src/templates/gcp/airflow-tls.json
+++ b/src/templates/gcp/airflow-tls.json
@@ -59,8 +59,8 @@
             "namespace": "airflow"
           },
           "stringData": {
-            "GIT_SYNC_USERNAME": "$.cndi.secrets.GIT_SYNC_USERNAME",
-            "GIT_SYNC_PASSWORD": "$.cndi.secrets.GIT_SYNC_PASSWORD"
+            "GIT_SYNC_USERNAME": "$.cndi.secrets.seal(GIT_SYNC_USERNAME)",
+            "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_SYNC_PASSWORD)"
           }
         },
         "cert-manager-cluster-issuer": {


### PR DESCRIPTION
The CNDI syntax for sealing a secret was `$.cndi.secrets.MY_ENV_VAR_TO_SEAL`, this is maybe a bit unintuitive because it is treating the secret as a property when it is really more analogous to a function call. Then again, maybe that does not matter, we invented the syntax so we can decide what it looks like.

This PR would change the syntax to `$.cndi.secrets.seal(MY_ENV_VAR_TO_SEAL)`, maybe that is not far enough and something like `$.cndi.secrets.seal('MY_ENV_VAR_TO_SEAL')` is more appropriate.