### PR TITLE
consistent default instance_type for az selection

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -81,3 +81,8 @@ export const ccolors = {
 // constants
 export const TERRAFORM_VERSION = "1.3.2";
 export const KUBESEAL_VERSION = "0.19.1";
+export const DEFAULT_INSTANCE_TYPES = {
+  aws: "m5a.large",
+  gcp: "n2-standard-2",
+  azure: "Standard_D4s_v3",
+};

--- a/src/outputs/terraform/aws/data.tf.json.ts
+++ b/src/outputs/terraform/aws/data.tf.json.ts
@@ -1,5 +1,6 @@
 import { getPrettyJSONString } from "src/utils.ts";
 import { AWSNodeItemSpec } from "src/types.ts";
+import { DEFAULT_INSTANCE_TYPES } from "deps";
 
 interface AWSTerraformEC2InstanceTypeOfferingsDataSource {
   [ec2_inst_type: string]: Array<{
@@ -30,7 +31,7 @@ export default function getAWSDataTFJSON(
 
   nodes.forEach((entry) => {
     const instance_type = entry?.instance_type || entry?.machine_type ||
-      "t3.large";
+      DEFAULT_INSTANCE_TYPES.aws;
     const azKey = `available_az_for_${entry.name}_instance_type`;
 
     data[0].aws_ec2_instance_type_offerings[0][

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,13 @@
-import { ccolors, deepMerge, homedir, JSONC, path, platform, walk } from "deps";
+import {
+  ccolors,
+  deepMerge,
+  DEFAULT_INSTANCE_TYPES,
+  homedir,
+  JSONC,
+  path,
+  platform,
+  walk,
+} from "deps";
 
 import {
   BaseNodeItemSpec,
@@ -381,11 +390,11 @@ async function getDefaultVmTypeForKind(
   switch (kind) {
     // most recent 4vCPU/16GiB Ram VMs
     case NODE_KIND.aws:
-      return ["instance_type", "m5a.large"];
+      return ["instance_type", DEFAULT_INSTANCE_TYPES.aws];
     case NODE_KIND.gcp:
-      return ["machine_type", "n2-standard-2"];
+      return ["machine_type", DEFAULT_INSTANCE_TYPES.gcp];
     case NODE_KIND.azure:
-      return ["machine_type", "Standard_D4s_v3"];
+      return ["machine_type", DEFAULT_INSTANCE_TYPES.azure];
     default:
       console.log("Unknown kind: " + kind);
       await emitExitEvent(205);


### PR DESCRIPTION
There was a bug relating to the default `instance_type` being hardcoded as two different values in two different spots for aws. Now the default `instance_type` for each cloud exists in only one place.