### PR TITLE
add hidden option for devs that sets .env CNDI_TELEMETRY=debug

### DIFF
--- a/main_test.ts
+++ b/main_test.ts
@@ -49,6 +49,15 @@ describe("cndi", () => {
       );
     });
 
+    it("should add a .env file containing CNDI_TELEMETRY='debug' if -d is set", async () => {
+      const { status } = await runCndi("init", "-t", "aws/airflow-tls", "-d");
+      const dotenv = Deno.readTextFileSync(
+        path.join(Deno.cwd(), `.env`),
+      );
+      assert(dotenv.indexOf(`CNDI_TELEMETRY=debug`) > -1);
+      assert(status.success);
+    });
+
     it(`should add correct files and directories when it succeeds`, async () => {
       const initFileList = new Set([
         "cndi-config.jsonc",

--- a/main_test.ts
+++ b/main_test.ts
@@ -49,7 +49,7 @@ describe("cndi", () => {
       );
     });
 
-    it("should add a .env file containing CNDI_TELEMETRY='debug' if -d is set", async () => {
+    it("should add a .env file containing CNDI_TELEMETRY=debug if -d is set", async () => {
       const { status } = await runCndi("init", "-t", "aws/airflow-tls", "-d");
       const dotenv = Deno.readTextFileSync(
         path.join(Deno.cwd(), `.env`),

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -52,6 +52,9 @@ const initCommand = new Command()
   )
   .option("-i, --interactive", "Run in interactive mode.")
   .option("-t, --template <template:string>", "CNDI Template to use.")
+  .option("-d, --debug", "Create a cndi project in debug mode.", {
+    hidden: true,
+  })
   .action(async (options) => {
     const pathToConfig = options.file;
     let template: string | undefined = options.template;
@@ -213,6 +216,13 @@ const initCommand = new Command()
           readme,
         );
       }
+    }
+
+    if (options?.debug) {
+      env.push(
+        { comment: "Telemetry Mode" },
+        { value: { CNDI_TELEMETRY: "debug" } },
+      );
     }
 
     await stageFile(".env", getEnvFileContents(env));

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -50,6 +50,9 @@ const cndiWorkflowObj = {
         {
           name: "cndi install",
           run: "cndi install",
+          env: {
+            CNDI_TELEMETRY: "${{ secrets.CNDI_TELEMETRY }}",
+          },
         },
         {
           name: "cndi run",
@@ -73,6 +76,7 @@ const cndiWorkflowObj = {
             ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}",
             ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}",
             ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}",
+            CNDI_TELEMETRY: "${{ secrets.CNDI_TELEMETRY }}",
           },
           run: "cndi run",
         },


### PR DESCRIPTION
We are interested in capturing cndi telemetry data with context around the current version of the system, this PR provides contributors the option to flag executions as `'debug'` so that we can track these events separately from those that may occur in production.