### PR TITLE
azure cloud-init fix

### DIFF
--- a/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
@@ -73,7 +73,7 @@ export default function getAzureComputeInstanceTFJSON(
     cndi_project_name: "${local.cndi_project_name}",
   };
 
-  const user_data = `\${base64encode(${getUserDataTemplateFileString(role)}}`;
+  const user_data = getUserDataTemplateFileString(role, true);
   const depends_on = role !== "leader" ? [leaderComputeInstance] : [];
 
   const resource = getTFResource(

--- a/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
@@ -73,7 +73,7 @@ export default function getAzureComputeInstanceTFJSON(
     cndi_project_name: "${local.cndi_project_name}",
   };
 
-  const user_data = getUserDataTemplateFileString(role);
+  const user_data = `\${base64encode(${getUserDataTemplateFileString(role)}}`;
   const depends_on = role !== "leader" ? [leaderComputeInstance] : [];
 
   const resource = getTFResource(


### PR DESCRIPTION
Azure requires that we base64encode the cloud-config file when it is passed into user-data.