### PR TITLE
use global env in GitHub actions for better telemetry

### DIFF
--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -10,6 +10,10 @@ const cndiWorkflowObj = {
   jobs: {
     "cndi-run": {
       "runs-on": "ubuntu-20.04",
+      env: {
+        GIT_REPO: "https://github.com/${{ github.repository }}",
+        CNDI_TELEMETRY: "${{ secrets.CNDI_TELEMETRY }}",
+      },
       steps: [
         {
           name: "welcome",
@@ -50,14 +54,10 @@ const cndiWorkflowObj = {
         {
           name: "cndi install",
           run: "cndi install",
-          env: {
-            CNDI_TELEMETRY: "${{ secrets.CNDI_TELEMETRY }}",
-          },
         },
         {
           name: "cndi run",
           env: {
-            GIT_REPO: "https://github.com/${{ github.repository }}",
             GIT_USERNAME: "${{ secrets.GIT_USERNAME }}",
             GIT_PASSWORD: "${{ secrets.GIT_PASSWORD }}",
             TERRAFORM_STATE_PASSPHRASE:

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -53,7 +53,7 @@ const cndiWorkflowObj = {
         },
         {
           name: "cndi install",
-          run: "cndi install",
+          run: "cndi install", // even though we install automatically in run.ts, we expect this has more performant caching
         },
         {
           name: "cndi run",


### PR DESCRIPTION
In order to improve telemetry we now set the `TELEMETRY_MODE` and `REPO_URL` vars globally in GitHub Actions.