### PR TITLE
ensure literalizing prompt values handle all types

### DIFF
--- a/main_test.ts
+++ b/main_test.ts
@@ -7,7 +7,7 @@ import { literalizeTemplateValuesInString } from "src/templates/useTemplate.ts";
 import { basicAWSCndiConfig } from "src/tests/mocks/cndiConfigs.ts";
 import gcpKeyFile from "src/tests/mocks/example-gcp-key.ts";
 
-import { getPrettyJSONString } from "src/utils.ts";
+import { getPrettyJSONString, replaceRange } from "src/utils.ts";
 
 import { getRunningCNDIProcess, runCndi } from "src/tests/helpers/run-cndi.ts";
 
@@ -30,6 +30,18 @@ beforeEach(() => {
 describe("cndi", () => {
   it("should have a working test suite", () => {
     assert(true);
+  });
+
+  describe("replaceRange utility", () => {
+    it("should replace a range of text in a string", () => {
+      const str = "foo bar baz";
+      const replaced = replaceRange(str, 4, 7, "qux");
+      assert(replaced === "foo qux baz");
+
+      const str2 = "foo bar baz";
+      const replaced2 = replaceRange(str2, 0, 3, `230`);
+      assert(replaced2 === "230 bar baz");
+    });
   });
 
   describe("cndi init", () => {
@@ -383,14 +395,24 @@ describe("cndi", () => {
       const promptResponses = {
         exampleA: "foo",
         exampleB: "bar",
-        whiteSpaceIgnored: "true",
+        numberExample: 1300,
+        booleanExample: true,
+        stringArrayExample: ["foo", "bar", "baz"],
+        whiteSpaceIgnored: true,
+        boolArrayExample: [true, false, true],
+        mixedArrayExample: [true, "foo", 1300],
       };
 
       const cndiConfigStr = `{
         "cluster_manifests": {
           "myExampleA": "{{ $.cndi.prompts.responses.exampleA }}",
           "myExampleB": "{{ $.cndi.prompts.responses.exampleB }}",
-          "whitespaceIgnored": {{      $.cndi.prompts.responses.whiteSpaceIgnored              }},
+          "numberExample": "{{ $.cndi.prompts.responses.numberExample }}",
+          "booleanExample": "{{ $.cndi.prompts.responses.booleanExample }}",
+          "stringArrayExample": "{{ $.cndi.prompts.responses.stringArrayExample }}",
+          "whitespaceIgnored": "{{      $.cndi.prompts.responses.whiteSpaceIgnored              }}",
+          "boolArrayExample": "{{ $.cndi.prompts.responses.boolArrayExample }}",
+          "mixedArrayExample": "{{ $.cndi.prompts.responses.mixedArrayExample }}",
           "title": "my-{{ $.cndi.prompts.responses.exampleA }}-{{ $.cndi.prompts.responses.exampleB }}-cluster"
         }
       }`;
@@ -399,10 +421,22 @@ describe("cndi", () => {
         promptResponses,
         cndiConfigStr,
       );
+
       assert(literalized.indexOf(`"myExampleA": "foo"`) > -1);
       assert(literalized.indexOf(`"myExampleB": "bar"`) > -1);
       assert(literalized.indexOf(`"title": "my-foo-bar-cluster"`) > -1);
-      assert(literalized.indexOf(`"whitespaceIgnored": true,`) > -1);
+      assert(literalized.indexOf(`"numberExample": 1300`) > -1);
+      assert(
+        literalized.indexOf(`"stringArrayExample": ["foo", "bar", "baz"]`) > -1,
+      );
+      assert(
+        literalized.indexOf(`"boolArrayExample": [true, false, true]`) > -1,
+      );
+      assert(
+        literalized.indexOf(`"mixedArrayExample": [true, "foo", 1300]`) > -1,
+      );
+      assert(literalized.indexOf(`"booleanExample": true`) > -1);
+      assert(literalized.indexOf(`"whitespaceIgnored": true`) > -1);
     });
 
     describe("aws", () => {

--- a/main_test.ts
+++ b/main_test.ts
@@ -427,13 +427,13 @@ describe("cndi", () => {
       assert(literalized.indexOf(`"title": "my-foo-bar-cluster"`) > -1);
       assert(literalized.indexOf(`"numberExample": 1300`) > -1);
       assert(
-        literalized.indexOf(`"stringArrayExample": ["foo", "bar", "baz"]`) > -1,
+        literalized.indexOf(`"stringArrayExample": ["foo","bar","baz"]`) > -1,
       );
       assert(
-        literalized.indexOf(`"boolArrayExample": [true, false, true]`) > -1,
+        literalized.indexOf(`"boolArrayExample": [true,false,true]`) > -1,
       );
       assert(
-        literalized.indexOf(`"mixedArrayExample": [true, "foo", 1300]`) > -1,
+        literalized.indexOf(`"mixedArrayExample": [true,"foo",1300]`) > -1,
       );
       assert(literalized.indexOf(`"booleanExample": true`) > -1);
       assert(literalized.indexOf(`"whitespaceIgnored": true`) > -1);

--- a/src/templates/useTemplate.ts
+++ b/src/templates/useTemplate.ts
@@ -167,26 +167,11 @@ export function literalizeTemplateValuesInString(
       } else {
         const indexOfOpenWrappingQuote = indexOfOpeningBraces - 1;
         const indexOfClosingWrappingQuoteInclusive = indexOfClosingBraces + 3;
-        let val;
-
-        if (Array.isArray(valueToSubstitute)) {
-          // if entries is a string array, wrap each entry in quotes
-          // otherwise, just use the entry as-is
-          const entries = valueToSubstitute.map((
-            v,
-          ) => (typeof v === "string" ? `"${v}"` : v));
-          // eg. ["a", "b", "c"]
-          val = `[${(entries).join(", ")}]`;
-        } else {
-          // valueToSubstitute is a boolean or number
-          val = valueToSubstitute;
-        }
-
         literalizedString = replaceRange(
           literalizedString,
           indexOfOpenWrappingQuote,
           indexOfClosingWrappingQuoteInclusive,
-          `${val}`,
+          JSON.stringify(valueToSubstitute),
         );
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -429,6 +429,23 @@ function getUserDataTemplateFileString(
   }
 }
 
+/**
+ * Replaces a range in a string with a substituted value
+ * @param s string which should be modified
+ * @param start index of the first character to be replaced
+ * @param end index of the last character to be replaced
+ * @param substitute
+ * @returns new string after substitution
+ */
+function replaceRange(
+  s: string,
+  start: number,
+  end: number,
+  substitute: string,
+) {
+  return s.substring(0, start) + substitute + s.substring(end);
+}
+
 function getSecretOfLength(len = 32): string {
   if (len % 2) {
     throw new Error("password length must be even");
@@ -467,6 +484,7 @@ export {
   loadRemoteJSONC,
   patchAndStageTerraformFilesWithConfig,
   persistStagedFiles,
+  replaceRange,
   sha256Digest,
   stageFile,
 };


### PR DESCRIPTION
# Related issue
#380
<!-- Please link the primary issue(s) related to this work and other relevant issues -->

<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

- [x] Ensure `literalizeTemplateValuesInString` supports all prompt response types
- [x] Make `replaceRange` agnostic to the inputs it is consuming 
- [x] add test for  `replaceRange`
- [x] add more tests for types to literalize in `literalizeTemplateValuesInString`

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

N/A

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
