### PR TITLE
leaderNodeName was assumed to exist, now it is guaranteed

### DIFF
--- a/src/outputs/terraform/aws/cndi_aws_instance.tf.json.ts
+++ b/src/outputs/terraform/aws/cndi_aws_instance.tf.json.ts
@@ -1,16 +1,11 @@
-import {
-  getLeaderNodeNameFromConfig,
-  getPrettyJSONString,
-  getTFResource,
-} from "src/utils.ts";
-import { AWSNodeItemSpec, CNDIConfig } from "src/types.ts";
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { AWSNodeItemSpec } from "src/types.ts";
 
 export default function getAWSComputeInstanceTFJSON(
   node: AWSNodeItemSpec,
-  config: CNDIConfig,
+  leaderNodeName: string,
 ): string {
   const { name, role } = node;
-  const leaderNodeName = getLeaderNodeNameFromConfig(config);
   const DEFAULT_AMI = "ami-0c1704bac156af62c";
   const DEFAULT_INSTANCE_TYPE = "m5a.large";
   const DEFAULT_VOLUME_SIZE = 100;

--- a/src/outputs/terraform/aws/stageAll.ts
+++ b/src/outputs/terraform/aws/stageAll.ts
@@ -31,9 +31,9 @@ export default async function stageTerraformResourcesForAWS(
   config: CNDIConfig,
 ) {
   const aws_region = (Deno.env.get("AWS_REGION") as string) || "us-east-1";
-  const leaderName = getLeaderNodeNameFromConfig(config);
+  const leaderNodeName = await getLeaderNodeNameFromConfig(config);
   const leader_node_ip =
-    `\${aws_instance.cndi_aws_instance_${leaderName}.private_ip}`;
+    `\${aws_instance.cndi_aws_instance_${leaderNodeName}.private_ip}`;
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) =>
     stageFile(
@@ -42,7 +42,7 @@ export default async function stageTerraformResourcesForAWS(
         "terraform",
         `cndi_aws_instance_${node.name}.tf.json`,
       ),
-      cndi_aws_instance(node, config),
+      cndi_aws_instance(node, leaderNodeName),
     )
   );
 

--- a/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
@@ -1,15 +1,10 @@
-import {
-  getLeaderNodeNameFromConfig,
-  getPrettyJSONString,
-  getTFResource,
-} from "src/utils.ts";
-import { AzureNodeItemSpec, CNDIConfig } from "src/types.ts";
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { AzureNodeItemSpec } from "src/types.ts";
 
 export default function getAzureComputeInstanceTFJSON(
   node: AzureNodeItemSpec,
-  config: CNDIConfig,
+  leaderNodeName: string,
 ): string {
-  const leaderNodeName = getLeaderNodeNameFromConfig(config);
   const { name, role } = node;
   const DEFAULT_IMAGE = "0001-com-ubuntu-server-focal"; // The image from which to initialize this disk
   const DEFAULT_MACHINE_TYPE = "Standard_DC2s_v2"; // The machine type to create.Standard_DC2s_v2 has 2cpu and 8g of ram

--- a/src/outputs/terraform/azure/stageAll.ts
+++ b/src/outputs/terraform/azure/stageAll.ts
@@ -32,10 +32,10 @@ export default async function stageTerraformResourcesForAzure(
 ) {
   const azure_location = (Deno.env.get("ARM_REGION") as string) || "eastus";
 
-  const leaderName = getLeaderNodeNameFromConfig(config);
+  const leaderNodeName = await getLeaderNodeNameFromConfig(config);
 
   const leader_node_ip =
-    `\${azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${leaderName}.private_ip_address}`;
+    `\${azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${leaderNodeName}.private_ip_address}`;
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) =>
     stageFile(
@@ -44,7 +44,7 @@ export default async function stageTerraformResourcesForAzure(
         "terraform",
         `cndi_azurerm_linux_virtual_machine_${node.name}.tf.json`,
       ),
-      cndi_azurerm_linux_virtual_machine(node, config),
+      cndi_azurerm_linux_virtual_machine(node, leaderNodeName),
     )
   );
 

