### PR TITLE
Templates two

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,12 @@
         "*cndi-config.json*"
       ],
       "url": "/src/schemas/cndi-config.schema.json"
+    },
+    {
+      "fileMatch": [
+        "src/templates/**/*.json*"
+      ],
+      "url": "/src/schemas/cndi-template.schema.json"
     }
   ]
 }

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.2",
+  "version": "1.8.0",
   "tasks": {
     "compile-win": "deno compile --unstable -A --target x86_64-pc-windows-msvc --output dist/cndi-win.exe dist/cndi.js",
     "compile-linux": "deno compile --unstable -A --target x86_64-unknown-linux-gnu --output dist/cndi-linux dist/cndi.js",

--- a/docs/error-code-reference.json
+++ b/docs/error-code-reference.json
@@ -148,6 +148,10 @@
     "message": "failed to stage gcp terraform objects"
   },
   {
+    "code": 806,
+    "message": "failed to stage eks terraform objects"
+  },
+  {
     "code": 803,
     "message": "'GOOGLE_CREDENTIALS' env var is not set during terraform staging"
   },

--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -46,7 +46,7 @@ export default async function cndi() {
       ccolors.error(`Could not create staging directory`),
       ccolors.key_name(`"${stagingDirectory}"`),
     );
-    console.log(ccolors.caught(failedToCreateStagingDirectoryError));
+    console.log(ccolors.caught(failedToCreateStagingDirectoryError, 1));
     await emitExitEvent(1);
     Deno.exit(1);
   }

--- a/src/deployment-targets/gcp.ts
+++ b/src/deployment-targets/gcp.ts
@@ -59,7 +59,7 @@ const getGCPEnvLines = async (interactive: boolean): Promise<EnvLines> => {
     }
 
     // if the path to google json key is valid, and the file is a valid json, write the GOOGLE_CREDENTIALS env variable
-    GOOGLE_CREDENTIALS = credentials_string;
+    GOOGLE_CREDENTIALS = `'${credentials_string}'`;
   }
 
   return [

--- a/src/deployment-targets/gcp.ts
+++ b/src/deployment-targets/gcp.ts
@@ -59,7 +59,7 @@ const getGCPEnvLines = async (interactive: boolean): Promise<EnvLines> => {
     }
 
     // if the path to google json key is valid, and the file is a valid json, write the GOOGLE_CREDENTIALS env variable
-    GOOGLE_CREDENTIALS = `'${credentials_string}'`;
+    GOOGLE_CREDENTIALS = credentials_string;
   }
 
   return [
@@ -67,7 +67,7 @@ const getGCPEnvLines = async (interactive: boolean): Promise<EnvLines> => {
       comment: "GCP",
     },
     { value: { GCP_REGION } },
-    { value: { GOOGLE_CREDENTIALS } },
+    { value: { GOOGLE_CREDENTIALS }, wrap: true },
   ];
 };
 

