### PR TITLE
Template file urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,32 @@ project repo.
 
 **non-interactive mode**
 
-The other way to initialize a CNDI project is to use a `cndi-config.jsonc` file.
-There are only 2 reasons to use the non-interactive mode. The first is that you
-have a `cndi-config.jsonc` file you found somewhere online which meets your
-needs. The second reason to avoid interactive mode is the standard for CLIs: you
-are calling `cndi init` from a script, though we can't think of any good reason
-to do that.
+The other way to initialize a CNDI project is to use a CNDI Template file. This
+is done by calling `cndi init --template <template_location>`. When specifying a
+Template location you can choose to use Templates the CNDI team have built that
+are found in this repo at [src/templates](src/templates). To do this you pass in
+a Template "name". For example if you wanted to run the Airflow Template on EC2
+you would run:
 
-To use CNDI in non-interactive mode you need a `cndi-config` file and pass that
-into cndi. For more information about the structure of this file, checkout the
-[config section](#configuration-📝) of this README.
+For example if you wanted to run the Airflow Template on EC2 you would run:
 
 ```bash
-# if you run `cndi init` without -f we will look for a file named `cndi-config.jsonc` in the current directory
-cndi init -f cndi-config.jsonc
+cndi init --template ec2/airflow
+```
+
+Alternatively, you can also specify a Template URL. A Template URL resolves to a
+CNDI Template file, this means that you are not limited to only Templates the
+CNDI team has put together, you can point to any arbitrary template file that
+follows the [Template Schema](/src/schemas/cndi-template.schema.json).
+
+These Template URLs can be `file://` URLs which have an absolute path to the
+file locally, or typical remote or `https://` URLs over the net.
+
+```bash
+# file:// URLs must be absolute paths
+cndi init --template file:///absolute/path/to/template.jsonc
+# or
+cndi init --template https://example.com/path/to/template.jsonc
 ```
 
 ---

--- a/main_test.ts
+++ b/main_test.ts
@@ -15,6 +15,7 @@ import processInteractiveEntries from "src/tests/helpers/processInteractiveEntri
 
 import {
   ensureResoureNamesMatchFileNames,
+  getModuleDir,
   hasSameFilesAfter,
 } from "src/tests/helpers/util.ts";
 
@@ -322,6 +323,42 @@ describe("cndi", () => {
         "init",
         "-t",
         "https://raw.githubusercontent.com/polyseam/example-cndi-templates/main/azure/airflow-tls.jsonc",
+      );
+
+      // read the current directory entries after "cndi init" has ran
+      for await (const afterDirEntry of Deno.readDir(".")) {
+        initFileList.delete(afterDirEntry.name); // remove the file from the set if it exists
+      }
+
+      assert(initFileList.size === 0); // if the set is empty, all files were created
+      assert(status.success);
+    });
+
+    it(`should successfully execute file:// templates`, async () => {
+      const initFileList = new Set([
+        "cndi-config.jsonc",
+        "README.md",
+        ".github",
+        ".gitignore",
+        ".env",
+        ".vscode",
+        "cndi",
+      ]);
+
+      const pathToThisDirectory = getModuleDir(import.meta);
+      const absPathToTemplate = path.join(
+        pathToThisDirectory,
+        "src",
+        "templates",
+        "ec2",
+        "airflow.jsonc",
+      );
+
+      // cndi init should fail because there is no config file
+      const { status } = await runCndi(
+        "init",
+        "-t",
+        `file://${absPathToTemplate}`,
       );
 
       // read the current directory entries after "cndi init" has ran

--- a/src/templates/azure/hop.jsonc
+++ b/src/templates/azure/hop.jsonc
@@ -228,7 +228,7 @@
     },
     "readme": {
       "extend_basic_readme": "azure",
-      "template": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
+      "template_section": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
     }
   }
 }

