### PR TITLE
only one cndi-run workflow can be active at a time

### DIFF
--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -16,6 +16,27 @@ const cndiWorkflowObj = {
           run: 'echo "welcome to cndi!"',
         },
         {
+          id: "lock-check",
+          uses: "github/lock@v2.0.1",
+          with: {
+            mode: "check",
+            environment: "global",
+          },
+        },
+        {
+          name: "fail if locked",
+          if: "${{ steps.lock-check.outputs.locked != 'false' }}",
+          run: "echo \"cndi cannot 'run': deployment in progress\" && exit 1",
+        },
+        {
+          id: "lock-acquire",
+          uses: "github/lock@v2.0.1",
+          with: {
+            mode: "lock",
+            environment: "global",
+          },
+        },
+        {
           name: "checkout repo",
           uses: "actions/checkout@v3",
           with: {
@@ -54,6 +75,15 @@ const cndiWorkflowObj = {
             ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}",
           },
           run: "cndi run",
+        },
+        {
+          id: "lock-release",
+          uses: "github/lock@v2.0.1",
+          if: "always()", // always release the lock even if `cndi run` fails
+          with: {
+            mode: "unlock",
+            environment: "global",
+          },
         },
       ],
     },


### PR DESCRIPTION
GitHub actions currently has bugs that result in 2 instances of a GitHub action workflow run for a single commit. CNDI is unable to work reliably if the terraform state is being read an manipulated from more than one execution simultaneously.

This pull request adds a [lock](https://github.com/github/lock) mechanism which makes it so each workflow must first verify that it is the only running instance before beginning work.