### PR TITLE
close file writer on upgrade

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -47,6 +47,7 @@ class GitHubBinaryUpgradeProvider extends GithubProvider {
         });
         const cndiWritableStream = writableStreamFromWriter(cndiFile);
         await response.body.pipeTo(cndiWritableStream);
+        cndiFile.close();
       }
       spinner.stop();
       const fromMsg = from ? ` from ${ccolors.warn(from)}` : "";

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -152,7 +152,9 @@ export default async function validateConfig(
       ccolors.key_name('"role"'),
       ccolors.error("is"),
       ccolors.key_name('"leader".'),
-      ccolors.error("There must be exactly one leader node when using microk8s based clusters."),
+      ccolors.error(
+        "There must be exactly one leader node when using microk8s based clusters.",
+      ),
     );
     await emitExitEvent(907);
     Deno.exit(907);


### PR DESCRIPTION
`cndi upgrade` did not close the file writer it used to persist updates to the binary, which may or may not have been the reasons for its inconsistent behavior