### PR TITLE
Update - replaceRange function to remove "" from number types

### DIFF
--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -130,10 +130,10 @@ function replaceRange(
   s: string,
   start: number,
   end: number,
-  substitute: string,
+  substitute: string | number | boolean | Array<unknown>,
 ) {
-  //For type that are not string add 1 to end index and reduce 1 from start index to remove "".
-  //So instead of it returning "members": "3" it will return "members": 3
+  // For type that are not string add 1 to end index and reduce 1 from start index to remove "".
+  // So instead of it returning "members": "3" it will return "members": 3
   return typeof (substitute) === "string"
     ? s.substring(0, start) + substitute + s.substring(end)
     : s.substring(0, start - 1) + substitute + s.substring(end + 1);

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -132,7 +132,11 @@ function replaceRange(
   end: number,
   substitute: string,
 ) {
-  return s.substring(0, start) + substitute + s.substring(end);
+  //For number type add 1 to end index and reduce 1 from start index to remove "".
+  //So instead of it returning "members": "3" it will return "members": 3
+  return typeof(substitute) ==="number"?
+  s.substring(0, start -1) + substitute + s.substring(end + 1):
+  s.substring(0, start) + substitute + s.substring(end)
 }
 
 // returns a string where templated values are replaced with their literal values from prompt responses
@@ -169,7 +173,7 @@ export function literalizeTemplateValuesInString(
         literalizedString,
         indexOfOpeningBraces,
         indexOfClosingBraces + 2,
-        `${valueToSubstitute}`,
+        valueToSubstitute,
       );
     }
     indexOfOpeningBraces = literalizedString.indexOf(

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -132,11 +132,12 @@ function replaceRange(
   end: number,
   substitute: string,
 ) {
-  //For number type add 1 to end index and reduce 1 from start index to remove "".
+  //For type that are not string add 1 to end index and reduce 1 from start index to remove "".
   //So instead of it returning "members": "3" it will return "members": 3
-  return typeof (substitute) === "number"
-    ? s.substring(0, start - 1) + substitute + s.substring(end + 1)
-    : s.substring(0, start) + substitute + s.substring(end);
+  return typeof (substitute) === "string"
+    ? s.substring(0, start) + substitute + s.substring(end)
+    : s.substring(0, start - 1) + substitute + s.substring(end + 1);
+
 }
 
 // returns a string where templated values are replaced with their literal values from prompt responses

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -137,7 +137,6 @@ function replaceRange(
   return typeof (substitute) === "string"
     ? s.substring(0, start) + substitute + s.substring(end)
     : s.substring(0, start - 1) + substitute + s.substring(end + 1);
-
 }
 
 // returns a string where templated values are replaced with their literal values from prompt responses

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -134,9 +134,9 @@ function replaceRange(
 ) {
   //For number type add 1 to end index and reduce 1 from start index to remove "".
   //So instead of it returning "members": "3" it will return "members": 3
-  return typeof(substitute) ==="number"?
-  s.substring(0, start -1) + substitute + s.substring(end + 1):
-  s.substring(0, start) + substitute + s.substring(end)
+  return typeof (substitute) === "number"
+    ? s.substring(0, start - 1) + substitute + s.substring(end + 1)
+    : s.substring(0, start) + substitute + s.substring(end);
 }
 
 // returns a string where templated values are replaced with their literal values from prompt responses


### PR DESCRIPTION
#380 

- Update - replaceRange function to remove "" from number types.
- Example:  Instead of it returning "members": "3" it will return "members": 3

# Testing instructions
- Pull this branch locally and use 
`cndi-next init -i -d -t https://raw.githubusercontent.com/polyseam/cndi/gh-300/mongodb-template/src/templates/ec2/mongodb.jsonc` to create a mongodb template repo locally.

After the init process you will notice the `mongodb-community-crd` manifest in cndi-config.json will have the number of replicasets as number type instead of string.
```
...
"spec": {
        "members": 3,
        "type": "ReplicaSet",
...
```