--- a/src/deployment-targets/gcp.ts
+++ b/src/deployment-targets/gcp.ts
@@ -39,7 +39,7 @@ const getGCPEnvLines = async (interactive: boolean): Promise<EnvLines> => {
           )
         }`,
       );
-      console.log(ccolors.caught(errorReadingCredentials));
+      console.log(ccolors.caught(errorReadingCredentials, 607));
       await emitExitEvent(607);
       Deno.exit(607);
     }
@@ -53,7 +53,7 @@ const getGCPEnvLines = async (interactive: boolean): Promise<EnvLines> => {
         ccolors.error(`Invalid GCP JSON key file found at the provided path`),
         ccolors.user_input(`"${google_credentials_path}"`),
       );
-      console.log(ccolors.caught(errorParsingCredentials));
+      console.log(ccolors.caught(errorParsingCredentials, 608));
       await emitExitEvent(608);
       Deno.exit(608);
     }

--- a/src/deployment-targets/shared.ts
+++ b/src/deployment-targets/shared.ts
@@ -96,15 +96,16 @@ const getCoreEnvLines = async (
     { comment: "Sealed Secrets keys for Kubeseal" },
     {
       value: {
-        SEALED_SECRETS_PUBLIC_KEY:
-          `'${sealedSecretsKeys.sealed_secrets_public_key}'`,
+        SEALED_SECRETS_PUBLIC_KEY: sealedSecretsKeys.sealed_secrets_public_key,
       },
+      wrap: true,
     },
     {
       value: {
         SEALED_SECRETS_PRIVATE_KEY:
-          `'${sealedSecretsKeys.sealed_secrets_private_key}'`,
+          sealedSecretsKeys.sealed_secrets_private_key,
       },
+      wrap: true,
     },
     { comment: "ArgoCD" },
     { value: { ARGOCD_ADMIN_PASSWORD } },

--- a/src/deployment-targets/shared.ts
+++ b/src/deployment-targets/shared.ts
@@ -96,13 +96,14 @@ const getCoreEnvLines = async (
     { comment: "Sealed Secrets keys for Kubeseal" },
     {
       value: {
-        SEALED_SECRETS_PUBLIC_KEY: sealedSecretsKeys.sealed_secrets_public_key,
+        SEALED_SECRETS_PUBLIC_KEY:
+          `'${sealedSecretsKeys.sealed_secrets_public_key}'`,
       },
     },
     {
       value: {
         SEALED_SECRETS_PRIVATE_KEY:
-          sealedSecretsKeys.sealed_secrets_private_key,
+          `'${sealedSecretsKeys.sealed_secrets_private_key}'`,
       },
     },
     { comment: "ArgoCD" },

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -73,7 +73,8 @@ export const ccolors = {
   prompt: colors.cyan,
   success: colors.green,
   key_name: colors.cyan,
-  caught: colors.red,
+  caught: (e: Error, num?: number) =>
+    `${colors.white(`E${num}`)}: ${colors.red(e.toString())}`,
 };
 
 // constants

--- a/src/install.ts
+++ b/src/install.ts
@@ -67,7 +67,7 @@ export default async function installDependenciesIfRequired(
         installLabel,
         ccolors.error("\nfailed to install terraform, please try again"),
       );
-      console.log(ccolors.caught(terraformInstallError));
+      console.log(ccolors.caught(terraformInstallError, 300));
 
       await emitExitEvent(300);
       Deno.exit(300);
@@ -100,7 +100,7 @@ export default async function installDependenciesIfRequired(
         installLabel,
         ccolors.error("\nfailed to install kubeseal, please try again"),
       );
-      console.log(ccolors.caught(kubesealInstallError));
+      console.log(ccolors.caught(kubesealInstallError, 301));
       await emitExitEvent(301);
       Deno.exit(301);
     }

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -22,7 +22,7 @@ const DEFAULT_SYNC_POLICY = {
     "Validate=false",
     "CreateNamespace=true",
     "PrunePropagationPolicy=foreground",
-    "PruneLast=true",
+    "PruneLast=false",
   ],
   retry: {
     limit: 10,

--- a/src/outputs/env.ts
+++ b/src/outputs/env.ts
@@ -18,7 +18,7 @@ const writeEnvObject = (envLines: EnvLines): string => {
 
       Deno.env.set(key, val);
 
-      return `${key}='${val}'`;
+      return `${key}=${val}`;
     } else {
       console.error("failed to build env file line", line);
       return "";

--- a/src/outputs/env.ts
+++ b/src/outputs/env.ts
@@ -18,6 +18,11 @@ const writeEnvObject = (envLines: EnvLines): string => {
 
       Deno.env.set(key, val);
 
+      // some values (especially multiline) need to be wrapped in quotes
+      if (valueLine?.wrap) {
+        return `${key}='${val}'`;
+      }
+
       return `${key}=${val}`;
     } else {
       console.error("failed to build env file line", line);

--- a/src/outputs/terraform/aws-ec2/stageAll.ts
+++ b/src/outputs/terraform/aws-ec2/stageAll.ts
@@ -188,7 +188,7 @@ export default async function stageTerraformResourcesForAWS(
     ]);
   } catch (e) {
     console.error(ccolors.error("failed to stage terraform resources"));
-    console.log(ccolors.caught(e));
+    console.log(ccolors.caught(e, 800));
     await emitExitEvent(800);
     Deno.exit(800);
   }

--- a/src/outputs/terraform/aws-eks/stageAll.ts
+++ b/src/outputs/terraform/aws-eks/stageAll.ts
@@ -589,8 +589,8 @@ export default async function stageTerraformResourcesForAWS(
     ]);
   } catch (e) {
     console.error(ccolors.error("failed to stage terraform resources"));
-    console.log(ccolors.caught(e));
-    await emitExitEvent(800);
-    Deno.exit(800);
+    console.log(ccolors.caught(e, 806));
+    await emitExitEvent(806);
+    Deno.exit(806);
   }
 }

--- a/src/outputs/terraform/azure/stageAll.ts
+++ b/src/outputs/terraform/azure/stageAll.ts
@@ -196,7 +196,7 @@ export default async function stageTerraformResourcesForAzure(
     ]);
   } catch (e) {
     console.error(ccolors.error("failed to stage terraform resources"));
-    console.log(ccolors.caught(e));
+    console.log(ccolors.caught(e, 801));
     await emitExitEvent(801);
     Deno.exit(801);
   }

--- a/src/outputs/terraform/gcp/stageAll.ts
+++ b/src/outputs/terraform/gcp/stageAll.ts
@@ -38,8 +38,6 @@ export default async function stageTerraformResourcesForGCP(
   const gcp_region = (Deno.env.get("GCP_REGION") as string) || "us-central1";
   const googleCredentials = Deno.env.get("GOOGLE_CREDENTIALS") as string; // project_id
 
-  console.log("googleCredentials", googleCredentials);
-
   const leaderNodeName = await getLeaderNodeNameFromConfig(config);
 
   const leader_node_ip =
@@ -96,7 +94,7 @@ export default async function stageTerraformResourcesForGCP(
         ccolors.error("failed to parse service account key json from"),
         ccolors.user_input(`"${dotEnvPath}"`),
       );
-      console.log(ccolors.caught(parsingError));
+      console.log(ccolors.caught(parsingError, 805));
       await emitExitEvent(805);
       Deno.exit(805);
     }
@@ -237,7 +235,7 @@ export default async function stageTerraformResourcesForGCP(
     ]);
   } catch (e) {
     console.log(ccolors.error("failed to stage terraform resources"));
-    console.log(ccolors.caught(e));
+    console.log(ccolors.caught(e, 802));
     await emitExitEvent(802);
     Deno.exit(802);
   }

--- a/src/outputs/terraform/gcp/stageAll.ts
+++ b/src/outputs/terraform/gcp/stageAll.ts
@@ -38,6 +38,8 @@ export default async function stageTerraformResourcesForGCP(
   const gcp_region = (Deno.env.get("GCP_REGION") as string) || "us-central1";
   const googleCredentials = Deno.env.get("GOOGLE_CREDENTIALS") as string; // project_id
 
+  console.log("googleCredentials", googleCredentials);
+
   const leaderNodeName = await getLeaderNodeNameFromConfig(config);
 
   const leader_node_ip =

--- a/src/schemas/cndi-config.schema.json
+++ b/src/schemas/cndi-config.schema.json
@@ -3,8 +3,8 @@
   "type": "object",
   "title": "cndi-config",
   "$comment": "The root of the cndi config schema",
-  "description": "An object used to configure the changelog generation for GitHub Releases",
-  "required": ["project_name", "infrastructure"],
+  "description": "A configuration file for CNDI that defines the hardware and software of your cluster",
+  "required": ["infrastructure"],
   "properties": {
     "project_name": {
       "type": "string",
@@ -46,7 +46,7 @@
                   "kind": {
                     "type": "string",
                     "description": "The type of node to deploy.",
-                    "enum": ["aws", "eks", "gcp", "azure"]
+                    "enum": ["aws", "eks", "ec2", "gcp", "azure"]
                   },
                   "role": {
                     "type": "string",

--- a/src/schemas/cndi-template.schema.json
+++ b/src/schemas/cndi-template.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "cndi-config",
+  "$comment": "The root of the cndi config schema",
+  "description": "An object used to configure the changelog generation for GitHub Releases",
+  "required": ["outputs"],
+  "properties": {
+    "outputs": {
+      "type": "object",
+      "description": "An object which defines the outputs of the cndi template",
+      "required": ["cndi-config", "env", "readme"],
+      "properties": {
+        "cndi-config": {
+          "type": "object",
+          "description": "The path to the cndi-config file",
+          "$ref": "./cndi-config.schema.json",
+          "not": {
+            "required": ["project_name"]
+          }
+        },
+        "env": {
+          "type": "object",
+          "description": "The path to the env file",
+          "properties": {
+            "entries": {
+              "type": "array"
+            },
+            "extend_basic_env": {
+              "type": "string",
+              "enum": ["aws", "gcp", "azure"]
+            }
+          }
+        }
+      }
+    },
+    "prompts": {
+      "type": "array",
+      "description": "An array of prompts to be presented to the user for configuration",
+      "items": {
+        "type": "object",
+        "required": ["name", "message", "type"],
+        "description": "A prompt to be presented the user of a CNDI template so they can configure it",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The key which can be used to inject the value later, eg. {{ $.cndi.prompts.responses.myPromptName }}"
+          },
+          "message": {
+            "type": "string",
+            "description": "The message to be presented to the user when they are prompted for a value"
+          },
+          "type": {
+            "type": "string",
+            "description": "The type of prompt to be presented to the user",
+            "enum": [
+              "Input",
+              "Secret",
+              "Confirm",
+              "Toggle",
+              "Select",
+              "List",
+              "Checkbox",
+              "Number"
+            ]
+          },
+          "default": {
+            "description": "The default value to be used if the user does not provide one"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/templates/aws/airflow-tls.json
+++ b/src/templates/aws/airflow-tls.json
@@ -1,50 +1,60 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "dagRepoUrl",
-        "default": "https://github.com/polyseam/demo-dag-bag",
-        "message": "Please enter the url of the git repo containing your dags:",
-        "type": "Input"
-      },
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "name": "airflowDomainName",
-        "default": "airflow.example.com",
-        "message": "Please enter the domain name you want airflow to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "airflowDomainName",
+      "default": "airflow.example.com",
+      "message": "Please enter the domain name you want airflow to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "dagRepoUrl",
+      "default": "https://github.com/polyseam/demo-dag-bag",
+      "message": "Please enter the url of the git repo containing your dags:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the username you want to use for git sync DAG storage:",
+      "name": "gitSyncUsername",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the password you want to use for git sync DAG storage:",
+      "name": "gitSyncPassword",
+      "type": "Secret"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
             {
               "name": "x-airflow-node",
-              "kind": "aws",
+              "kind": "ec2",
               "role": "leader",
-              "instance_type": "t3.medium",
+              "machine_type": "n2-standard-2",
               "volume_size": 128
             },
             {
               "name": "y-airflow-node",
-              "kind": "aws",
+              "kind": "ec2",
               "volume_size": 128
             },
             {
               "name": "z-airflow-node",
-              "kind": "aws",
+              "kind": "ec2",
               "volume_size": 128
             }
           ]
@@ -71,7 +81,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -104,13 +114,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -142,7 +152,7 @@
             "dags": {
               "gitSync": {
                 "enabled": true,
-                "repo": "$.cndi.prompts.responses.dagRepoUrl",
+                "repo": "{{ $.cndi.prompts.responses.dagRepoUrl }}",
                 "credentialsSecret": "airflow-git-credentials",
                 "branch": "main",
                 "wait": 40,
@@ -154,7 +164,7 @@
                 "expose_config": "True",
                 "instance_name": "Polyseam",
                 "enable_proxy_fix": "True",
-                "base_url": "https://$.cndi.prompts.responses.airflowDomainName"
+                "base_url": "https://{{ $.cndi.prompts.responses.airflowDomainName }}"
               },
               "operators": {
                 "default_owner": "Polyseam"
@@ -168,7 +178,7 @@
                 },
                 "hosts": [
                   {
-                    "name": "$.cndi.prompts.responses.airflowDomainName",
+                    "name": "{{ $.cndi.prompts.responses.airflowDomainName }}",
                     "tls": {
                       "secretName": "lets-encrypt-private-key",
                       "enabled": true
@@ -192,29 +202,26 @@
           }
         }
       }
+    },
+    "env": {
+      "extend_basic_env": "aws",
+      "entries": [
+        {
+          "comment": "airflow-git-credentials secret values for DAG Storage"
+        },
+        {
+          "name": "GIT_SYNC_USERNAME",
+          "value": "{{ $.cndi.prompts.responses.gitSyncUsername }}"
+        },
+        {
+          "name": "GIT_SYNC_PASSWORD",
+          "value": "{{ $.cndi.prompts.responses.gitSyncPassword }}"
+        }
+      ]
+    },
+    "readme": {
+      "extend_basic_readme": "aws",
+      "template_section": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
     }
-  },
-  "env": {
-    "extend_basic_env": "aws",
-    "prompts": [
-      {
-        "type": "Comment",
-        "comment": "airflow-git-credentials secret values for DAG Storage"
-      },
-      {
-        "name": "GIT_SYNC_USERNAME",
-        "message": "Please enter your git username for Airflow DAG Storage:",
-        "type": "Input"
-      },
-      {
-        "name": "GIT_SYNC_PASSWORD",
-        "message": "Please enter your git password for Airflow DAG Storage:",
-        "type": "Secret"
-      }
-    ]
-  },
-  "readme": {
-    "extend_basic_readme": "aws",
-    "template": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
   }
 }

--- a/src/templates/aws/basic.json
+++ b/src/templates/aws/basic.json
@@ -1,37 +1,38 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
             {
-              "name": "x-node",
-              "kind": "aws",
+              "name": "x-airflow-node",
+              "kind": "ec2",
               "role": "leader",
+              "machine_type": "n2-standard-2",
               "volume_size": 128
             },
             {
-              "name": "y-node",
-              "kind": "aws",
+              "name": "y-airflow-node",
+              "kind": "ec2",
               "volume_size": 128
             },
             {
-              "name": "z-node",
-              "kind": "aws",
+              "name": "z-airflow-node",
+              "kind": "ec2",
               "volume_size": 128
             }
           ]
@@ -46,7 +47,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -79,13 +80,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -108,12 +109,12 @@
         }
       },
       "applications": {}
+    },
+    "env": {
+      "extend_basic_env": "aws"
+    },
+    "readme": {
+      "extend_basic_readme": "aws"
     }
-  },
-  "env": {
-    "extend_basic_env": "aws"
-  },
-  "readme": {
-    "extend_basic_readme": "aws"
   }
 }

--- a/src/templates/azure/airflow-tls.json
+++ b/src/templates/azure/airflow-tls.json
@@ -1,32 +1,42 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "dagRepoUrl",
-        "default": "https://github.com/polyseam/demo-dag-bag",
-        "message": "Please enter the url of the git repo containing your dags:",
-        "type": "Input"
-      },
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "name": "airflowDomainName",
-        "default": "airflow.example.com",
-        "message": "Please enter the domain name you want airflow to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "airflowDomainName",
+      "default": "airflow.example.com",
+      "message": "Please enter the domain name you want airflow to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "dagRepoUrl",
+      "default": "https://github.com/polyseam/demo-dag-bag",
+      "message": "Please enter the url of the git repo containing your dags:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the username you want to use for git sync DAG storage:",
+      "name": "gitSyncUsername",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the password you want to use for git sync DAG storage:",
+      "name": "gitSyncPassword",
+      "type": "Secret"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
@@ -34,7 +44,7 @@
               "name": "x-airflow-node",
               "kind": "azure",
               "role": "leader",
-              "machine_type": "Standard_DC2s_v2",
+              "machine_type": "n2-standard-2",
               "volume_size": 128
             },
             {
@@ -71,7 +81,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -104,13 +114,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -142,7 +152,7 @@
             "dags": {
               "gitSync": {
                 "enabled": true,
-                "repo": "$.cndi.prompts.responses.dagRepoUrl",
+                "repo": "{{ $.cndi.prompts.responses.dagRepoUrl }}",
                 "credentialsSecret": "airflow-git-credentials",
                 "branch": "main",
                 "wait": 40,
@@ -154,7 +164,7 @@
                 "expose_config": "True",
                 "instance_name": "Polyseam",
                 "enable_proxy_fix": "True",
-                "base_url": "https://$.cndi.prompts.responses.airflowDomainName"
+                "base_url": "https://{{ $.cndi.prompts.responses.airflowDomainName }}"
               },
               "operators": {
                 "default_owner": "Polyseam"
@@ -168,7 +178,7 @@
                 },
                 "hosts": [
                   {
-                    "name": "$.cndi.prompts.responses.airflowDomainName",
+                    "name": "{{ $.cndi.prompts.responses.airflowDomainName }}",
                     "tls": {
                       "secretName": "lets-encrypt-private-key",
                       "enabled": true
@@ -192,29 +202,26 @@
           }
         }
       }
+    },
+    "env": {
+      "extend_basic_env": "azure",
+      "entries": [
+        {
+          "comment": "airflow-git-credentials secret values for DAG Storage"
+        },
+        {
+          "name": "GIT_SYNC_USERNAME",
+          "value": "{{ $.cndi.prompts.responses.gitSyncUsername }}"
+        },
+        {
+          "name": "GIT_SYNC_PASSWORD",
+          "value": "{{ $.cndi.prompts.responses.gitSyncPassword }}"
+        }
+      ]
+    },
+    "readme": {
+      "extend_basic_readme": "azure",
+      "template_section": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
     }
-  },
-  "env": {
-    "extend_basic_env": "azure",
-    "prompts": [
-      {
-        "type": "Comment",
-        "comment": "airflow-git-credentials secret values for DAG Storage"
-      },
-      {
-        "name": "GIT_SYNC_USERNAME",
-        "message": "Please enter your git username for Airflow DAG Storage:",
-        "type": "Input"
-      },
-      {
-        "name": "GIT_SYNC_PASSWORD",
-        "message": "Please enter your git password for Airflow DAG Storage:",
-        "type": "Secret"
-      }
-    ]
-  },
-  "readme": {
-    "extend_basic_readme": "azure",
-    "template": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
   }
 }

--- a/src/templates/azure/basic.json
+++ b/src/templates/azure/basic.json
@@ -1,36 +1,37 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
             {
-              "name": "x-node",
+              "name": "x-airflow-node",
               "kind": "azure",
               "role": "leader",
+              "machine_type": "n2-standard-2",
               "volume_size": 128
             },
             {
-              "name": "y-node",
+              "name": "y-airflow-node",
               "kind": "azure",
               "volume_size": 128
             },
             {
-              "name": "z-node",
+              "name": "z-airflow-node",
               "kind": "azure",
               "volume_size": 128
             }
@@ -46,7 +47,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -79,13 +80,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -108,12 +109,12 @@
         }
       },
       "applications": {}
+    },
+    "env": {
+      "extend_basic_env": "azure"
+    },
+    "readme": {
+      "extend_basic_readme": "azure"
     }
-  },
-  "env": {
-    "extend_basic_env": "azure"
-  },
-  "readme": {
-    "extend_basic_readme": "azure"
   }
 }

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -290,7 +290,8 @@
       },
       {
         "name": "POSTGRESQL_PROTOCOL",
-        "default": "postgresql"
+        "default": "postgresql",
+        "type": "Input"
       },
       {
         "name": "POSTGRESQL_USER",
@@ -304,11 +305,13 @@
       },
       {
         "name": "POSTGRESQL_HOST",
-        "default": "cnpg-cluster-rw"
+        "default": "cnpg-cluster-rw",
+        "type": "Input"
       },
       {
         "name": "POSTGRESQL_PORT",
-        "default": "5432"
+        "default": "5432",
+        "type": "Input"
       },
       {
         "name": "POSTGRESQL_DB",
@@ -317,15 +320,18 @@
       },
       {
         "name": "POSTGRESQL_SSLMODE",
-        "default": "disable"
+        "default": "disable",
+        "type": "Input"
       },
       {
         "name": "POSTGRESQL_CONNECTION_STRING",
-        "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE"
+        "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
+        "type": "Input"
       },
       {
         "name": "POSTGRESQL_CLUSTER_SUPERUSER",
         "default": "postgres"
+        ,"type": "Input"
       },
       {
         "type": "Comment",

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -1,32 +1,60 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "dagRepoUrl",
-        "default": "https://github.com/polyseam/demo-dag-bag",
-        "message": "Please enter the url of the git repo containing your dags:",
-        "type": "Input"
-      },
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "name": "airflowDomainName",
-        "default": "airflow.example.com",
-        "message": "Please enter the domain name you want airflow to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "dagRepoUrl",
+      "default": "https://github.com/polyseam/demo-dag-bag",
+      "message": "Please enter the url of the git repo containing your dags:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the username airflow should use to access your dag repo:",
+      "name": "gitSyncUsername",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the password airflow should use to access your dag repo:",
+      "name": "gitSyncPassword",
+      "type": "Secret"
+    },
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "airflowDomainName",
+      "default": "airflow.example.com",
+      "message": "Please enter the domain name you want airflow to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the username for your postgresql admin:",
+      "default": "admin",
+      "name": "postgresqlUser",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the postgresql password you want to use for your postgresql database:",
+      "default": "password",
+      "name": "postgresqlPassword",
+      "type": "Secret"
+    },
+    {
+      "message": "Please enter the name for the postgresql database you want to use:",
+      "default": "airflow-pg",
+      "name": "postgresqlDb",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
@@ -73,7 +101,9 @@
             "name": "cnpg-cluster",
             "namespace": "airflow",
             "annotations": {
-              "argocd.argoproj.io/sync-options": {"SkipDryRunOnMissingResource":true}
+              "argocd.argoproj.io/sync-options": {
+                "SkipDryRunOnMissingResource": true
+              }
             }
           },
           "spec": {
@@ -89,13 +119,13 @@
             },
             "postgresql": {
               "pg_hba": [
-                "host $.cndi.prompts.responses.POSTGRESQL_DB $.cndi.prompts.responses.POSTGRESQL_USER all password"
+                "host {{ $.cndi.prompts.responses.postgresqlDb }} {{ $.cndi.prompts.responses.postgresqlUser }} all password"
               ]
             },
             "bootstrap": {
               "initdb": {
-                "database": "https://$.cndi.prompts.responses.POSTGRESQL_DB",
-                "owner": "https://$.cndi.prompts.responses.POSTGRESQL_USER",
+                "database": "https://{{ $.cndi.prompts.responses.postgresqlDb }}",
+                "owner": "https://{{ $.cndi.prompts.responses.postgresqlUser }}",
                 "secret": {
                   "name": "cnpg-database-user-auth-secret"
                 }
@@ -140,7 +170,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -173,15 +203,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": [
-                  "$.cndi.prompts.responses.argocdDomainName"
-                ],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -226,7 +254,7 @@
             "dags": {
               "gitSync": {
                 "enabled": true,
-                "repo": "$.cndi.prompts.responses.dagRepoUrl",
+                "repo": "{{ $.cndi.prompts.responses.dagRepoUrl }}",
                 "credentialsSecret": "airflow-git-credentials",
                 "branch": "main",
                 "wait": 40,
@@ -238,7 +266,7 @@
                 "expose_config": "True",
                 "instance_name": "Polyseam",
                 "enable_proxy_fix": "True",
-                "base_url": "https://$.cndi.prompts.responses.airflowDomainName"
+                "base_url": "https://{{ $.cndi.prompts.responses.airflowDomainName }}"
               },
               "operators": {
                 "default_owner": "Polyseam"
@@ -252,7 +280,7 @@
                 },
                 "hosts": [
                   {
-                    "name": "$.cndi.prompts.responses.airflowDomainName",
+                    "name": "{{ $.cndi.prompts.responses.airflowDomainName }}",
                     "tls": {
                       "secretName": "lets-encrypt-private-key",
                       "enabled": true
@@ -277,87 +305,63 @@
           }
         }
       }
+    },
+    "env": {
+      "extend_basic_env": "aws",
+      "entries": [
+        {
+          "type": "Comment",
+          "comment": "PostgreSQL connection parameters"
+        },
+        {
+          "name": "POSTGRESQL_DB",
+          "value": "{{ $.cndi.prompts.responses.postgresqlDb }}"
+        },
+        {
+          "name": "POSTGRESQL_USER",
+          "value": "{{ $.cndi.prompts.responses.postgresqlUser }}"
+        },
+        {
+          "name": "POSTGRESQL_PROTOCOL",
+          "value": "postgresql"
+        },
+        {
+          "name": "POSTGRESQL_HOST",
+          "value": "cnpg-cluster-rw"
+        },
+        {
+          "name": "POSTGRESQL_PORT",
+          "value": "5432"
+        },
+        {
+          "name": "POSTGRESQL_SSLMODE",
+          "value": "disable"
+        },
+        {
+          "name": "POSTGRESQL_CONNECTION_STRING",
+          "value": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE"
+        },
+        {
+          "name": "POSTGRESQL_CLUSTER_SUPERUSER",
+          "value": "postgres"
+        },
+        {
+          "type": "Comment",
+          "comment": "airflow-git-credentials secret values for DAG Storage"
+        },
+        {
+          "name": "GIT_SYNC_USERNAME",
+          "value": "{{ $.cndi.prompts.responses.gitSyncUsername }}}}"
+        },
+        {
+          "name": "GIT_SYNC_PASSWORD",
+          "value": "{{ $.cndi.prompts.responses.gitSyncPassword }}"
+        }
+      ]
+    },
+    "readme": {
+      "extend_basic_readme": "aws",
+      "template": "## airflow-tls-cnpg\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart) and an external production ready posgresql database [cloudnative-pg](https://github.com/cloudnative-pg/charts) \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
     }
-  },
-  "env": {
-    "extend_basic_env": "aws",
-    "prompts": [
-      {
-        "type": "Comment",
-        "comment": "PostgreSQL connection parameters"
-      },
-      {
-        "message": "Please enter the name of the postgresql database",
-        "default": "cnpg-db",
-        "name": "POSTGRESQL_DB",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql user you want to use for your postgresql database:",
-        "default": "admin",
-        "name": "POSTGRESQL_USER",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql password you want to use for your postgresql database:",
-        "default": "password",
-        "name": "POSTGRESQL_PASSWORD",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql protocol you want to use for your postgresql database:",
-        "name": "POSTGRESQL_PROTOCOL",
-        "default": "postgresql",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql host you want to use for your postgresql database:",
-        "name": "POSTGRESQL_HOST",
-        "default": "cnpg-cluster-rw",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql port you want to use for your postgresql database:",
-        "name": "POSTGRESQL_PORT ",
-        "default": "5432",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql ssl mode you want to use for your postgresql database:",
-        "name": "POSTGRESQL_SSLMODE",
-        "default": "disable",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql connection string you want to use to connect your postgresql database:",
-        "name": "POSTGRESQL_CONNECTION_STRING",
-        "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql cluster superuser you want to use for your postgresql cluster:",
-        "name": "POSTGRESQL_CLUSTER_SUPERUSER",
-        "default": "postgres",
-        "type": "Input"
-      },
-      {
-        "type": "Comment",
-        "comment": "airflow-git-credentials secret values for DAG Storage"
-      },
-      {
-        "name": "GIT_SYNC_USERNAME",
-        "message": "Please enter your git username for Airflow DAG Storage:",
-        "type": "Input"
-      },
-      {
-        "name": "GIT_SYNC_PASSWORD",
-        "message": "Please enter your git password for Airflow DAG Storage:",
-        "type": "Secret"
-      }
-    ]
-  },
-  "readme": {
-    "extend_basic_readme": "aws",
-    "template": "## airflow-tls-cnpg\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart) and an external production ready posgresql database [cloudnative-pg](https://github.com/cloudnative-pg/charts) \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
   }
 }

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -25,7 +25,6 @@
         "name": "letsEncryptClusterIssuerEmailAddress",
         "type": "Input"
       }
-      
     ],
     "template": {
       "infrastructure": {
@@ -36,6 +35,7 @@
               "kind": "eks",
               "instance_type": "t3.large",
               "volume_size": 128,
+              "min_count": 1,
               "max_count": 3
             }
           ]
@@ -71,7 +71,10 @@
           "kind": "Cluster",
           "metadata": {
             "name": "cnpg-cluster",
-            "namespace": "airflow"
+            "namespace": "airflow",
+            "annotations": {
+              "argocd.argoproj.io/sync-options": {"SkipDryRunOnMissingResource":true}
+            }
           },
           "spec": {
             "imageName": "ghcr.io/cloudnative-pg/postgresql:15.2",
@@ -213,6 +216,7 @@
           "repoURL": "https://airflow.apache.org",
           "chart": "airflow",
           "values": {
+            "executor": "LocalKubernetesExecutor",
             "data": {
               "metadataSecretName": "postgresql-connection-string-secret"
             },

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -24,61 +24,8 @@
         "default": "admin@example.com",
         "name": "letsEncryptClusterIssuerEmailAddress",
         "type": "Input"
-      },
-      {
-        "message": "Please enter the name of the postgresql database",
-        "default": "cnpg-db",
-        "name": "POSTGRESQL_DB",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql user you want to use for your postgresql database:",
-        "default": "admin",
-        "name": "POSTGRESQL_USER",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql password you want to use for your postgresql database:",
-        "default": "password",
-        "name": "POSTGRESQL_PASSWORD",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql protocol you want to use for your postgresql database:",
-        "name": "POSTGRESQL_PROTOCOL",
-        "default": "postgresql",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql host you want to use for your postgresql database:",
-        "name": "POSTGRESQL_HOST",
-        "default": "cnpg-cluster-rw",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql port you want to use for your postgresql database:",
-        "name": "POSTGRESQL_PORT ",
-        "default": "5432",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql ssl mode you want to use for your postgresql database:",
-        "name": "POSTGRESQL_SSLMODE",
-        "default": "disable",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql connection string you want to use to connect your postgresql database:",
-        "name": "POSTGRESQL_CONNECTION_STRING",
-        "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql cluster superuser you want to use for your postgresql cluster:",
-        "name": "POSTGRESQL_CLUSTER_SUPERUSER",
-        "default": "postgres",
-        "type": "Input"
       }
+      
     ],
     "template": {
       "infrastructure": {

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -351,7 +351,7 @@
         },
         {
           "name": "GIT_SYNC_USERNAME",
-          "value": "{{ $.cndi.prompts.responses.gitSyncUsername }}}}"
+          "value": "{{ $.cndi.prompts.responses.gitSyncUsername }}"
         },
         {
           "name": "GIT_SYNC_PASSWORD",

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -26,6 +26,12 @@
         "type": "Input"
       },
       {
+        "message": "Please enter the name of the postgresql database",
+        "default": "cnpg-db",
+        "name": "postgreSQLDatabaseName",
+        "type": "Input"
+      },
+      {
         "message": "Please enter postgresql user you want to use for your postgresql databse:",
         "default": "admin",
         "name": "postgreSQLUserName",
@@ -38,9 +44,33 @@
         "type": "Input"
       },
       {
-        "message": "Please enter the name of the postgresql database",
-        "default": "cnpg-db",
-        "name": "postgreSQLDatabaseName",
+        "name": "POSTGRESQL_PROTOCOL",
+        "default": "postgresql",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_HOST",
+        "default": "cnpg-cluster-rw",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_PORT",
+        "default": "5432",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_SSLMODE",
+        "default": "disable",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_CONNECTION_STRING",
+        "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_CLUSTER_SUPERUSER",
+        "default": "postgres",
         "type": "Input"
       }
     ],
@@ -330,8 +360,8 @@
       },
       {
         "name": "POSTGRESQL_CLUSTER_SUPERUSER",
-        "default": "postgres"
-        ,"type": "Input"
+        "default": "postgres",
+        "type": "Input"
       },
       {
         "type": "Comment",

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -28,47 +28,47 @@
       {
         "message": "Please enter the name of the postgresql database",
         "default": "cnpg-db",
-        "name": "postgreSQLDatabaseName",
+        "name": "POSTGRESQL_DB",
         "type": "Input"
       },
       {
-        "message": "Please enter the postgresql user you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql user you want to use for your postgresql database:",
         "default": "admin",
-        "name": "postgreSQLUserName",
+        "name": "POSTGRESQL_USER",
         "type": "Input"
       },
       {
-        "message": "Please enter the postgresql password you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql password you want to use for your postgresql database:",
         "default": "password",
-        "name": "postgreSQLDatabasePasswordAuthentication",
+        "name": "POSTGRESQL_PASSWORD",
         "type": "Input"
       },
       {
-        "message": "Please enter the postgresql protocol you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql protocol you want to use for your postgresql database:",
         "name": "POSTGRESQL_PROTOCOL",
         "default": "postgresql",
         "type": "Input"
       },
       {
-        "message": "Please enter the postgresql host you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql host you want to use for your postgresql database:",
         "name": "POSTGRESQL_HOST",
         "default": "cnpg-cluster-rw",
         "type": "Input"
       },
       {
-        "message": "Please enter the postgresql port you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql port you want to use for your postgresql database:",
         "name": "POSTGRESQL_PORT ",
         "default": "5432",
         "type": "Input"
       },
       {
-        "message": "Please enter the postgresql ssl mode you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql ssl mode you want to use for your postgresql database:",
         "name": "POSTGRESQL_SSLMODE",
         "default": "disable",
         "type": "Input"
       },
       {
-        "message": "Please enter the postgresql connection string you want to use to connect your postgresql databse:",
+        "message": "Please enter the postgresql connection string you want to use to connect your postgresql database:",
         "name": "POSTGRESQL_CONNECTION_STRING",
         "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
         "type": "Input"
@@ -107,11 +107,11 @@
             "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_SYNC_PASSWORD)"
           }
         },
-        "custom-airflow-metadata-secret": {
+        "postgresql-connection-string-secret": {
           "apiVersion": "v1",
           "kind": "Secret",
           "metadata": {
-            "name": "custom-metadata-secret"
+            "name": "postgresql-connection-string-secret"
           },
           "type": "Opaque",
           "stringData": {
@@ -137,17 +137,21 @@
             },
             "postgresql": {
               "pg_hba": [
-                "host $.cndi.prompts.responses.postgreSQLDatabaseName $.cndi.prompts.responses.postgreSQLUserName all password"
+                "host $.cndi.prompts.responses.POSTGRESQL_DB $.cndi.prompts.responses.POSTGRESQL_USER all password"
               ]
             },
             "bootstrap": {
               "initdb": {
-                "database": "https://$.cndi.prompts.responses.postgreSQLDatabaseName",
-                "owner": "https://$.cndi.prompts.responses.postgreSQLUserName",
-                "secret": { "name": "cnpg-database-user-auth-secret" }
+                "database": "https://$.cndi.prompts.responses.POSTGRESQL_DB",
+                "owner": "https://$.cndi.prompts.responses.POSTGRESQL_USER",
+                "secret": {
+                  "name": "cnpg-database-user-auth-secret"
+                }
               }
             },
-            "superuserSecret": { "name": "cnpg-cluster-superuser-auth-secret" }
+            "superuserSecret": {
+              "name": "cnpg-cluster-superuser-auth-secret"
+            }
           }
         },
         "cnpg-cluster-superuser-auth-secret": {
@@ -215,7 +219,9 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": [
+                  "$.cndi.prompts.responses.argocdDomainName"
+                ],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
@@ -257,7 +263,7 @@
           "chart": "airflow",
           "values": {
             "data": {
-              "metadataSecretName": "custom-airflow-metadata-secret"
+              "metadataSecretName": "postgresql-connection-string-secret"
             },
             "postgresql": {
               "enabled": false
@@ -325,46 +331,55 @@
         "comment": "PostgreSQL connection parameters"
       },
       {
+        "message": "Please enter the name of the postgresql database",
+        "default": "cnpg-db",
+        "name": "POSTGRESQL_DB",
+        "type": "Input"
+      },
+      {
+        "message": "Please enter the postgresql user you want to use for your postgresql database:",
+        "default": "admin",
+        "name": "POSTGRESQL_USER",
+        "type": "Input"
+      },
+      {
+        "message": "Please enter the postgresql password you want to use for your postgresql database:",
+        "default": "password",
+        "name": "POSTGRESQL_PASSWORD",
+        "type": "Input"
+      },
+      {
+        "message": "Please enter the postgresql protocol you want to use for your postgresql database:",
         "name": "POSTGRESQL_PROTOCOL",
         "default": "postgresql",
         "type": "Input"
       },
       {
-        "name": "POSTGRESQL_USER",
-        "message": "Please enter postgresql user you want to use for your postgresql databse:",
-        "type": "Input"
-      },
-      {
-        "name": "POSTGRESQL_PASSWORD",
-        "message": "Please enter postgresql password you want to use for your postgresql databse:",
-        "type": "Input"
-      },
-      {
+        "message": "Please enter the postgresql host you want to use for your postgresql database:",
         "name": "POSTGRESQL_HOST",
         "default": "cnpg-cluster-rw",
         "type": "Input"
       },
       {
-        "name": "POSTGRESQL_PORT",
+        "message": "Please enter the postgresql port you want to use for your postgresql database:",
+        "name": "POSTGRESQL_PORT ",
         "default": "5432",
         "type": "Input"
       },
       {
-        "name": "POSTGRESQL_DB",
-        "message": "Please enter the name of the postgresql database",
-        "type": "Input"
-      },
-      {
+        "message": "Please enter the postgresql ssl mode you want to use for your postgresql database:",
         "name": "POSTGRESQL_SSLMODE",
         "default": "disable",
         "type": "Input"
       },
       {
+        "message": "Please enter the postgresql connection string you want to use to connect your postgresql database:",
         "name": "POSTGRESQL_CONNECTION_STRING",
         "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
         "type": "Input"
       },
       {
+        "message": "Please enter the postgresql cluster superuser you want to use for your postgresql cluster:",
         "name": "POSTGRESQL_CLUSTER_SUPERUSER",
         "default": "postgres",
         "type": "Input"

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -32,43 +32,49 @@
         "type": "Input"
       },
       {
-        "message": "Please enter postgresql user you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql user you want to use for your postgresql databse:",
         "default": "admin",
         "name": "postgreSQLUserName",
         "type": "Input"
       },
       {
-        "message": "Please enter postgresql password you want to use for your postgresql databse:",
+        "message": "Please enter the postgresql password you want to use for your postgresql databse:",
         "default": "password",
         "name": "postgreSQLDatabasePasswordAuthentication",
         "type": "Input"
       },
       {
+        "message": "Please enter the postgresql protocol you want to use for your postgresql databse:",
         "name": "POSTGRESQL_PROTOCOL",
         "default": "postgresql",
         "type": "Input"
       },
       {
+        "message": "Please enter the postgresql host you want to use for your postgresql databse:",
         "name": "POSTGRESQL_HOST",
         "default": "cnpg-cluster-rw",
         "type": "Input"
       },
       {
-        "name": "POSTGRESQL_PORT",
+        "message": "Please enter the postgresql port you want to use for your postgresql databse:",
+        "name": "POSTGRESQL_PORT ",
         "default": "5432",
         "type": "Input"
       },
       {
+        "message": "Please enter the postgresql ssl mode you want to use for your postgresql databse:",
         "name": "POSTGRESQL_SSLMODE",
         "default": "disable",
         "type": "Input"
       },
       {
+        "message": "Please enter the postgresql connection string you want to use to connect your postgresql databse:",
         "name": "POSTGRESQL_CONNECTION_STRING",
         "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
         "type": "Input"
       },
       {
+        "message": "Please enter the postgresql cluster superuser you want to use for your postgresql cluster:",
         "name": "POSTGRESQL_CLUSTER_SUPERUSER",
         "default": "postgres",
         "type": "Input"

--- a/src/templates/eks/airflow-tls-cnpg.json
+++ b/src/templates/eks/airflow-tls-cnpg.json
@@ -1,0 +1,350 @@
+{
+  "cndi-config": {
+    "prompts": [
+      {
+        "name": "dagRepoUrl",
+        "default": "https://github.com/polyseam/demo-dag-bag",
+        "message": "Please enter the url of the git repo containing your dags:",
+        "type": "Input"
+      },
+      {
+        "name": "argocdDomainName",
+        "default": "argocd.example.com",
+        "message": "Please enter the domain name you want argocd to be accessible on:",
+        "type": "Input"
+      },
+      {
+        "name": "airflowDomainName",
+        "default": "airflow.example.com",
+        "message": "Please enter the domain name you want airflow to be accessible on:",
+        "type": "Input"
+      },
+      {
+        "message": "Please enter the email address you want to use for lets encrypt:",
+        "default": "admin@example.com",
+        "name": "letsEncryptClusterIssuerEmailAddress",
+        "type": "Input"
+      },
+      {
+        "message": "Please enter postgresql user you want to use for your postgresql databse:",
+        "default": "admin",
+        "name": "postgreSQLUserName",
+        "type": "Input"
+      },
+      {
+        "message": "Please enter postgresql password you want to use for your postgresql databse:",
+        "default": "password",
+        "name": "postgreSQLDatabasePasswordAuthentication",
+        "type": "Input"
+      },
+      {
+        "message": "Please enter the name of the postgresql database",
+        "default": "cnpg-db",
+        "name": "postgreSQLDatabaseName",
+        "type": "Input"
+      }
+    ],
+    "template": {
+      "infrastructure": {
+        "cndi": {
+          "nodes": [
+            {
+              "name": "airflow-nodes",
+              "kind": "eks",
+              "instance_type": "t3.large",
+              "volume_size": 128,
+              "max_count": 3
+            }
+          ]
+        }
+      },
+      "cluster_manifests": {
+        "git-credentials-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "airflow-git-credentials",
+            "namespace": "airflow"
+          },
+          "stringData": {
+            "GIT_SYNC_USERNAME": "$.cndi.secrets.seal(GIT_SYNC_USERNAME)",
+            "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_SYNC_PASSWORD)"
+          }
+        },
+        "custom-airflow-metadata-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "custom-metadata-secret"
+          },
+          "type": "Opaque",
+          "stringData": {
+            "connection": "$.cndi.secrets.seal(POSTGRESQL_CONNECTION_STRING)"
+          }
+        },
+        "cnpg-cluster": {
+          "apiVersion": "postgresql.cnpg.io/v1",
+          "kind": "Cluster",
+          "metadata": {
+            "name": "cnpg-cluster"
+          },
+          "spec": {
+            "imageName": "ghcr.io/cloudnative-pg/postgresql:15.2",
+            "instances": 3,
+            "storage": {
+              "size": "1Gi"
+            },
+            "replicationSlots": {
+              "highAvailability": {
+                "enabled": true
+              }
+            },
+            "postgresql": {
+              "pg_hba": [
+                "host $.cndi.prompts.responses.postgreSQLDatabaseName $.cndi.prompts.responses.postgreSQLUserName all password"
+              ]
+            },
+            "bootstrap": {
+              "initdb": {
+                "database": "https://$.cndi.prompts.responses.postgreSQLDatabaseName",
+                "owner": "https://$.cndi.prompts.responses.postgreSQLUserName",
+                "secret": { "name": "cnpg-database-user-auth-secret" }
+              }
+            },
+            "superuserSecret": { "name": "cnpg-cluster-superuser-auth-secret" }
+          }
+        },
+        "cnpg-cluster-superuser-auth-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "cnpg-cluster-superuser-auth-secret"
+          },
+          "type": "kubernetes.io/basic-auth",
+          "stringData": {
+            "username": "$.cndi.secrets.seal(POSTGRESQL_CLUSTER_SUPERUSER)",
+            "password": "$.cndi.secrets.seal(POSTGRESQL_PASSWORD)"
+          }
+        },
+        "cnpg-database-user-auth-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "cnpg-database-user-auth-secret"
+          },
+          "type": "kubernetes.io/basic-auth",
+          "stringData": {
+            "username": "$.cndi.secrets.seal(POSTGRESQL_USER)",
+            "password": "$.cndi.secrets.seal(POSTGRESQL_PASSWORD)"
+          }
+        },
+        "cert-manager-cluster-issuer": {
+          "apiVersion": "cert-manager.io/v1",
+          "kind": "ClusterIssuer",
+          "metadata": {
+            "name": "lets-encrypt"
+          },
+          "spec": {
+            "acme": {
+              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "server": "https://acme-v02.api.letsencrypt.org/directory",
+              "privateKeySecretRef": {
+                "name": "lets-encrypt-private-key"
+              },
+              "solvers": [
+                {
+                  "http01": {
+                    "ingress": {
+                      "ingressClassName": "public"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "argo-ingress": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "argocd-server-ingress",
+            "namespace": "argocd",
+            "annotations": {
+              "cert-manager.io/cluster-issuer": "lets-encrypt",
+              "kubernetes.io/tls-acme": "true",
+              "nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+            }
+          },
+          "spec": {
+            "tls": [
+              {
+                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "secretName": "lets-encrypt-private-key"
+              }
+            ],
+            "rules": [
+              {
+                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "http": {
+                  "paths": [
+                    {
+                      "path": "/",
+                      "pathType": "Prefix",
+                      "backend": {
+                        "service": {
+                          "name": "argocd-server",
+                          "port": {
+                            "name": "https"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "applications": {
+        "cnpg": {
+          "targetRevision": "0.18.0",
+          "destinationNamespace": "cnpg-system",
+          "repoURL": "https://cloudnative-pg.github.io/charts",
+          "chart": "cloudnative-pg"
+        },
+        "airflow": {
+          "targetRevision": "1.7.0",
+          "destinationNamespace": "airflow",
+          "repoURL": "https://airflow.apache.org",
+          "chart": "airflow",
+          "values": {
+            "data": {
+              "metadataSecretName": "custom-airflow-metadata-secret"
+            },
+            "postgresql": {
+              "enabled": false
+            },
+            "dags": {
+              "gitSync": {
+                "enabled": true,
+                "repo": "$.cndi.prompts.responses.dagRepoUrl",
+                "credentialsSecret": "airflow-git-credentials",
+                "branch": "main",
+                "wait": 40,
+                "subPath": "dags"
+              }
+            },
+            "config": {
+              "webserver": {
+                "expose_config": "True",
+                "instance_name": "Polyseam",
+                "enable_proxy_fix": "True",
+                "base_url": "https://$.cndi.prompts.responses.airflowDomainName"
+              },
+              "operators": {
+                "default_owner": "Polyseam"
+              }
+            },
+            "ingress": {
+              "web": {
+                "enabled": true,
+                "annotations": {
+                  "cert-manager.io/cluster-issuer": "lets-encrypt"
+                },
+                "hosts": [
+                  {
+                    "name": "$.cndi.prompts.responses.airflowDomainName",
+                    "tls": {
+                      "secretName": "lets-encrypt-private-key",
+                      "enabled": true
+                    }
+                  }
+                ]
+              }
+            },
+            "logs": {
+              "persistence": {
+                "enabled": true,
+                "size": "15Gi"
+              }
+            },
+            "createUserJob": {
+              "useHelmHooks": false
+            },
+            "migrateDatabaseJob": {
+              "useHelmHooks": false
+            }
+          }
+        }
+      }
+    }
+  },
+  "env": {
+    "extend_basic_env": "aws",
+    "prompts": [
+      {
+        "type": "Comment",
+        "comment": "PostgreSQL connection parameters"
+      },
+      {
+        "name": "POSTGRESQL_PROTOCOL",
+        "default": "postgresql"
+      },
+      {
+        "name": "POSTGRESQL_USER",
+        "message": "Please enter postgresql user you want to use for your postgresql databse:",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_PASSWORD",
+        "message": "Please enter postgresql password you want to use for your postgresql databse:",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_HOST",
+        "default": "cnpg-cluster-rw"
+      },
+      {
+        "name": "POSTGRESQL_PORT",
+        "default": "5432"
+      },
+      {
+        "name": "POSTGRESQL_DB",
+        "message": "Please enter the name of the postgresql database",
+        "type": "Input"
+      },
+      {
+        "name": "POSTGRESQL_SSLMODE",
+        "default": "disable"
+      },
+      {
+        "name": "POSTGRESQL_CONNECTION_STRING",
+        "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE"
+      },
+      {
+        "name": "POSTGRESQL_CLUSTER_SUPERUSER",
+        "default": "postgres"
+      },
+      {
+        "type": "Comment",
+        "comment": "airflow-git-credentials secret values for DAG Storage"
+      },
+      {
+        "name": "GIT_SYNC_USERNAME",
+        "message": "Please enter your git username for Airflow DAG Storage:",
+        "type": "Input"
+      },
+      {
+        "name": "GIT_SYNC_PASSWORD",
+        "message": "Please enter your git password for Airflow DAG Storage:",
+        "type": "Secret"
+      }
+    ]
+  },
+  "readme": {
+    "extend_basic_readme": "aws",
+    "template": "## airflow-tls-cnpg\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart) and an external production ready posgresql database [cloudnative-pg](https://github.com/cloudnative-pg/charts) \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
+  }
+}

--- a/src/templates/eks/airflow-tls.json
+++ b/src/templates/eks/airflow-tls.json
@@ -35,6 +35,7 @@
               "kind": "eks",
               "instance_type": "t3.large",
               "volume_size": 128,
+              "min_count": 1,
               "max_count": 3
             }
           ]
@@ -70,7 +71,7 @@
                 {
                   "http01": {
                     "ingress": {
-                      "class": "public"
+                      "ingressClassName": "public"
                     }
                   }
                 }
@@ -129,6 +130,7 @@
           "repoURL": "https://airflow.apache.org",
           "chart": "airflow",
           "values": {
+            "executor": "LocalKubernetesExecutor",
             "dags": {
               "gitSync": {
                 "enabled": true,

--- a/src/templates/eks/airflow-tls.json
+++ b/src/templates/eks/airflow-tls.json
@@ -1,32 +1,32 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "dagRepoUrl",
-        "default": "https://github.com/polyseam/demo-dag-bag",
-        "message": "Please enter the url of the git repo containing your dags:",
-        "type": "Input"
-      },
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "name": "airflowDomainName",
-        "default": "airflow.example.com",
-        "message": "Please enter the domain name you want airflow to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "dagRepoUrl",
+      "default": "https://github.com/polyseam/demo-dag-bag",
+      "message": "Please enter the url of the git repo containing your dags:",
+      "type": "Input"
+    },
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "airflowDomainName",
+      "default": "airflow.example.com",
+      "message": "Please enter the domain name you want airflow to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
@@ -186,29 +186,26 @@
           }
         }
       }
+    },
+    "env": {
+      "extend_basic_env": "aws",
+      "entries": [
+        {
+          "comment": "airflow-git-credentials secret values for DAG Storage"
+        },
+        {
+          "name": "GIT_SYNC_USERNAME",
+          "value": "{{ $.cndi.prompts.responses.gitSyncUsername }}"
+        },
+        {
+          "name": "GIT_SYNC_PASSWORD",
+          "value": "{{ $.cndi.prompts.responses.gitSyncPassword }}"
+        }
+      ]
+    },
+    "readme": {
+      "extend_basic_readme": "aws",
+      "template_section": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
     }
-  },
-  "env": {
-    "extend_basic_env": "aws",
-    "prompts": [
-      {
-        "type": "Comment",
-        "comment": "airflow-git-credentials secret values for DAG Storage"
-      },
-      {
-        "name": "GIT_SYNC_USERNAME",
-        "message": "Please enter your git username for Airflow DAG Storage:",
-        "type": "Input"
-      },
-      {
-        "name": "GIT_SYNC_PASSWORD",
-        "message": "Please enter your git password for Airflow DAG Storage:",
-        "type": "Secret"
-      }
-    ]
-  },
-  "readme": {
-    "extend_basic_readme": "eks",
-    "template": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
   }
 }

--- a/src/templates/eks/basic.json
+++ b/src/templates/eks/basic.json
@@ -22,6 +22,8 @@
               "name": "my-nodes",
               "kind": "eks",
               "volume_size": 128,
+              "instance_type": "t3.large",
+              "min_count": 1,
               "max_count": 3
             }
           ]
@@ -45,7 +47,7 @@
                 {
                   "http01": {
                     "ingress": {
-                      "class": "public"
+                      "ingressClassName": "public"
                     }
                   }
                 }

--- a/src/templates/eks/basic.json
+++ b/src/templates/eks/basic.json
@@ -1,20 +1,20 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
@@ -22,8 +22,6 @@
               "name": "my-nodes",
               "kind": "eks",
               "volume_size": 128,
-              "instance_type": "t3.large",
-              "min_count": 1,
               "max_count": 3
             }
           ]
@@ -38,7 +36,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -71,13 +69,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -100,12 +98,12 @@
         }
       },
       "applications": {}
+    },
+    "env": {
+      "extend_basic_env": "aws"
+    },
+    "readme": {
+      "extend_basic_readme": "eks"
     }
-  },
-  "env": {
-    "extend_basic_env": "aws"
-  },
-  "readme": {
-    "extend_basic_readme": "eks"
   }
 }

--- a/src/templates/eks/cnpg.json
+++ b/src/templates/eks/cnpg.json
@@ -1,32 +1,43 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "dagRepoUrl",
-        "default": "https://github.com/polyseam/demo-dag-bag",
-        "message": "Please enter the url of the git repo containing your dags:",
-        "type": "Input"
-      },
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the username for your postgresql admin:",
+      "default": "admin",
+      "name": "postgresqlUser",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the postgresql password you want to use for your postgresql database:",
+      "default": "password",
+      "name": "postgresqlPassword",
+      "type": "Secret"
+    },
+    {
+      "message": "Please enter the name for the postgresql database you want to use:",
+      "default": "my-pgdatabase",
+      "name": "postgresqlDb",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
             {
-              "name": "cnpg-nodes",
+              "name": "pg-nodes",
               "kind": "eks",
               "instance_type": "t3.large",
               "volume_size": 128,
@@ -41,7 +52,8 @@
           "apiVersion": "v1",
           "kind": "Secret",
           "metadata": {
-            "name": "postgresql-connection-string-secret"
+            "name": "postgresql-connection-string-secret",
+            "namespace": "default"
           },
           "type": "Opaque",
           "stringData": {
@@ -53,9 +65,11 @@
           "kind": "Cluster",
           "metadata": {
             "name": "cnpg-cluster",
-            "namespace": "argocd",
+            "namespace": "default",
             "annotations": {
-              "argocd.argoproj.io/sync-options": {"SkipDryRunOnMissingResource":true}
+              "argocd.argoproj.io/sync-options": {
+                "SkipDryRunOnMissingResource": true
+              }
             }
           },
           "spec": {
@@ -71,13 +85,13 @@
             },
             "postgresql": {
               "pg_hba": [
-                "host $.cndi.prompts.responses.POSTGRESQL_DB $.cndi.prompts.responses.POSTGRESQL_USER all password"
+                "host {{ $.cndi.prompts.responses.postgresqlDb }} {{ $.cndi.prompts.responses.postgresqlUser }} all password"
               ]
             },
             "bootstrap": {
               "initdb": {
-                "database": "https://$.cndi.prompts.responses.POSTGRESQL_DB",
-                "owner": "https://$.cndi.prompts.responses.POSTGRESQL_USER",
+                "database": "https://{{ $.cndi.prompts.responses.postgresqlDb }}",
+                "owner": "https://{{ $.cndi.prompts.responses.postgresqlUser }}",
                 "secret": {
                   "name": "cnpg-database-user-auth-secret"
                 }
@@ -93,7 +107,7 @@
           "kind": "Secret",
           "metadata": {
             "name": "cnpg-cluster-superuser-auth-secret",
-            "namespace": "argocd"
+            "namespace": "default"
           },
           "type": "kubernetes.io/basic-auth",
           "stringData": {
@@ -106,7 +120,7 @@
           "kind": "Secret",
           "metadata": {
             "name": "cnpg-database-user-auth-secret",
-            "namespace": "argocd"
+            "namespace": "default"
           },
           "type": "kubernetes.io/basic-auth",
           "stringData": {
@@ -122,7 +136,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -155,15 +169,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": [
-                  "$.cndi.prompts.responses.argocdDomainName"
-                ],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -193,73 +205,55 @@
           "chart": "cloudnative-pg"
         }
       }
+    },
+    "env": {
+      "extend_basic_env": "aws",
+      "entries": [
+        {
+          "type": "Comment",
+          "comment": "PostgreSQL connection parameters"
+        },
+        {
+          "name": "POSTGRESQL_DB",
+          "value": "{{ $.cndi.prompts.responses.postgresqlDb }}"
+        },
+        {
+          "name": "POSTGRESQL_USER",
+          "value": "{{ $.cndi.prompts.responses.postgresqlUser }}"
+        },
+        {
+          "name": "POSTGRESQL_PASSWORD",
+          "value": "{{ $.cndi.prompts.responses.postgresqlPassword }}"
+        },
+        {
+          "name": "POSTGRESQL_PROTOCOL",
+          "value": "postgresql"
+        },
+        {
+          "name": "POSTGRESQL_HOST",
+          "value": "cnpg-cluster-rw"
+        },
+        {
+          "name": "POSTGRESQL_PORT",
+          "value": "5432"
+        },
+        {
+          "name": "POSTGRESQL_SSLMODE",
+          "value": "disable"
+        },
+        {
+          "name": "POSTGRESQL_CONNECTION_STRING",
+          "value": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE"
+        },
+        {
+          "name": "POSTGRESQL_CLUSTER_SUPERUSER",
+          "value": "postgres"
+        }
+      ]
+    },
+    "readme": {
+      "extend_basic_readme": "aws",
+      "template": "## cloudnative-pg\n\nThis template deploys a Standalone production ready posgresql database [cloudnative-pg](https://github.com/cloudnative-pg/charts)"
     }
-  },
-  "env": {
-    "extend_basic_env": "aws",
-    "prompts": [
-      {
-        "type": "Comment",
-        "comment": "PostgreSQL connection parameters"
-      },
-      {
-        "message": "Please enter the name of the postgresql database",
-        "default": "cnpg-db",
-        "name": "POSTGRESQL_DB",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql user you want to use for your postgresql database:",
-        "default": "admin",
-        "name": "POSTGRESQL_USER",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql password you want to use for your postgresql database:",
-        "default": "password",
-        "name": "POSTGRESQL_PASSWORD",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql protocol you want to use for your postgresql database:",
-        "name": "POSTGRESQL_PROTOCOL",
-        "default": "postgresql",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql host you want to use for your postgresql database:",
-        "name": "POSTGRESQL_HOST",
-        "default": "cnpg-cluster-rw",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql port you want to use for your postgresql database:",
-        "name": "POSTGRESQL_PORT ",
-        "default": "5432",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql ssl mode you want to use for your postgresql database:",
-        "name": "POSTGRESQL_SSLMODE",
-        "default": "disable",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql connection string you want to use to connect your postgresql database:",
-        "name": "POSTGRESQL_CONNECTION_STRING",
-        "default": "$POSTGRESQL_PROTOCOL://$POSTGRESQL_USER:$POSTGRESQL_PASSWORD@$POSTGRESQL_HOST:$POSTGRESQL_PORT/$POSTGRESQL_DB?$POSTGRESQL_SSLMODE",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the postgresql cluster superuser you want to use for your postgresql cluster:",
-        "name": "POSTGRESQL_CLUSTER_SUPERUSER",
-        "default": "postgres",
-        "type": "Input"
-      }
-    ]
-  },
-  "readme": {
-    "extend_basic_readme": "aws",
-    "template": "## cloudnative-pg\n\nThis template deploys a Standalone production ready posgresql database [cloudnative-pg](https://github.com/cloudnative-pg/charts)"
   }
 }

--- a/src/templates/eks/cnpg.json
+++ b/src/templates/eks/cnpg.json
@@ -13,14 +13,13 @@
         "message": "Please enter the domain name you want argocd to be accessible on:",
         "type": "Input"
       },
-    
+
       {
         "message": "Please enter the email address you want to use for lets encrypt:",
         "default": "admin@example.com",
         "name": "letsEncryptClusterIssuerEmailAddress",
         "type": "Input"
       }
-      
     ],
     "template": {
       "infrastructure": {
@@ -31,13 +30,13 @@
               "kind": "eks",
               "instance_type": "t3.large",
               "volume_size": 128,
+              "min_count": 1,
               "max_count": 3
             }
           ]
         }
       },
       "cluster_manifests": {
-        
         "postgresql-connection-string-secret": {
           "apiVersion": "v1",
           "kind": "Secret",
@@ -53,7 +52,11 @@
           "apiVersion": "postgresql.cnpg.io/v1",
           "kind": "Cluster",
           "metadata": {
-            "name": "cnpg-cluster"
+            "name": "cnpg-cluster",
+            "namespace": "argocd",
+            "annotations": {
+              "argocd.argoproj.io/sync-options": {"SkipDryRunOnMissingResource":true}
+            }
           },
           "spec": {
             "imageName": "ghcr.io/cloudnative-pg/postgresql:15.2",
@@ -89,7 +92,8 @@
           "apiVersion": "v1",
           "kind": "Secret",
           "metadata": {
-            "name": "cnpg-cluster-superuser-auth-secret"
+            "name": "cnpg-cluster-superuser-auth-secret",
+            "namespace": "argocd"
           },
           "type": "kubernetes.io/basic-auth",
           "stringData": {
@@ -101,7 +105,8 @@
           "apiVersion": "v1",
           "kind": "Secret",
           "metadata": {
-            "name": "cnpg-database-user-auth-secret"
+            "name": "cnpg-database-user-auth-secret",
+            "namespace": "argocd"
           },
           "type": "kubernetes.io/basic-auth",
           "stringData": {
@@ -187,7 +192,6 @@
           "repoURL": "https://cloudnative-pg.github.io/charts",
           "chart": "cloudnative-pg"
         }
-
       }
     }
   },
@@ -252,7 +256,6 @@
         "default": "postgres",
         "type": "Input"
       }
-     
     ]
   },
   "readme": {

--- a/src/templates/eks/cnpg.json
+++ b/src/templates/eks/cnpg.json
@@ -13,12 +13,7 @@
         "message": "Please enter the domain name you want argocd to be accessible on:",
         "type": "Input"
       },
-      {
-        "name": "airflowDomainName",
-        "default": "airflow.example.com",
-        "message": "Please enter the domain name you want airflow to be accessible on:",
-        "type": "Input"
-      },
+    
       {
         "message": "Please enter the email address you want to use for lets encrypt:",
         "default": "admin@example.com",
@@ -32,7 +27,7 @@
         "cndi": {
           "nodes": [
             {
-              "name": "airflow-nodes",
+              "name": "cnpg-nodes",
               "kind": "eks",
               "instance_type": "t3.large",
               "volume_size": 128,
@@ -42,24 +37,12 @@
         }
       },
       "cluster_manifests": {
-        "git-credentials-secret": {
-          "apiVersion": "v1",
-          "kind": "Secret",
-          "metadata": {
-            "name": "airflow-git-credentials",
-            "namespace": "airflow"
-          },
-          "stringData": {
-            "GIT_SYNC_USERNAME": "$.cndi.secrets.seal(GIT_SYNC_USERNAME)",
-            "GIT_SYNC_PASSWORD": "$.cndi.secrets.seal(GIT_SYNC_PASSWORD)"
-          }
-        },
+        
         "postgresql-connection-string-secret": {
           "apiVersion": "v1",
           "kind": "Secret",
           "metadata": {
-            "name": "postgresql-connection-string-secret",
-            "namespace": "airflow"
+            "name": "postgresql-connection-string-secret"
           },
           "type": "Opaque",
           "stringData": {
@@ -70,8 +53,7 @@
           "apiVersion": "postgresql.cnpg.io/v1",
           "kind": "Cluster",
           "metadata": {
-            "name": "cnpg-cluster",
-            "namespace": "airflow"
+            "name": "cnpg-cluster"
           },
           "spec": {
             "imageName": "ghcr.io/cloudnative-pg/postgresql:15.2",
@@ -107,8 +89,7 @@
           "apiVersion": "v1",
           "kind": "Secret",
           "metadata": {
-            "name": "cnpg-cluster-superuser-auth-secret",
-            "namespace": "airflow"
+            "name": "cnpg-cluster-superuser-auth-secret"
           },
           "type": "kubernetes.io/basic-auth",
           "stringData": {
@@ -120,8 +101,7 @@
           "apiVersion": "v1",
           "kind": "Secret",
           "metadata": {
-            "name": "cnpg-database-user-auth-secret",
-            "namespace": "airflow"
+            "name": "cnpg-database-user-auth-secret"
           },
           "type": "kubernetes.io/basic-auth",
           "stringData": {
@@ -206,72 +186,8 @@
           "destinationNamespace": "cnpg-system",
           "repoURL": "https://cloudnative-pg.github.io/charts",
           "chart": "cloudnative-pg"
-        },
-        "airflow": {
-          "targetRevision": "1.7.0",
-          "destinationNamespace": "airflow",
-          "repoURL": "https://airflow.apache.org",
-          "chart": "airflow",
-          "values": {
-            "data": {
-              "metadataSecretName": "postgresql-connection-string-secret"
-            },
-            "postgresql": {
-              "enabled": false
-            },
-            "dags": {
-              "gitSync": {
-                "enabled": true,
-                "repo": "$.cndi.prompts.responses.dagRepoUrl",
-                "credentialsSecret": "airflow-git-credentials",
-                "branch": "main",
-                "wait": 40,
-                "subPath": "dags"
-              }
-            },
-            "config": {
-              "webserver": {
-                "expose_config": "True",
-                "instance_name": "Polyseam",
-                "enable_proxy_fix": "True",
-                "base_url": "https://$.cndi.prompts.responses.airflowDomainName"
-              },
-              "operators": {
-                "default_owner": "Polyseam"
-              }
-            },
-            "ingress": {
-              "web": {
-                "enabled": true,
-                "annotations": {
-                  "cert-manager.io/cluster-issuer": "lets-encrypt"
-                },
-                "hosts": [
-                  {
-                    "name": "$.cndi.prompts.responses.airflowDomainName",
-                    "tls": {
-                      "secretName": "lets-encrypt-private-key",
-                      "enabled": true
-                    }
-                  }
-                ]
-              }
-            },
-            "logs": {
-              "persistence": {
-                "enabled": true,
-                "size": "15Gi",
-                "storageClassName": "efs"
-              }
-            },
-            "createUserJob": {
-              "useHelmHooks": false
-            },
-            "migrateDatabaseJob": {
-              "useHelmHooks": false
-            }
-          }
         }
+
       }
     }
   },
@@ -335,25 +251,12 @@
         "name": "POSTGRESQL_CLUSTER_SUPERUSER",
         "default": "postgres",
         "type": "Input"
-      },
-      {
-        "type": "Comment",
-        "comment": "airflow-git-credentials secret values for DAG Storage"
-      },
-      {
-        "name": "GIT_SYNC_USERNAME",
-        "message": "Please enter your git username for Airflow DAG Storage:",
-        "type": "Input"
-      },
-      {
-        "name": "GIT_SYNC_PASSWORD",
-        "message": "Please enter your git password for Airflow DAG Storage:",
-        "type": "Secret"
       }
+     
     ]
   },
   "readme": {
     "extend_basic_readme": "aws",
-    "template": "## airflow-tls-cnpg\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart) and an external production ready posgresql database [cloudnative-pg](https://github.com/cloudnative-pg/charts) \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
+    "template": "## cloudnative-pg\n\nThis template deploys a Standalone production ready posgresql database [cloudnative-pg](https://github.com/cloudnative-pg/charts)"
   }
 }

--- a/src/templates/gcp/airflow-tls.json
+++ b/src/templates/gcp/airflow-tls.json
@@ -1,32 +1,42 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "dagRepoUrl",
-        "default": "https://github.com/polyseam/demo-dag-bag",
-        "message": "Please enter the url of the git repo containing your dags:",
-        "type": "Input"
-      },
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "name": "airflowDomainName",
-        "default": "airflow.example.com",
-        "message": "Please enter the domain name you want airflow to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "airflowDomainName",
+      "default": "airflow.example.com",
+      "message": "Please enter the domain name you want airflow to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "name": "dagRepoUrl",
+      "default": "https://github.com/polyseam/demo-dag-bag",
+      "message": "Please enter the url of the git repo containing your dags:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the username you want to use for git sync DAG storage:",
+      "name": "gitSyncUsername",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the password you want to use for git sync DAG storage:",
+      "name": "gitSyncPassword",
+      "type": "Secret"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
@@ -71,7 +81,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -104,13 +114,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -142,7 +152,7 @@
             "dags": {
               "gitSync": {
                 "enabled": true,
-                "repo": "$.cndi.prompts.responses.dagRepoUrl",
+                "repo": "{{ $.cndi.prompts.responses.dagRepoUrl }}",
                 "credentialsSecret": "airflow-git-credentials",
                 "branch": "main",
                 "wait": 40,
@@ -154,7 +164,7 @@
                 "expose_config": "True",
                 "instance_name": "Polyseam",
                 "enable_proxy_fix": "True",
-                "base_url": "https://$.cndi.prompts.responses.airflowDomainName"
+                "base_url": "https://{{ $.cndi.prompts.responses.airflowDomainName }}"
               },
               "operators": {
                 "default_owner": "Polyseam"
@@ -168,7 +178,7 @@
                 },
                 "hosts": [
                   {
-                    "name": "$.cndi.prompts.responses.airflowDomainName",
+                    "name": "{{ $.cndi.prompts.responses.airflowDomainName }}",
                     "tls": {
                       "secretName": "lets-encrypt-private-key",
                       "enabled": true
@@ -192,29 +202,26 @@
           }
         }
       }
+    },
+    "env": {
+      "extend_basic_env": "gcp",
+      "entries": [
+        {
+          "comment": "airflow-git-credentials secret values for DAG Storage"
+        },
+        {
+          "name": "GIT_SYNC_USERNAME",
+          "value": "{{ $.cndi.prompts.responses.gitSyncUsername }}"
+        },
+        {
+          "name": "GIT_SYNC_PASSWORD",
+          "value": "{{ $.cndi.prompts.responses.gitSyncPassword }}"
+        }
+      ]
+    },
+    "readme": {
+      "extend_basic_readme": "gcp",
+      "template_section": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
     }
-  },
-  "env": {
-    "extend_basic_env": "gcp",
-    "prompts": [
-      {
-        "type": "Comment",
-        "comment": "airflow-git-credentials secret values for DAG Storage"
-      },
-      {
-        "name": "GIT_SYNC_USERNAME",
-        "message": "Please enter your git username for Airflow DAG Storage:",
-        "type": "Input"
-      },
-      {
-        "name": "GIT_SYNC_PASSWORD",
-        "message": "Please enter your git password for Airflow DAG Storage:",
-        "type": "Secret"
-      }
-    ]
-  },
-  "readme": {
-    "extend_basic_readme": "gcp",
-    "template": "## airflow-tls\n\nThis template deploys a fully functional [Airflow](https://airflow.apache.org) cluster using the [official Airflow Helm chart](https://github.com/apache/airflow/tree/main/chart). \n\nThe default credentials for Airflow are: \n\nusername: `admin`\npassword: `admin`"
   }
 }

--- a/src/templates/gcp/basic.json
+++ b/src/templates/gcp/basic.json
@@ -1,28 +1,28 @@
 {
-  "cndi-config": {
-    "prompts": [
-      {
-        "name": "argocdDomainName",
-        "default": "argocd.example.com",
-        "message": "Please enter the domain name you want argocd to be accessible on:",
-        "type": "Input"
-      },
-      {
-        "message": "Please enter the email address you want to use for lets encrypt:",
-        "default": "admin@example.com",
-        "name": "letsEncryptClusterIssuerEmailAddress",
-        "type": "Input"
-      }
-    ],
-    "template": {
+  "prompts": [
+    {
+      "name": "argocdDomainName",
+      "default": "argocd.example.com",
+      "message": "Please enter the domain name you want argocd to be accessible on:",
+      "type": "Input"
+    },
+    {
+      "message": "Please enter the email address you want to use for lets encrypt:",
+      "default": "admin@example.com",
+      "name": "letsEncryptClusterIssuerEmailAddress",
+      "type": "Input"
+    }
+  ],
+  "outputs": {
+    "cndi-config": {
       "infrastructure": {
         "cndi": {
           "nodes": [
             {
               "name": "x-node",
               "kind": "gcp",
-              "machine_type": "n2-standard-2",
               "role": "leader",
+              "machine_type": "n2-standard-2",
               "volume_size": 128
             },
             {
@@ -47,7 +47,7 @@
           },
           "spec": {
             "acme": {
-              "email": "$.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress",
+              "email": "{{ $.cndi.prompts.responses.letsEncryptClusterIssuerEmailAddress }}",
               "server": "https://acme-v02.api.letsencrypt.org/directory",
               "privateKeySecretRef": {
                 "name": "lets-encrypt-private-key"
@@ -80,13 +80,13 @@
           "spec": {
             "tls": [
               {
-                "hosts": ["$.cndi.prompts.responses.argocdDomainName"],
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
                 "secretName": "lets-encrypt-private-key"
               }
             ],
             "rules": [
               {
-                "host": "$.cndi.prompts.responses.argocdDomainName",
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
                 "http": {
                   "paths": [
                     {
@@ -109,12 +109,12 @@
         }
       },
       "applications": {}
+    },
+    "env": {
+      "extend_basic_env": "gcp"
+    },
+    "readme": {
+      "extend_basic_readme": "gcp"
     }
-  },
-  "env": {
-    "extend_basic_env": "gcp"
-  },
-  "readme": {
-    "extend_basic_readme": "gcp"
   }
 }

--- a/src/templates/knownTemplates.ts
+++ b/src/templates/knownTemplates.ts
@@ -1,5 +1,5 @@
 export const POLYSEAM_TEMPLATE_DIRECTORY =
-  "https://raw.githubusercontent.com/polyseam/cndi/main/src/templates/";
+  "https://raw.githubusercontent.com/polyseam/cndi/templates-two/src/templates/";
 
 export default function getKnownTemplates() {
   const knownTemplates = [];

--- a/src/templates/knownTemplates.ts
+++ b/src/templates/knownTemplates.ts
@@ -1,5 +1,5 @@
 export const POLYSEAM_TEMPLATE_DIRECTORY =
-  "https://raw.githubusercontent.com/polyseam/cndi/templates-two/src/templates/";
+  "https://raw.githubusercontent.com/polyseam/cndi/main/src/templates/";
 
 export default function getKnownTemplates() {
   const knownTemplates = [];

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -145,8 +145,6 @@ function literalizeTemplateValuesInString(
     indexOfOpeningBraces !== -1 && indexOfClosingBraces !== -1 &&
     indexOfClosingBraces > indexOfOpeningBraces
   ) {
-    console.log("indexOfOpeningBraces", indexOfOpeningBraces);
-    console.log("indexOfClosingBraces", indexOfClosingBraces);
 
     const contentsOfFirstPair = literalizedString.substring(
       indexOfOpeningBraces + 2,

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -145,7 +145,6 @@ function literalizeTemplateValuesInString(
     indexOfOpeningBraces !== -1 && indexOfClosingBraces !== -1 &&
     indexOfClosingBraces > indexOfOpeningBraces
   ) {
-
     const contentsOfFirstPair = literalizedString.substring(
       indexOfOpeningBraces + 2,
       indexOfClosingBraces,

--- a/src/tfstate/decrypt.ts
+++ b/src/tfstate/decrypt.ts
@@ -27,7 +27,7 @@ export default async function decrypt(
         'your "TERRAFORM_STATE_PASSPHRASE" is likely incorrect, consider deleting your "_state" branch\n',
       ),
     );
-    console.log(ccolors.caught(decryptError));
+    console.log(ccolors.caught(decryptError, 1000));
     await emitExitEvent(1000);
     Deno.exit(1000);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,7 @@ interface EnvCommentEntry {
 }
 interface EnvValueEntry {
   value: { [key: string]: string };
+  wrap?: boolean;
 }
 
 type EnvLines = Array<EnvCommentEntry | EnvValueEntry>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,6 +258,7 @@ async function patchAndStageTerraformFilesWithConfig(config: CNDIConfig) {
       ccolors.error("error patching terraform files with config"),
     );
     console.log(ccolors.caught(error));
+    console.log("attempting to continue anyway...");
   }
 }
 


### PR DESCRIPTION
The templates system has been overhauled, they are now more simple to write and more flexible too. The two big changes are:

1. The overall structure of the template file. The first version presented prompts for each of the 3 file outputs, which prevented values from one file's prompts being consumed in another. The new syntax has `prompts` and `outputs` and any prompt can be consumed in any output.
2. New template syntax. The reserved key `$.cndi.prompts.responses.foo` must now be wrapped in `{{ }}`. This change was made to support using the values flexibly and predictably, especially when being a part of some larger string.

We've also added a schema for the template syntax too which improves the template authoring experience.