### PR TITLE
eks open ports service and configmap

### DIFF
--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -190,7 +190,7 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
         ),
       ]);
     }
-    console.log(ccolors.success("staged open ports"));
+    console.log(ccolors.success("staged open ports manifests"));
   }
 
   // write each manifest in the "cluster_manifests" section of the config to `cndi/cluster_manifests`

--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -17,13 +17,18 @@ import { loadArgoUIAdminPassword } from "src/initialize/argoUIAdminPassword.ts";
 import getApplicationManifest from "src/outputs/application-manifest.ts";
 import RootChartYaml from "src/outputs/root-chart.ts";
 import getSealedSecretManifest from "src/outputs/sealed-secret-manifest.ts";
-import getIngressTcpServicesConfigMapManifest from "src/outputs/custom-port-manifests/ingress-tcp-services-configmap.ts";
-import getIngressDaemonsetManifest from "src/outputs/custom-port-manifests/ingress-daemonset.ts";
+
+import getMicrok8sIngressTcpServicesConfigMapManifest from "src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts";
+import getMicrok8sIngressDaemonsetManifest from "src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts";
+
+import getEKSIngressServiceManifest from "src/outputs/custom-port-manifests/eks/ingress-service.ts";
+import getEKSIngressTcpServicesConfigMapManifest from "src/outputs/custom-port-manifests/eks/ingress-tcp-services-configmap.ts";
 
 import stageTerraformResourcesForConfig from "src/outputs/terraform/stageTerraformResourcesForConfig.ts";
 
 import { CNDIConfig, KubernetesManifest, KubernetesSecret } from "src/types.ts";
 import validateConfig from "src/validate/cndiConfig.ts";
+import { nonMicrok8sNodeKinds } from "../constants.ts";
 
 const owLabel = ccolors.faded("\nsrc/commands/overwrite.ts:");
 
@@ -147,22 +152,44 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
   console.log(ccolors.success("staged terraform files"));
 
   const open_ports = config?.infrastructure?.cndi?.open_ports;
+  const isNotMicrok8sCluster = nonMicrok8sNodeKinds.includes(
+    config?.infrastructure?.cndi?.nodes?.[0]?.kind,
+  );
 
   if (open_ports) {
-    await Promise.all([
-      stageFile(
-        path.join(
-          "cndi",
-          "cluster_manifests",
-          "ingress-tcp-services-configmap.json",
+    if (
+      isNotMicrok8sCluster // currently only EKS
+    ) {
+      await Promise.all([
+        stageFile(
+          path.join(
+            "cndi",
+            "cluster_manifests",
+            "ingress-tcp-services-configmap.json",
+          ),
+          getEKSIngressTcpServicesConfigMapManifest(open_ports),
         ),
-        getIngressTcpServicesConfigMapManifest(open_ports),
-      ),
-      stageFile(
-        path.join("cndi", "cluster_manifests", "ingress-daemonset.json"),
-        getIngressDaemonsetManifest(open_ports),
-      ),
-    ]);
+        stageFile(
+          path.join("cndi", "cluster_manifests", "ingress-service.json"),
+          getEKSIngressServiceManifest(open_ports),
+        ),
+      ]);
+    } else {
+      await Promise.all([
+        stageFile(
+          path.join(
+            "cndi",
+            "cluster_manifests",
+            "ingress-tcp-services-configmap.json",
+          ),
+          getMicrok8sIngressTcpServicesConfigMapManifest(open_ports),
+        ),
+        stageFile(
+          path.join("cndi", "cluster_manifests", "ingress-daemonset.json"),
+          getMicrok8sIngressDaemonsetManifest(open_ports),
+        ),
+      ]);
+    }
     console.log(ccolors.success("staged open ports"));
   }
 

--- a/src/outputs/custom-port-manifests/eks/ingress-service.ts
+++ b/src/outputs/custom-port-manifests/eks/ingress-service.ts
@@ -1,0 +1,105 @@
+import { ccolors } from "deps";
+
+import { getPrettyJSONString } from "src/utils.ts";
+import { CNDIPort } from "src/types.ts";
+
+const ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
+  "\nsrc/outputs/custom-port-manifests/eks/ingress-service.ts:",
+);
+
+interface IngressService {
+  apiVersion: string;
+  kind: "Service";
+  metadata: {
+    "name": "ingress-nginx-controller";
+    "namespace": "ingress";
+  };
+  spec: {
+    type: "LoadBalancer";
+    ports: Array<ServicePort>;
+  };
+}
+
+const default_ports: Array<ServicePort> = [
+  {
+    "name": "http",
+    "port": 80,
+    "targetPort": 80,
+    "protocol": "TCP",
+  },
+  {
+    "name": "https",
+    "port": 443,
+    "targetPort": 443,
+    "protocol": "TCP",
+  },
+];
+
+type ServicePort = {
+  name: string;
+  port: number;
+  targetPort: number;
+  protocol: "TCP";
+};
+
+const getIngressServiceManifest = (
+  user_ports: Array<CNDIPort>,
+): string => {
+  const ports: Array<ServicePort> = [...default_ports];
+
+  user_ports.forEach((port) => {
+    const { number, name, disable } = port;
+
+    if (!port?.number) {
+      console.error(
+        ingressTcpServicesConfigMapManifestLabel,
+        'custom port specs need "number" property',
+      );
+    }
+
+    if (!port?.namespace) {
+      console.error(
+        ingressTcpServicesConfigMapManifestLabel,
+        'custom port specs need "namespace" property',
+      );
+    }
+
+    if (!port?.service) {
+      console.error(
+        ingressTcpServicesConfigMapManifestLabel,
+        'custom port specs need "service" property',
+      );
+    }
+
+    if (disable) {
+      const portToRemove = ports.findIndex((item) => item.port === port.number);
+      if (portToRemove > -1) {
+        ports.splice(portToRemove, 1);
+      }
+    } else {
+      ports.push({
+        port: number,
+        targetPort: number,
+        protocol: "TCP",
+        name: name || `port-${number}`,
+      });
+    }
+  });
+
+  const manifest: IngressService = {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: {
+      "name": "ingress-nginx-controller",
+      "namespace": "ingress",
+    },
+    spec: {
+      type: "LoadBalancer",
+      ports,
+    },
+  };
+
+  return getPrettyJSONString(manifest);
+};
+
+export default getIngressServiceManifest;

