### PR TITLE
reorganize dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -9,5 +9,10 @@
     "build": "deno lint && deno fmt && deno task clean-dist && deno task compile-all",
     "test": "deno test --unstable --allow-all"
   },
-  "importMap": "import_map.json"
+  "imports": {
+    "src/": "./src/",
+    "deps": "./src/deps.ts",
+    "constants": "./src/constants.ts",
+    "test-deps": "./src/tests/deps.ts"
+  }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,8 +1,0 @@
-{
-  "imports": {
-    "events": "https://deno.land/std@0.173.0/node/events.ts",
-    "child_process": "https://deno.land/std@0.173.0/node/child_process.ts",
-    "src/": "./src/",
-    "deps": "./src/deps.ts"
-  }
-}

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,4 +1,6 @@
-import { assert, beforeEach, describe, it, path } from "deps";
+import { assert, beforeEach, describe, it } from "test-deps";
+
+import { path } from "deps";
 
 import { literalizeTemplateValuesInString } from "src/templates/useTemplate.ts";
 

--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -1,20 +1,25 @@
+import deno_json from "../deno.json" assert { type: "json" };
+
 import {
+  ccolors,
   Command,
   CompletionsCommand,
   HelpCommand,
-} from "https://deno.land/x/cliffy@v0.25.7/command/mod.ts";
-import { homedir } from "https://deno.land/std@0.173.0/node/os.ts?s=homedir";
-import * as path from "https://deno.land/std@0.173.0/path/mod.ts";
+  homedir,
+  path,
+} from "deps";
+import { KUBESEAL_VERSION, TERRAFORM_VERSION } from "constants";
+
+// commands
 import upgradeCommand from "src/commands/upgrade.ts";
 import runCommand from "src/commands/run.ts";
 import initCommand from "src/commands/init.ts";
 import { overwriteCommand } from "src/commands/overwrite.ts";
 import terraformCommand from "src/commands/terraform.ts";
 import destroyCommand from "src/commands/destroy.ts";
-import deno_json from "../deno.json" assert { type: "json" };
-import { ccolors, KUBESEAL_VERSION, TERRAFORM_VERSION } from "src/deps.ts";
 import installDependenciesIfRequired from "src/install.ts";
 import installCommand from "src/commands/install.ts";