--- a/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
+++ b/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
@@ -1,15 +1,10 @@
-import {
-  getLeaderNodeNameFromConfig,
-  getPrettyJSONString,
-  getTFResource,
-} from "src/utils.ts";
-import { CNDIConfig, GCPNodeItemSpec } from "src/types.ts";
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { GCPNodeItemSpec } from "src/types.ts";
 
 export default function getGCPComputeInstanceTFJSON(
   node: GCPNodeItemSpec,
-  config: CNDIConfig,
+  leaderNodeName: string,
 ): string {
-  const leaderNodeName = getLeaderNodeNameFromConfig(config);
   const { name, role } = node;
   const DEFAULT_MACHINE_TYPE = "n2-standard-2"; // The machine type to create.
   const machine_type = node?.machine_type || node?.instance_type ||

--- a/src/outputs/terraform/gcp/stageAll.ts
+++ b/src/outputs/terraform/gcp/stageAll.ts
@@ -38,10 +38,10 @@ export default async function stageTerraformResourcesForGCP(
   const gcp_region = (Deno.env.get("GCP_REGION") as string) || "us-central1";
   const googleCredentials = Deno.env.get("GOOGLE_CREDENTIALS") as string; // project_id
 
-  const leaderName = getLeaderNodeNameFromConfig(config);
+  const leaderNodeName = await getLeaderNodeNameFromConfig(config);
 
   const leader_node_ip =
-    `\${google_compute_instance.cndi_google_compute_instance_${leaderName}.network_interface.0.network_ip}`;
+    `\${google_compute_instance.cndi_google_compute_instance_${leaderNodeName}.network_interface.0.network_ip}`;
 
   if (!googleCredentials) {
     console.error(
@@ -107,7 +107,7 @@ export default async function stageTerraformResourcesForGCP(
         "terraform",
         `cndi_google_compute_instance_${node.name}.tf.json`,
       ),
-      cndi_google_compute_instance(node, config),
+      cndi_google_compute_instance(node, leaderNodeName),
     )
   );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,11 +38,28 @@ function getPrettyJSONString(object: unknown) {
   return JSON.stringify(object, null, 2);
 }
 
-function getLeaderNodeNameFromConfig(config: CNDIConfig): string | undefined {
-  const leaderNode = config.infrastructure.cndi.nodes.find(
+async function getLeaderNodeNameFromConfig(
+  config: CNDIConfig,
+): Promise<string> {
+  const nodesWithRoleLeader = config.infrastructure.cndi.nodes.filter(
     (node: BaseNodeItemSpec) => node.role === "leader",
   );
-  return leaderNode?.name;
+  if (nodesWithRoleLeader.length !== 1) {
+    console.error(
+      utilsLabel,
+      ccolors.error("cndi-config exists"),
+      ccolors.error("but it does not have exactly 1"),
+      ccolors.key_name('"infrastructure.cndi.nodes"'),
+      ccolors.error("entry where"),
+      ccolors.key_name('"role"'),
+      ccolors.error("is"),
+      ccolors.key_name('"leader".'),
+      ccolors.error("There must be exactly one leader node."),
+    );
+    await emitExitEvent(200);
+    Deno.exit(200);
+  }
+  return nodesWithRoleLeader[0].name;
 }
 
 function getDeploymentTargetFromConfig(config: CNDIConfig): DeploymentTarget {


### PR DESCRIPTION
Prior to this PR we would validate `cndi-config` early in the execution flow of `cndi ow` to assert that, among other things, there is exactly one item in the `infrastructure.cndi.nodes` array which had the `role` key equal to `"leader"`. 

The terraform staging functions then assumed that this validation code has already ran. This was a brittle solution because if that validation check was moved or broken it would result in unhandled exceptions downstream. 

Now we check for `leaderNodeName` (redundantly) when staging tf output files.