### PR TITLE
allow ports to be opened and closed without manifests

### DIFF
--- a/cndi-config.jsonc
+++ b/cndi-config.jsonc
@@ -3,16 +3,6 @@
   "project_name": "my-cndi-project",
   "infrastructure": {
     "cndi": {
-      "open_ports": [
-        {
-          "number": 80,
-          "disable": true
-        },
-        {
-          "number": 443,
-          "disable": true
-        }
-      ],
       "nodes": [
         {
           "name": "x-node",

--- a/cndi-config.jsonc
+++ b/cndi-config.jsonc
@@ -3,6 +3,16 @@
   "project_name": "my-cndi-project",
   "infrastructure": {
     "cndi": {
+      "open_ports": [
+        {
+          "number": 80,
+          "disable": true
+        },
+        {
+          "number": 443,
+          "disable": true
+        }
+      ],
       "nodes": [
         {
           "name": "x-node",

--- a/main_test.ts
+++ b/main_test.ts
@@ -239,6 +239,32 @@ describe("cndi", () => {
       );
     });
 
+    it(`should be possible to specify an open_port which does not create or modify corresponding manifests`, async () => {
+      Deno.writeTextFileSync(
+        path.join(Deno.cwd(), `cndi-config.jsonc`),
+        getPrettyJSONString({
+          ...basicAWSCndiConfig,
+          infrastructure: {
+            cndi: {
+              ...basicAWSCndiConfig.infrastructure.cndi,
+              open_ports: [
+                {
+                  name: "ssh",
+                  number: 22,
+                },
+              ],
+            },
+          },
+        }),
+      );
+      assert(
+        !await hasSameFilesAfter(async () => {
+          const { status } = await runCndiLoud("init");
+          assert(status.success);
+        }),
+      );
+    });
+
     it(`should succeed if a config file has valid 'infrastructure.cndi.open_ports'`, async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.jsonc`),

--- a/main_test.ts
+++ b/main_test.ts
@@ -259,7 +259,7 @@ describe("cndi", () => {
       );
       assert(
         !await hasSameFilesAfter(async () => {
-          const { status } = await runCndiLoud("init");
+          const { status } = await runCndi("init");
           assert(status.success);
         }),
       );

--- a/src/outputs/custom-port-manifests/eks/ingress-service.ts
+++ b/src/outputs/custom-port-manifests/eks/ingress-service.ts
@@ -57,18 +57,8 @@ const getIngressServiceManifest = (
       );
     }
 
-    if (!port?.namespace) {
-      console.error(
-        ingressTcpServicesConfigMapManifestLabel,
-        'custom port specs need "namespace" property',
-      );
-    }
-
-    if (!port?.service) {
-      console.error(
-        ingressTcpServicesConfigMapManifestLabel,
-        'custom port specs need "service" property',
-      );
+    if (!disable && !port?.namespace && !port?.service) {
+      return;
     }
 
     if (disable) {

--- a/src/outputs/custom-port-manifests/eks/ingress-tcp-services-configmap.ts
+++ b/src/outputs/custom-port-manifests/eks/ingress-tcp-services-configmap.ts
@@ -39,18 +39,25 @@ const getIngressTcpServicesConfigMapManifest = (
         'custom port specs need "number" property',
       );
     }
+
+    if (!port?.namespace && !port?.service) {
+      return;
+    }
+
     if (!port?.namespace) {
       console.error(
         ingressTcpServicesConfigMapManifestLabel,
-        'custom port specs need "namespace" property',
+        'custom port specs with "service" need "namespace" property',
       );
     }
+
     if (!port?.service) {
       console.error(
         ingressTcpServicesConfigMapManifestLabel,
-        'custom port specs need "service" property',
+        'custom port specs with "namespace" need "service" property',
       );
     }
+
     manifest.data[`${port.number}`] =
       `${port.namespace}/${port.service}:${port.number}`;
   });

--- a/src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts
+++ b/src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts
@@ -80,25 +80,43 @@ const getIngressDaemonSetManifest = (
       "name": "http",
       "containerPort": 80,
       "hostPort": 80,
+      "protocol": "TCP",
     },
     {
       "name": "https",
       "containerPort": 443,
       "hostPort": 443,
+      "protocol": "TCP",
     },
   ];
 
   const ports = [
     ...default_ports,
-    ...user_ports.map(
-      (port) => ({
+  ];
+
+  user_ports.forEach(
+    (port) => {
+      if (port?.disable) {
+        const portToRemove = ports.findIndex((item) =>
+          item.hostPort === port.number
+        );
+        if (portToRemove > -1) {
+          ports.splice(portToRemove, 1);
+        }
+      }
+
+      if (!port?.service && !port?.namespace) {
+        return;
+      }
+
+      ports.push({
         name: port.name,
         containerPort: port.number,
         hostPort: port.number,
         protocol: "TCP",
-      }),
-    ),
-  ];
+      });
+    },
+  );
 
   const manifest: IngressDaemonSetManifest = {
     "apiVersion": "apps/v1",

--- a/src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts
+++ b/src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts
@@ -39,18 +39,25 @@ const getIngressTcpServicesConfigMapManifest = (
         'custom port specs need "number" property',
       );
     }
+
+    if (!port?.namespace && !port?.service) {
+      return;
+    }
+
     if (!port?.namespace) {
       console.error(
         ingressTcpServicesConfigMapManifestLabel,
-        'custom port specs need "namespace" property',
+        'custom port specs with "service" need "namespace" property',
       );
     }
+
     if (!port?.service) {
       console.error(
         ingressTcpServicesConfigMapManifestLabel,
-        'custom port specs need "service" property',
+        'custom port specs with "namespace" need "service" property',
       );
     }
+
     manifest.data[`${port.number}`] =
       `${port.namespace}/${port.service}:${port.number}`;
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,8 +154,8 @@ type TFBlocks = {
 
 interface CNDIPort {
   name: string;
-  service: string;
-  namespace: string;
+  service?: string;
+  namespace?: string;
   number: number;
   disable?: boolean;
 }

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -68,7 +68,17 @@ export default async function validateConfig(
           await emitExitEvent(911);
           Deno.exit(911);
         }
-        if (!port.service) {
+        if (!port.service && !port.namespace) {
+          console.log(
+            cndiConfigLabel,
+            ccolors.warn(`port`),
+            ccolors.user_input(`${port.number}`),
+            ccolors.warn(`is open but is not assigned to a`),
+            ccolors.key_name("service"),
+            ccolors.warn("or"),
+            ccolors.key_name("namespace"),
+          );
+        } else if (!port.service) {
           console.error(
             cndiConfigLabel,
             ccolors.error("cndi-config file found was at "),
@@ -81,8 +91,7 @@ export default async function validateConfig(
           );
           await emitExitEvent(910);
           Deno.exit(910);
-        }
-        if (!port.namespace) {
+        } else if (!port.namespace) {
           console.error(
             cndiConfigLabel,
             ccolors.error("cndi-config file found was at "),


### PR DESCRIPTION
It may be useful to open or close system ports like `16443`, `80`, `443`, `22`, without requiring that a service is listening on that port for ingress inside the cluster. By specifying an open_ports entry without `"namespace"` and `"service"` users can open ports at the infrastructure level without also opening them inside the cluster.