### PR TITLE
node_id_list for ec2, gcp, azure

### DIFF
--- a/src/outputs/terraform/aws-ec2/locals.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/locals.tf.json.ts
@@ -5,10 +5,11 @@ interface GetAWSLocalsTFJSONArgs {
   aws_region: string;
   leader_node_ip: string;
   nodes: Array<AWSEC2NodeItemSpec>;
+  node_id_list: string[];
 }
 
 export default function getAWSLocalsTFJSON(
-  { aws_region, leader_node_ip, nodes }: GetAWSLocalsTFJSONArgs,
+  { aws_region, leader_node_ip, nodes, node_id_list }: GetAWSLocalsTFJSONArgs,
 ): string {
   const availabilityZoneKeys = nodes.map((node) => {
     const azKey = `available_az_for_${node.name}_instance_type`;
@@ -27,6 +28,7 @@ export default function getAWSLocalsTFJSON(
       leader_node_ip,
       bootstrap_token: "${random_password.cndi_join_token.result}",
       availability_zones,
+      node_id_list,
       // node_count: "", may be useful for az redundancy
       // availability_zones: this used to be in the locals, now it's in data.tf.json
     },

--- a/src/outputs/terraform/aws-ec2/stageAll.ts
+++ b/src/outputs/terraform/aws-ec2/stageAll.ts
@@ -39,16 +39,19 @@ export default async function stageTerraformResourcesForAWS(
     AWSEC2NodeItemSpec
   >;
 
-  const stageNodes = awsEC2Nodes.map((node) =>
-    stageFile(
+  const node_id_list: string[] = [];
+
+  const stageNodes = awsEC2Nodes.map((node) => {
+    node_id_list.push(`\${cndi_aws_instance_${node.name}.id}`);
+    return stageFile(
       path.join(
         "cndi",
         "terraform",
         `cndi_aws_instance_${node.name}.tf.json`,
       ),
       cndi_aws_instance(node, leaderNodeName),
-    )
-  );
+    );
+  });
 
   const stageLbTargetGroupAttachmentHTTP = awsEC2Nodes.map(
     (node) =>
@@ -88,6 +91,7 @@ export default async function stageTerraformResourcesForAWS(
       stageFile(
         path.join("cndi", "terraform", "locals.tf.json"),
         cndi_aws_locals({
+          node_id_list,
           leader_node_ip,
           aws_region,
           nodes: awsEC2Nodes,

--- a/src/outputs/terraform/aws-ec2/stageAll.ts
+++ b/src/outputs/terraform/aws-ec2/stageAll.ts
@@ -42,7 +42,7 @@ export default async function stageTerraformResourcesForAWS(
   const node_id_list: string[] = [];
 
   const stageNodes = awsEC2Nodes.map((node) => {
-    node_id_list.push(`\${cndi_aws_instance_${node.name}.id}`);
+    node_id_list.push(`\${aws_instance.cndi_aws_instance_${node.name}.id}`);
     return stageFile(
       path.join(
         "cndi",

--- a/src/outputs/terraform/azure/locals.tf.json.ts
+++ b/src/outputs/terraform/azure/locals.tf.json.ts
@@ -3,16 +3,19 @@ import { getPrettyJSONString } from "src/utils.ts";
 interface GetAzureLocalsTFJSONArg {
   azure_location: string;
   leader_node_ip: string;
+  node_id_list: string[];
 }
 
 export default function getAzureLocalsTFJSON({
   azure_location,
   leader_node_ip,
+  node_id_list,
 }: GetAzureLocalsTFJSONArg): string {
   return getPrettyJSONString({
     locals: {
       azure_location,
       leader_node_ip,
+      node_id_list,
       bootstrap_token: "${random_password.cndi_join_token.result}",
     },
   });

--- a/src/outputs/terraform/azure/stageAll.ts
+++ b/src/outputs/terraform/azure/stageAll.ts
@@ -40,7 +40,9 @@ export default async function stageTerraformResourcesForAzure(
   const node_id_list: string[] = [];
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) => {
-    node_id_list.push(`\${cndi_azurerm_linux_virtual_machine_${node.name}}.id`);
+    node_id_list.push(
+      `\${azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${node.name}}.id`,
+    );
     return stageFile(
       path.join(
         "cndi",

--- a/src/outputs/terraform/azure/stageAll.ts
+++ b/src/outputs/terraform/azure/stageAll.ts
@@ -41,7 +41,7 @@ export default async function stageTerraformResourcesForAzure(
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) => {
     node_id_list.push(
-      `\${azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${node.name}}.id`,
+      `\${azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${node.name}.id}`,
     );
     return stageFile(
       path.join(

--- a/src/outputs/terraform/azure/stageAll.ts
+++ b/src/outputs/terraform/azure/stageAll.ts
@@ -37,16 +37,19 @@ export default async function stageTerraformResourcesForAzure(
   const leader_node_ip =
     `\${azurerm_linux_virtual_machine.cndi_azurerm_linux_virtual_machine_${leaderNodeName}.private_ip_address}`;
 
-  const stageNodes = config.infrastructure.cndi.nodes.map((node) =>
-    stageFile(
+  const node_id_list: string[] = [];
+
+  const stageNodes = config.infrastructure.cndi.nodes.map((node) => {
+    node_id_list.push(`\$cndi_azurerm_linux_virtual_machine_${node.name}.id`);
+    return stageFile(
       path.join(
         "cndi",
         "terraform",
         `cndi_azurerm_linux_virtual_machine_${node.name}.tf.json`,
       ),
       cndi_azurerm_linux_virtual_machine(node, leaderNodeName),
-    )
-  );
+    );
+  });
 
   const stageNetworkInterface = config.infrastructure.cndi.nodes.map((node) =>
     stageFile(
@@ -83,7 +86,7 @@ export default async function stageTerraformResourcesForAzure(
       ),
       stageFile(
         path.join("cndi", "terraform", "locals.tf.json"),
-        cndi_azurerm_locals({ azure_location, leader_node_ip }),
+        cndi_azurerm_locals({ azure_location, leader_node_ip, node_id_list }),
       ),
       stageFile(
         path.join("cndi", "terraform", "terraform.tf.json"),

--- a/src/outputs/terraform/azure/stageAll.ts
+++ b/src/outputs/terraform/azure/stageAll.ts
@@ -40,7 +40,7 @@ export default async function stageTerraformResourcesForAzure(
   const node_id_list: string[] = [];
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) => {
-    node_id_list.push(`\$cndi_azurerm_linux_virtual_machine_${node.name}.id`);
+    node_id_list.push(`\${cndi_azurerm_linux_virtual_machine_${node.name}}.id`);
     return stageFile(
       path.join(
         "cndi",

--- a/src/outputs/terraform/gcp/locals.tf.json.ts
+++ b/src/outputs/terraform/gcp/locals.tf.json.ts
@@ -3,15 +3,18 @@ import { getPrettyJSONString } from "src/utils.ts";
 interface GetGCPLocalsTFJSONArg {
   gcp_region: string;
   leader_node_ip: string;
+  node_id_list: string[];
 }
 
 export default function getGCPLocalsTFJSON({
   gcp_region,
   leader_node_ip,
+  node_id_list,
 }: GetGCPLocalsTFJSONArg): string {
   return getPrettyJSONString({
     locals: {
       gcp_zone: "${local.gcp_region}-a",
+      node_id_list,
       gcp_region,
       leader_node_ip,
       bootstrap_token: "${random_password.cndi_join_token.result}",

--- a/src/outputs/terraform/gcp/stageAll.ts
+++ b/src/outputs/terraform/gcp/stageAll.ts
@@ -100,16 +100,19 @@ export default async function stageTerraformResourcesForGCP(
     }
   }
 
-  const stageNodes = config.infrastructure.cndi.nodes.map((node) =>
-    stageFile(
+  const node_id_list: string[] = [];
+
+  const stageNodes = config.infrastructure.cndi.nodes.map((node) => {
+    node_id_list.push(`\${cndi_google_compute_instance_${node.name}.id}`);
+    return stageFile(
       path.join(
         "cndi",
         "terraform",
         `cndi_google_compute_instance_${node.name}.tf.json`,
       ),
       cndi_google_compute_instance(node as GCPNodeItemSpec, leaderNodeName),
-    )
-  );
+    );
+  });
 
   const stageDisks = config.infrastructure.cndi.nodes.map((node) =>
     stageFile(
@@ -129,7 +132,7 @@ export default async function stageTerraformResourcesForGCP(
       ...stageDisks,
       stageFile(
         path.join("cndi", "terraform", "locals.tf.json"),
-        cndi_google_locals({ gcp_region, leader_node_ip }),
+        cndi_google_locals({ gcp_region, leader_node_ip, node_id_list }),
       ),
       stageFile(
         path.join("cndi", "terraform", "provider.tf.json"),

--- a/src/outputs/terraform/gcp/stageAll.ts
+++ b/src/outputs/terraform/gcp/stageAll.ts
@@ -103,7 +103,9 @@ export default async function stageTerraformResourcesForGCP(
   const node_id_list: string[] = [];
 
   const stageNodes = config.infrastructure.cndi.nodes.map((node) => {
-    node_id_list.push(`\${cndi_google_compute_instance_${node.name}.id}`);
+    node_id_list.push(
+      `\${google_compute_instance.cndi_google_compute_instance_${node.name}.id}`,
+    );
     return stageFile(
       path.join(
         "cndi",

--- a/src/outputs/terraform/shared/global.locals.tf.json.ts
+++ b/src/outputs/terraform/shared/global.locals.tf.json.ts
@@ -2,16 +2,14 @@ import { getPrettyJSONString } from "src/utils.ts";
 
 type LocalsArgs = {
   cndi_project_name: string;
-  node_name_list: string[];
 };
 
 export default function getVariablesTFJSON(
-  { cndi_project_name, node_name_list }: LocalsArgs,
+  { cndi_project_name }: LocalsArgs,
 ): string {
   return getPrettyJSONString({
     locals: {
       cndi_project_name,
-      node_name_list,
     },
   });
 }

--- a/src/outputs/terraform/stageTerraformResourcesForConfig.ts
+++ b/src/outputs/terraform/stageTerraformResourcesForConfig.ts
@@ -21,10 +21,6 @@ export default async function stageTerraformResourcesForConfig(
 
   const kind = config.infrastructure.cndi.nodes[0].kind;
 
-  const node_name_list = config.infrastructure.cndi.nodes.map((node) => {
-    return node.name ? node.name : "";
-  });
-
   switch (kind) {
     case "aws":
       console.log(
@@ -60,7 +56,6 @@ export default async function stageTerraformResourcesForConfig(
       path.join("cndi", "terraform", "global.locals.tf.json"),
       global_locals({
         cndi_project_name,
-        node_name_list,
       }),
     ),
     // write the microk8s join token generator


### PR DESCRIPTION
This PR replaces the "global" local `node_name_list` with a local called `node_id_list` which is generated for each deployment target independently