### PR TITLE
check debug env on init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -218,7 +218,10 @@ const initCommand = new Command()
       }
     }
 
-    if (options?.debug) {
+    const inDebugEnv =
+      Deno.env.get("CNDI_TELEMETRY")?.toLowerCase() === "debug";
+
+    if (options?.debug || inDebugEnv) {
       env.push(
         { comment: "Telemetry Mode" },
         { value: { CNDI_TELEMETRY: "debug" } },


### PR DESCRIPTION
CNDI should persist `CNDI_TELEMETRY=debug` to `.env` if that value is true in the runtime environment of `cndi init`