+
 import { emitExitEvent } from "src/utils.ts";
 
 const cndiLabel = ccolors.faded("\nsrc/cndi.ts:");

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,4 +1,5 @@
-import { Command, KUBESEAL_VERSION, TERRAFORM_VERSION } from "deps";
+import { Command } from "deps";
+import { KUBESEAL_VERSION, TERRAFORM_VERSION } from "constants";
 import install from "src/install.ts";
 
 /**

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,13 +1,13 @@
 import {
   ccolors,
   GithubProvider,
-  KUBESEAL_VERSION,
   SpinnerTypes,
   TerminalSpinner,
-  TERRAFORM_VERSION,
   UpgradeCommand,
   UpgradeOptions,
 } from "deps";
+
+import { KUBESEAL_VERSION, TERRAFORM_VERSION } from "constants";
 
 import { getCndiInstallPath, getFileSuffixForPlatform } from "src/utils.ts";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,18 @@
+export const TERRAFORM_VERSION = "1.4.6";
+export const KUBESEAL_VERSION = "0.19.1";
+
+export const DEFAULT_INSTANCE_TYPES = {
+  aws: "m5a.large" as const,
+  gcp: "n2-standard-2" as const,
+  azure: "Standard_D4s_v3" as const,
+};
+
+export const DEFAULT_NODE_DISK_SIZE = 100;
+
+export const NODE_DISK_SIZE_KEY = {
+  aws: "volume_size" as const,
+  gcp: "size" as const,
+  azure: "disk_size_gb" as const,
+};
+
+export const nonMicrok8sNodeKinds = ["eks"];

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -10,15 +10,6 @@ export { platform } from "https://deno.land/std@0.173.0/node/os.ts";
 export { walk } from "https://deno.land/std@0.180.0/fs/mod.ts";
 export * as JSONC from "https://deno.land/std@0.180.0/encoding/jsonc.ts";
 export { delay } from "https://deno.land/std@0.180.0/async/delay.ts";
-//  - testing
-export {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  it,
-} from "https://deno.land/std@0.180.0/testing/bdd.ts";
-export { assert } from "https://deno.land/std@0.180.0/testing/asserts.ts";
 
 // Third party
 //  - cliffy
@@ -78,23 +69,3 @@ export const ccolors = {
     return `${colors.white(errCode)}: ${colors.red(e.toString())}`;
   },
 };
-
-// constants
-export const TERRAFORM_VERSION = "1.4.6";
-export const KUBESEAL_VERSION = "0.19.1";
-
-export const DEFAULT_INSTANCE_TYPES = {
-  aws: "m5a.large" as const,
-  gcp: "n2-standard-2" as const,
-  azure: "Standard_D4s_v3" as const,
-};
-
-export const DEFAULT_NODE_DISK_SIZE = 100;
-
-export const NODE_DISK_SIZE_KEY = {
-  aws: "volume_size" as const,
-  gcp: "size" as const,
-  azure: "disk_size_gb" as const,
-};
-
-export const nonMicrok8sNodeKinds = ["eks"];

--- a/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
@@ -1,6 +1,6 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 import { AWSEC2NodeItemSpec } from "src/types.ts";
-import { DEFAULT_INSTANCE_TYPES, DEFAULT_NODE_DISK_SIZE } from "deps";
+import { DEFAULT_INSTANCE_TYPES, DEFAULT_NODE_DISK_SIZE } from "constants";
 
 export default function getAWSComputeInstanceTFJSON(
   node: AWSEC2NodeItemSpec,

--- a/src/outputs/terraform/aws-ec2/data.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/data.tf.json.ts
@@ -1,6 +1,6 @@
 import { getPrettyJSONString } from "src/utils.ts";
 import { AWSEC2NodeItemSpec } from "src/types.ts";
-import { DEFAULT_INSTANCE_TYPES } from "deps";
+import { DEFAULT_INSTANCE_TYPES } from "constants";
 
 interface AWSTerraformEC2InstanceTypeOfferingsDataSource {
   [ec2_inst_type: string]: Array<{

--- a/src/outputs/terraform/aws-eks/cndi_aws_eks_node_group.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_aws_eks_node_group.tf.json.ts
@@ -1,5 +1,5 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
-import { DEFAULT_INSTANCE_TYPES, DEFAULT_NODE_DISK_SIZE } from "deps";
+import { DEFAULT_INSTANCE_TYPES, DEFAULT_NODE_DISK_SIZE } from "constants";
 import { AWSEKSNodeItemSpec } from "src/types.ts";
 
 export default function getAWSEKServiceNodeGroupTFJSON(

--- a/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
@@ -1,6 +1,6 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 import { AzureNodeItemSpec } from "src/types.ts";
-import { DEFAULT_INSTANCE_TYPES, DEFAULT_NODE_DISK_SIZE } from "deps";
+import { DEFAULT_INSTANCE_TYPES, DEFAULT_NODE_DISK_SIZE } from "constants";
 
 export default function getAzureComputeInstanceTFJSON(
   node: AzureNodeItemSpec,

--- a/src/outputs/terraform/gcp/cndi_google_compute_disk.tf.json.ts
+++ b/src/outputs/terraform/gcp/cndi_google_compute_disk.tf.json.ts
@@ -1,6 +1,6 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 import { GCPNodeItemSpec } from "src/types.ts";
-import { DEFAULT_NODE_DISK_SIZE } from "deps";
+import { DEFAULT_NODE_DISK_SIZE } from "constants";
 
 export default function getGCPComputeInstanceTFJSON(
   node: GCPNodeItemSpec,

--- a/src/tests/deps.ts
+++ b/src/tests/deps.ts
@@ -1,0 +1,7 @@
+export {
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.180.0/testing/bdd.ts";
+
+export { assert } from "https://deno.land/std@0.180.0/testing/asserts.ts";

--- a/src/tests/helpers/util.ts
+++ b/src/tests/helpers/util.ts
@@ -1,4 +1,5 @@
-import { assert, path } from "deps";
+import { assert } from "test-deps";
+import { path } from "deps";
 
 function areSetsEqual(setA: Set<string>, setB: Set<string>) {
   if (setA.size !== setB.size) return false;

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -1,4 +1,5 @@
-import { ccolors, nonMicrok8sNodeKinds } from "deps";
+import { ccolors } from "deps";
+import { nonMicrok8sNodeKinds } from "constants";
 import { CNDIConfig } from "src/types.ts";
 import { emitExitEvent } from "src/utils.ts";
 


### PR DESCRIPTION
We had one file called `"deps"` which was generally being used as a catch all which wasn't semantically accurate. Now depencies are in `"deps"` dependencies for tests are in `"test-deps"` and constants are in `"constants"`,

The `import_map` object is now in `"deno.json"` and the maps previously used for node dependencies (`events` and `child_process`)  have been removed now that we are on `npm:` specifiers.