### PR TITLE
Migrate to Deno 1.33.2

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.32.5
+          deno-version: v1.33.2
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main-latest.yaml
+++ b/.github/workflows/main-latest.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.32.5
+          deno-version: v1.33.2
 
       - run: deno lint
 
@@ -28,7 +28,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.32.5
+          deno-version: v1.33.2
 
       - run: deno task build
           

--- a/.github/workflows/main-pull.yml
+++ b/.github/workflows/main-pull.yml
@@ -12,7 +12,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.32.5
+          deno-version: v1.33.2
       
       - name: Check formatting
         run: deno fmt --check

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -109,7 +109,7 @@ const runCommand = new Command()
 
       await pushStateFromRun({ pathToTerraformResources, cmd });
 
-      // if `terraform destroy` fails, exit with the code
+      // if `terraform apply` fails, exit with the code
       if (terraformApplyCommandOutput.code !== 0) {
         Deno.exit(terraformApplyCommandOutput.code);
       }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,6 @@
 import "https://deno.land/std@0.173.0/dotenv/load.ts";
 
-import { ccolors, Command, copy, path } from "deps";
+import { ccolors, Command, path } from "deps";
 
 import pullStateForRun from "src/tfstate/git/read-state.ts";
 import pushStateFromRun from "src/tfstate/git/write-state.ts";
@@ -72,10 +72,8 @@ const runCommand = new Command()
 
       await pullStateForRun({ pathToTerraformResources, cmd });
 
-      // terraform.tfstate will be in this folder after the first run
-      const ranTerraformInit = Deno.run({
-        cmd: [
-          pathToTerraformBinary,
+      const terraformInitCommand = new Deno.Command(pathToTerraformBinary, {
+        args: [
           `-chdir=${pathToTerraformResources}`,
           "init",
         ],
@@ -83,21 +81,18 @@ const runCommand = new Command()
         stdout: "piped",
       });
 
-      copy(ranTerraformInit.stdout, Deno.stdout);
-      copy(ranTerraformInit.stderr, Deno.stderr);
+      const terraformInitCommandOutput = await terraformInitCommand.output();
 
-      const initStatus = await ranTerraformInit.status();
+      await Deno.stdout.write(terraformInitCommandOutput.stdout);
+      await Deno.stderr.write(terraformInitCommandOutput.stderr);
 
-      if (initStatus.code !== 0) {
+      if (terraformInitCommandOutput.code !== 0) {
         console.log(runLabel, ccolors.error("terraform init failed"));
-        Deno.exit(initStatus.code);
+        Deno.exit(terraformInitCommandOutput.code);
       }
 
-      ranTerraformInit.close();
-
-      const ranTerraformApply = Deno.run({
-        cmd: [
-          pathToTerraformBinary,
+      const terraformApplyCommand = new Deno.Command(pathToTerraformBinary, {
+        args: [
           `-chdir=${pathToTerraformResources}`,
           "apply",
           "-auto-approve",
@@ -106,19 +101,18 @@ const runCommand = new Command()
         stdout: "piped",
       });
 
-      copy(ranTerraformApply.stdout, Deno.stdout);
-      copy(ranTerraformApply.stderr, Deno.stderr);
+      const terraformApplyCommandOutput = await terraformApplyCommand.output();
 
-      const applyStatus = await ranTerraformApply.status();
+      // print any terraform output to stdout/stderr
+      await Deno.stdout.write(terraformApplyCommandOutput.stdout);
+      await Deno.stderr.write(terraformApplyCommandOutput.stderr);
 
       await pushStateFromRun({ pathToTerraformResources, cmd });
 
-      // if `terraform apply` fails, exit with the code
-      if (applyStatus.code !== 0) {
-        Deno.exit(applyStatus.code);
+      // if `terraform destroy` fails, exit with the code
+      if (terraformApplyCommandOutput.code !== 0) {
+        Deno.exit(terraformApplyCommandOutput.code);
       }
-
-      ranTerraformApply.close();
     } catch (err) {
       console.log(
         runLabel,

--- a/src/initialize/sealedSecretsKeys.ts
+++ b/src/initialize/sealedSecretsKeys.ts
@@ -15,9 +15,8 @@ const createSealedSecretsKeys = async (
   let sealed_secrets_private_key;
   let sealed_secrets_public_key;
 
-  const ranOpenSSLGenerateKeyPair = Deno.run({
-    cmd: [
-      pathToOpenSSL,
+  const openSSLGenerateKeyPairCommand = new Deno.Command(pathToOpenSSL, {
+    args: [
       "req",
       "-x509",
       "-nodes",
@@ -34,11 +33,11 @@ const createSealedSecretsKeys = async (
     stderr: "piped",
   });
 
-  const generateKeyPairStatus = await ranOpenSSLGenerateKeyPair.status();
-  const generateKeyPairStderr = await ranOpenSSLGenerateKeyPair.stderrOutput();
+  const openSSLGenerateKeyPairCommandOutput =
+    await openSSLGenerateKeyPairCommand.output();
 
-  if (generateKeyPairStatus.code !== 0) {
-    Deno.stdout.write(generateKeyPairStderr);
+  if (openSSLGenerateKeyPairCommandOutput.code !== 0) {
+    Deno.stdout.write(openSSLGenerateKeyPairCommandOutput.stderr);
     Deno.exit(251); // arbitrary exit code
   } else {
     sealed_secrets_private_key = await Deno.readTextFile(
@@ -49,8 +48,6 @@ const createSealedSecretsKeys = async (
     );
     Deno.removeSync(pathToKeys, { recursive: true });
   }
-
-  ranOpenSSLGenerateKeyPair.close();
 
   return {
     sealed_secrets_private_key,

--- a/src/outputs/sealed-secret-manifest.ts
+++ b/src/outputs/sealed-secret-manifest.ts
@@ -211,31 +211,24 @@ const getSealedSecretManifest = async (
     },
   );
 
-  const cmd = [
-    pathToKubeseal,
-    `--cert=${publicKeyFilePath}`,
-    `--secret-file=${secretPath}`,
-    `--scope=cluster-wide`,
-  ];
-
-  const ranKubeseal = Deno.run({
-    cmd,
-    stdout: "piped",
+  const kubesealCommand = new Deno.Command(pathToKubeseal, {
+    args: [
+      `--cert=${publicKeyFilePath}`,
+      `--secret-file=${secretPath}`,
+      `--scope=cluster-wide`,
+    ],
     stderr: "piped",
-    stdin: "piped",
+    stdout: "piped",
   });
 
-  const ranKubesealStatus = await ranKubeseal.status();
-  const ranKubesealOutput = await ranKubeseal.output();
-  const ranKubesealStderr = await ranKubeseal.stderrOutput();
+  const kubesealCommandOutput = await kubesealCommand.output();
 
-  if (ranKubesealStatus.code !== 0) {
+  if (kubesealCommandOutput.code !== 0) {
     console.log("kubeseal failed");
-    Deno.stdout.write(ranKubesealStderr);
+    Deno.stdout.write(kubesealCommandOutput.stderr);
     Deno.exit(332); // arbitrary exit code
   } else {
-    // Deno.stdout.write(ranKubesealOutput);
-    sealed = new TextDecoder().decode(ranKubesealOutput);
+    sealed = new TextDecoder().decode(kubesealCommandOutput.stdout);
   }
   return sealed;
 };


### PR DESCRIPTION
The newest versions of Deno deprecate the `Deno.run` API in favor of `Deno.Command`. This PR 

- removes all instances of `Deno.run` and replaces them with `Deno.Command`
- upgrades version of deno used in CI from `1.32.5` to `1.33.2`