--- a/src/templates/ec2/hop.jsonc
+++ b/src/templates/ec2/hop.jsonc
@@ -228,7 +228,7 @@
     },
     "readme": {
       "extend_basic_readme": "aws",
-      "template": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
+      "template_section": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
     }
   }
 }

--- a/src/templates/eks/basic.jsonc
+++ b/src/templates/eks/basic.jsonc
@@ -104,7 +104,7 @@
       "extend_basic_env": "aws"
     },
     "readme": {
-      "extend_basic_readme": "eks"
+      "extend_basic_readme": "aws"
     }
   }
 }

--- a/src/templates/eks/hop.jsonc
+++ b/src/templates/eks/hop.jsonc
@@ -219,7 +219,7 @@
     },
     "readme": {
       "extend_basic_readme": "aws",
-      "template": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
+      "template_section": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
     }
   }
 }

--- a/src/templates/gcp/hop.jsonc
+++ b/src/templates/gcp/hop.jsonc
@@ -228,7 +228,7 @@
     },
     "readme": {
       "extend_basic_readme": "gcp",
-      "template": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
+      "template_section": "## Apache Hop\n\nThis template deploys [Apache Hop](https://hop.apache.org/), a data processing tool that is widely used for ETL to extract transform and load processing. "
     }
   }
 }

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -213,12 +213,26 @@ export default async function useTemplate(
     if (
       !validTarget
     ) {
+      const numberOfSlashes = templateLocation.split("/").length - 1;
+
       // it's not a valid template target
       console.error(
         useTemplateLabel,
-        ccolors.key_name(`"${templateLocation}"`),
+        ccolors.user_input(`"${templateLocation}"`),
         ccolors.error("is not a valid template name"),
       );
+
+      if (numberOfSlashes > 1) {
+        console.log(
+          useTemplateLabel,
+          ccolors.warn("Were you trying to use a local template file?"),
+          ccolors.warn("Try using the"),
+          ccolors.key_name("file://"),
+          ccolors.warn("prefix with an absolute file path to the template."),
+        );
+        console.log();
+      }
+
       await emitExitEvent(1200);
       Deno.exit(1200);
     } else if (validTarget?.aliasFor) {
@@ -247,6 +261,15 @@ export default async function useTemplate(
       ccolors.user_input(`"${templateUrl}"`),
     );
     console.log(ccolors.caught(fetchError, 1201));
+    if (templateUrl.protocol === "file:") {
+      console.log(
+        useTemplateLabel,
+        ccolors.user_input(templateLocation),
+        ccolors.warn(
+          "is not a valid file URL. Please ensure you are using an absolute path to the template file.",
+        ),
+      );
+    }
     await emitExitEvent(1201);
     Deno.exit(1201);
   }

--- a/src/tests/helpers/util.ts
+++ b/src/tests/helpers/util.ts
@@ -7,6 +7,10 @@ function areSetsEqual(setA: Set<string>, setB: Set<string>) {
   return true;
 }
 
+function getModuleDir(importMeta: ImportMeta): string {
+  return path.resolve(path.dirname(path.fromFileUrl(importMeta.url)));
+}
+
 const assertSetEquality = (setA: Set<string>, setB: Set<string>) =>
   assert(areSetsEqual(setA, setB));
 
@@ -60,5 +64,6 @@ async function ensureResoureNamesMatchFileNames() {
 export {
   assertSetEquality,
   ensureResoureNamesMatchFileNames,
+  getModuleDir,
   hasSameFilesAfter,
 };


### PR DESCRIPTION
CNDI Templates can be hosted and invoked remotely, but we should also support passing a file path to a template that exists on the machine running `cndi init`. To do this we've better documented the option of passing in a `file://` URL which contains an absolute path to the Template that should be invoked.

- [x] updated README to include more info about remote and local Templates
- [x] fixed a couple issues in Templates where old (and broken) syntax was being used 
- [x] added hints about `file://` Templates to be presented when it seems like the user intended to use a local template
- [x] added test which ensures local templates are functional