### PR TITLE
add node_name_list local

### DIFF
--- a/src/outputs/terraform/shared/global.locals.tf.json.ts
+++ b/src/outputs/terraform/shared/global.locals.tf.json.ts
@@ -1,11 +1,17 @@
 import { getPrettyJSONString } from "src/utils.ts";
 
+type LocalsArgs = {
+  cndi_project_name: string;
+  node_name_list: string[];
+};
+
 export default function getVariablesTFJSON(
-  { cndi_project_name }: { cndi_project_name: string },
+  { cndi_project_name, node_name_list }: LocalsArgs,
 ): string {
   return getPrettyJSONString({
     locals: {
       cndi_project_name,
+      node_name_list,
     },
   });
 }

--- a/src/outputs/terraform/stageTerraformResourcesForConfig.ts
+++ b/src/outputs/terraform/stageTerraformResourcesForConfig.ts
@@ -21,9 +21,9 @@ export default async function stageTerraformResourcesForConfig(
 
   const kind = config.infrastructure.cndi.nodes[0].kind;
 
-  const node_name_list = config.infrastructure.cndi.nodes.map(({ name }) =>
-    name
-  );
+  const node_name_list = config.infrastructure.cndi.nodes.map((node) => {
+    return node.name ? node.name : '';
+  });
 
   switch (kind) {
     case "aws":

--- a/src/outputs/terraform/stageTerraformResourcesForConfig.ts
+++ b/src/outputs/terraform/stageTerraformResourcesForConfig.ts
@@ -21,6 +21,10 @@ export default async function stageTerraformResourcesForConfig(
 
   const kind = config.infrastructure.cndi.nodes[0].kind;
 
+  const node_name_list = config.infrastructure.cndi.nodes.map(({ name }) =>
+    name
+  );
+
   switch (kind) {
     case "aws":
       console.log(
@@ -54,7 +58,10 @@ export default async function stageTerraformResourcesForConfig(
     // add global locals
     stageFile(
       path.join("cndi", "terraform", "global.locals.tf.json"),
-      global_locals({ cndi_project_name }),
+      global_locals({
+        cndi_project_name,
+        node_name_list,
+      }),
     ),
     // write the microk8s join token generator
     stageFile(

--- a/src/outputs/terraform/stageTerraformResourcesForConfig.ts
+++ b/src/outputs/terraform/stageTerraformResourcesForConfig.ts
@@ -22,7 +22,7 @@ export default async function stageTerraformResourcesForConfig(
   const kind = config.infrastructure.cndi.nodes[0].kind;
 
   const node_name_list = config.infrastructure.cndi.nodes.map((node) => {
-    return node.name ? node.name : '';
+    return node.name ? node.name : "";
   });
 
   switch (kind) {


### PR DESCRIPTION
In order to enable users committing new terraform resources via passthrough on a per-node basis, we created a local called `node_name_list` which can be looped through in `"terraform"` passthrough.