### PR TITLE
fix ec2 outputs

### DIFF
--- a/src/outputs/terraform/aws-ec2/cndi_outputs.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_outputs.tf.json.ts
@@ -4,11 +4,14 @@ export default function getOutputTFJSON(): string {
   return getPrettyJSONString({
     output: {
       public_host: {
-        value: "${aws_lb.cndi_aws_lb.dns_name}",
+        // GitHub Actions Secrets will redact the domain is it contains the secret AWS_REGION
+        // so we need to replace the secret with the same value in uppercase
+        value:
+          "${replace(aws_lb.cndi_aws_lb.dns_name,local.aws_region,upper(local.aws_region))}",
       },
       resource_group: {
         value:
-          "https://${local.aws_region}.console.aws.amazon.com/resource-groups/group/CNDIResourceGroup_${local.cndi_project_name}?region=${local.aws_region}",
+          "https://${upper(local.aws_region)}.console.aws.amazon.com/resource-groups/group/CNDIResourceGroup_${local.cndi_project_name}?region=${upper(local.aws_region)}",
       },
     },
   });


### PR DESCRIPTION
EC2 outputs from `cndi run` now show with the region unredacted.