--- a/src/outputs/custom-port-manifests/eks/ingress-tcp-services-configmap.ts
+++ b/src/outputs/custom-port-manifests/eks/ingress-tcp-services-configmap.ts
@@ -4,14 +4,14 @@ import { getPrettyJSONString } from "src/utils.ts";
 import { CNDIPort } from "src/types.ts";
 
 const ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
-  "\nsrc/outputs/custom-port-manifests/ingress-tcp-services-configmap.ts:",
+  "\nsrc/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts:",
 );
 
 interface IngressTCPServicesConfigMap {
   apiVersion: string;
   kind: "ConfigMap";
   metadata: {
-    name: "nginx-ingress-tcp-microk8s-conf";
+    name: "ingress-nginx-controller";
     namespace: "ingress";
   };
   data: {
@@ -26,7 +26,7 @@ const getIngressTcpServicesConfigMapManifest = (
     "apiVersion": "v1",
     "kind": "ConfigMap",
     "metadata": {
-      "name": "nginx-ingress-tcp-microk8s-conf",
+      "name": "ingress-nginx-controller",
       "namespace": "ingress",
     },
     "data": {},

--- a/src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts
+++ b/src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts
@@ -4,7 +4,7 @@ import { getPrettyJSONString } from "src/utils.ts";
 import { CNDIPort } from "src/types.ts";
 
 const _ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
-  "\nsrc/outputs/custom-port-manifests/ingress-tcp-services-configmap.ts:",
+  "\nsrc/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts:",
 );
 
 interface NginxIngressContainerPorts {

--- a/src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts
+++ b/src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts
@@ -1,0 +1,61 @@
+import { ccolors } from "deps";
+
+import { getPrettyJSONString } from "src/utils.ts";
+import { CNDIPort } from "src/types.ts";
+
+const ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
+  "\nsrc/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts:",
+);
+
+interface IngressTCPServicesConfigMap {
+  apiVersion: string;
+  kind: "ConfigMap";
+  metadata: {
+    name: "nginx-ingress-tcp-microk8s-conf";
+    namespace: "ingress";
+  };
+  data: {
+    [key: string]: string;
+  };
+}
+
+const getIngressTcpServicesConfigMapManifest = (
+  ports: Array<CNDIPort>,
+): string => {
+  const manifest: IngressTCPServicesConfigMap = {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+      "name": "nginx-ingress-tcp-microk8s-conf",
+      "namespace": "ingress",
+    },
+    "data": {},
+  };
+
+  ports.forEach((port) => {
+    if (!port?.number) {
+      console.error(
+        ingressTcpServicesConfigMapManifestLabel,
+        'custom port specs need "number" property',
+      );
+    }
+    if (!port?.namespace) {
+      console.error(
+        ingressTcpServicesConfigMapManifestLabel,
+        'custom port specs need "namespace" property',
+      );
+    }
+    if (!port?.service) {
+      console.error(
+        ingressTcpServicesConfigMapManifestLabel,
+        'custom port specs need "service" property',
+      );
+    }
+    manifest.data[`${port.number}`] =
+      `${port.namespace}/${port.service}:${port.number}`;
+  });
+
+  return getPrettyJSONString(manifest);
+};
+
+export default getIngressTcpServicesConfigMapManifest;


### PR DESCRIPTION
There was a regression in EKS support where Templates using `open_ports` would not provision the required Service and ConfigMap. This PR opens ports for EKS using the standard `open_ports` syntax.