### PR TITLE
Gh 398/no m5a large

### DIFF
--- a/cndi-config.jsonc
+++ b/cndi-config.jsonc
@@ -11,20 +11,18 @@
           "name": "x-node",
           "kind": "ec2",
           "role": "leader",
-          "instance_type": "m5a.2xlarge",
+          "instance_type": "t3.2xlarge",
           "volume_size": 128
         },
         {
           "name": "y-node",
           "kind": "ec2",
           "role": "controller",
-          "instance_type": "m5a.large",
           "volume_size": 128
         },
         {
           "name": "z-node",
           "kind": "ec2",
-          "instance_type": "m5a.large",
           "volume_size": 128
         }
       ]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ const KUBESEAL_VERSION = "0.21.0";
 const DEFAULT_MICROK8S_VERSION = "1.27";
 
 const DEFAULT_INSTANCE_TYPES = {
-  aws: "m5a.large" as const,
+  aws: "t3.large" as const,
   gcp: "n2-standard-2" as const,
   azure: "Standard_D4s_v3" as const,
 };

--- a/src/templates/ec2/airflow.jsonc
+++ b/src/templates/ec2/airflow.jsonc
@@ -66,7 +66,7 @@
               "name": "x-airflow-node",
               "kind": "ec2",
               "role": "leader",
-              "instance_type": "m5a.large",
+              "instance_type": "t3.large",
               "volume_size": 128
             },
             {

--- a/src/templates/ec2/basic.jsonc
+++ b/src/templates/ec2/basic.jsonc
@@ -26,7 +26,7 @@
               "name": "x-node",
               "kind": "ec2",
               "role": "leader",
-              "instance_type": "m5a.large",
+              "instance_type": "t3.large",
               "volume_size": 128
             },
             {

--- a/src/templates/ec2/cnpg.jsonc
+++ b/src/templates/ec2/cnpg.jsonc
@@ -70,7 +70,7 @@
               "name": "x-cnpg-node",
               "kind": "ec2",
               "role": "leader",
-              "instance_type": "m5a.large",
+              "instance_type": "t3.large",
               "volume_size": 128
             },
             {

--- a/src/templates/ec2/hop.jsonc
+++ b/src/templates/ec2/hop.jsonc
@@ -38,7 +38,7 @@
               "name": "x-hop-node",
               "kind": "ec2",
               "role": "leader",
-              "instance_type": "m5a.large",
+              "instance_type": "t3.large",
               "volume_size": 128
             },
             {

--- a/src/templates/ec2/mysql.jsonc
+++ b/src/templates/ec2/mysql.jsonc
@@ -52,7 +52,7 @@
               "name": "x-mysql-node",
               "kind": "ec2",
               "role": "leader",
-              "instance_type": "m5a.large",
+              "instance_type": "t3.large",
               "volume_size": 128
             },
             {


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->

<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

#398 

# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

AWS deployments were failing because `m5a.large` instance types are not reliably available, now we use a more common type `t3.large`


# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
