### PR TITLE
az lb rule custom port name

### DIFF
--- a/src/outputs/terraform/azure/cndi_azurerm_lb_rule_custom_port.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_lb_rule_custom_port.tf.json.ts
@@ -10,7 +10,7 @@ export default function getAzureLbRuleCustomPortTFJSON(port: CNDIPort): string {
     frontend_ip_configuration_name: "cndi_azurerm_lb_frontend_ip_configuration",
     frontend_port: port.number,
     loadbalancer_id: "${azurerm_lb.cndi_azurerm_lb.id}",
-    name: "HTTP",
+    name: port.name,
     probe_id: `\${azurerm_lb_probe.cndi_azurerm_lb_probe_${port.name}.id}`,
     protocol: "Tcp",
   }, `cndi_azurerm_lb_rule_${port.name}`);


### PR DESCRIPTION
Azure's custom load balancer rules for `open_ports` were using `"name": "HTTP"` instead of `"name": port.name`. This PR fixes that issue.