### PR TITLE
Scale ebs volume fix

### DIFF
--- a/src/outputs/terraform/aws-ec2/cndi_aws_ebs_volume.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_aws_ebs_volume.tf.json.ts
@@ -1,0 +1,31 @@
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { AWSEC2NodeItemSpec } from "src/types.ts";
+import { DEFAULT_NODE_DISK_SIZE } from "constants";
+
+export default function getAWSComputeInstanceTFJSON(
+  node: AWSEC2NodeItemSpec,
+): string {
+  const { name } = node;
+  const size = node?.volume_size || node?.disk_size || node?.size ||
+    node?.disk_size_gb || DEFAULT_NODE_DISK_SIZE; // the size of the drive in GiBs.
+  const type = "gp3"; // general purpose SSD
+  const availability_zone = "${local.availability_zones[0]}"; // first availability zone in list
+
+  const resource = getTFResource(
+    "aws_ebs_volume",
+    {
+      size,
+      type,
+      availability_zone,
+      tags: {
+        Name: "EBSVolume",
+        CNDIProject: "${local.cndi_project_name}",
+      },
+    },
+    `cndi_aws_ebs_volume_${name}`,
+  ).resource;
+
+  return getPrettyJSONString({
+    resource,
+  });
+}

--- a/src/outputs/terraform/aws-ec2/cndi_aws_ebs_volume.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_aws_ebs_volume.tf.json.ts
@@ -8,7 +8,7 @@ export default function getAWSComputeInstanceTFJSON(
   const { name } = node;
   const size = node?.volume_size || node?.disk_size || node?.size ||
     node?.disk_size_gb || DEFAULT_NODE_DISK_SIZE; // the size of the drive in GiBs.
-  const type = "gp3"; // general purpose SSD
+  const type = "gp2"; // general purpose SSD
   const availability_zone = "${local.availability_zones[0]}"; // first availability zone in list
 
   const resource = getTFResource(

--- a/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
@@ -1,6 +1,6 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 import { AWSEC2NodeItemSpec } from "src/types.ts";
-import { DEFAULT_INSTANCE_TYPES, DEFAULT_NODE_DISK_SIZE } from "constants";
+import { DEFAULT_INSTANCE_TYPES } from "constants";
 
 export default function getAWSComputeInstanceTFJSON(
   node: AWSEC2NodeItemSpec,
@@ -8,25 +8,12 @@ export default function getAWSComputeInstanceTFJSON(
 ): string {
   const { name, role } = node;
   const DEFAULT_EC2_AMI = "ami-0c1704bac156af62c";
-  const ami = node?.ami || DEFAULT_EC2_AMI;
-  const instance_type = node?.instance_type || DEFAULT_INSTANCE_TYPES.aws;
-  const delete_on_termination = false;
-  const device_name = "/dev/sda1";
-  const volume_size = node?.volume_size || node?.disk_size || node?.size ||
-    node?.disk_size_gb || DEFAULT_NODE_DISK_SIZE; //GiB
-  const volume_type = "gp3"; // general purpose SSD
-  const subnet_id = `\${aws_subnet.cndi_aws_subnet[0].id}`;
+  const ami = node?.ami || DEFAULT_EC2_AMI; // AMI to use for the instance.
+  const instance_type = node?.instance_type || DEFAULT_INSTANCE_TYPES.aws; //Instance type to use for the instance
+  const subnet_id = `\${aws_subnet.cndi_aws_subnet[0].id}`; // VPC Subnet ID to launch in.
   const vpc_security_group_ids = [
     "${aws_security_group.cndi_aws_security_group.id}",
-  ];
-  const ebs_block_device = [
-    {
-      device_name,
-      volume_size,
-      volume_type,
-      delete_on_termination,
-    },
-  ];
+  ]; // List of security group IDs to associate with.
   const leaderAWSInstance = `aws_instance.cndi_aws_instance_${leaderNodeName}`;
   const leader_user_data =
     '${templatefile("leader_bootstrap_cndi.sh.tftpl",{ "bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${var.sealed_secrets_private_key}", "sealed_secrets_public_key": "${var.sealed_secrets_public_key}", "argocd_admin_password": "${var.argocd_admin_password}" })}';
@@ -45,7 +32,6 @@ export default function getAWSComputeInstanceTFJSON(
         CNDIProject: "${local.cndi_project_name}",
         CNDINodeRole: role,
       },
-      ebs_block_device,
       subnet_id,
       vpc_security_group_ids,
       user_data,

--- a/src/outputs/terraform/aws-ec2/cndi_aws_volume_attachment.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_aws_volume_attachment.tf.json.ts
@@ -1,0 +1,24 @@
+import { getPrettyJSONString, getTFResource } from "src/utils.ts";
+import { AWSEC2NodeItemSpec } from "src/types.ts";
+
+export default function getAWSComputeInstanceTFJSON(
+  node: AWSEC2NodeItemSpec,
+): string {
+  const { name } = node;
+  const instance_id = `\${aws_instance.cndi_aws_instance_${name}.id}`; // ID of the Instance to attach to
+  const volume_id = `$\{aws_ebs_volume.cndi_aws_ebs_volume_${name}.id}`; // ID of the Volume to be attached
+  const device_name = "/dev/sdf"; // The device name to expose to the instance
+  const resource = getTFResource(
+    "aws_volume_attachment",
+    {
+      instance_id,
+      volume_id,
+      device_name,
+    },
+    `cndi_aws_volume_attachment_${name}`,
+  ).resource;
+
+  return getPrettyJSONString({
+    resource,
+  });
+}

--- a/src/outputs/terraform/aws-ec2/stageAll.ts
+++ b/src/outputs/terraform/aws-ec2/stageAll.ts
@@ -26,7 +26,8 @@ import cndi_aws_security_group from "./cndi_aws_security_group.tf.json.ts";
 import cndi_aws_subnet from "./cndi_aws_subnet.tf.json.ts";
 import cndi_aws_vpc from "./cndi_aws_vpc.tf.json.ts";
 import cndi_aws_locals from "./locals.tf.json.ts";
-
+import cndi_aws_ebs_volume from "./cndi_aws_ebs_volume.tf.json.ts";
+import cndi_aws_volume_attachment from "./cndi_aws_volume_attachment.tf.json.ts";
 export default async function stageTerraformResourcesForAWS(
   config: CNDIConfig,
 ) {
@@ -53,6 +54,28 @@ export default async function stageTerraformResourcesForAWS(
     );
   });
 
+  const stageEbsVolume = awsEC2Nodes.map(
+    (node) =>
+      stageFile(
+        path.join(
+          "cndi",
+          "terraform",
+          `cndi_aws_ebs_volume_${node.name}.tf.json`,
+        ),
+        cndi_aws_ebs_volume(node),
+      ),
+  );
+  const stageEbsVolumeAttachment = awsEC2Nodes.map(
+    (node) =>
+      stageFile(
+        path.join(
+          "cndi",
+          "terraform",
+          `cndi_aws_volume_attachment_${node.name}.tf.json`,
+        ),
+        cndi_aws_volume_attachment(node),
+      ),
+  );
   const stageLbTargetGroupAttachmentHTTP = awsEC2Nodes.map(
     (node) =>
       stageFile(
@@ -84,6 +107,8 @@ export default async function stageTerraformResourcesForAWS(
       ...stageNodes,
       ...stageLbTargetGroupAttachmentHTTP,
       ...stageLbTargetGroupAttachmentHTTPS,
+      ...stageEbsVolume,
+      ...stageEbsVolumeAttachment,
       stageFile(
         path.join("cndi", "terraform", "data.tf.json"),
         data(awsEC2Nodes),


### PR DESCRIPTION
Currently, changes to the ebs_block_device configuration of existing resources cannot be automatically detected by Terraform. To manage **changes** and attachments of an EBS block to an instance, use the **aws_ebs_volume** and **aws_volume_attachment** resources instead. 