### PR TITLE
Fix [Bug]: Neo4j Template TLS Disabled

### DIFF
--- a/src/templates/azure/neo4j.jsonc
+++ b/src/templates/azure/neo4j.jsonc
@@ -69,49 +69,6 @@
         }
       },
       "cluster_manifests": {
-        "neo4j-ingress": {
-          "apiVersion": "networking.k8s.io/v1",
-          "kind": "Ingress",
-          "metadata": {
-            "name": "neo4j-ingress",
-            "namespace": "neo4j",
-            "annotations": {
-              "cert-manager.io/cluster-issuer": "cluster-issuer",
-              "kubernetes.io/tls-acme": "true",
-              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
-              "nginx.ingress.kubernetes.io/ssl-passthrough": "true"
-            }
-          },
-          "spec": {
-            "tls": [
-              {
-                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
-                "secretName": "cluster-issuer-private-key"
-              }
-            ],
-            "rules": [
-              {
-                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
-                "http": {
-                  "paths": [
-                    {
-                      "path": "/",
-                      "pathType": "Prefix",
-                      "backend": {
-                        "service": {
-                          "name": "neo4j-kube-lb-neo4j",
-                          "port": {
-                            "name": "https"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
         "neo4j-auth-secret": {
           "apiVersion": "v1",
           "kind": "Secret",
@@ -125,115 +82,28 @@
           }
         }
       },
-
       "applications": {
         "neo4j": {
-          "targetRevision": "5.7.0",
+          "targetRevision": "5.9.0",
           "destinationNamespace": "neo4j",
           "repoURL": "https://helm.neo4j.com/neo4j",
           "chart": "neo4j",
           "values": {
             "disableLookups": true,
             "neo4j": {
-              "name": "neo4j-kube",
-              "password": "",
+              "name": "neo4j",
               "passwordFromSecret": "neo4j-auth-secret",
-              "edition": "community",
-              "acceptLicenseAgreement": "yes",
-              "offlineMaintenanceModeEnabled": false,
-              "resources": {
-                "cpu": "1000m",
-                "memory": "4Gi"
-              },
-              "labels": null
+              "acceptLicenseAgreement": "yes"
             },
             "volumes": {
               "data": {
-                "mode": "defaultStorageClass",
-                "defaultStorageClass": {
-                  "accessModes": ["ReadWriteOnce"],
-                  "requests": {
-                    "storage": "10Gi"
-                  }
-                }
-              },
-              "plugins": {
-                "mode": "share",
-                "share": {
-                  "name": "data"
-                }
+                "mode": "defaultStorageClass"
               }
             },
             "services": {
               "neo4j": {
-                "enabled": true,
-                "spec": {
-                  "type": "LoadBalancer"
-                },
-                "ports": {
-                  "http": {
-                    "enabled": false
-                  },
-                  "https": {
-                    "enabled": true
-                  },
-                  "bolt": {
-                    "enabled": true,
-                    "name": "neo4j-bolt-7687",
-                    "port": "7687",
-                    "protocol": "TCP",
-                    "targetPort": "7687"
-                  },
-                  "backup": {
-                    "enabled": false
-                  }
-                },
-                "selector": {
-                  "helm.neo4j.com/neo4j.loadbalancer": "include"
-                },
-                "multiCluster": false,
-                "cleanup": {
-                  "enabled": true,
-                  "image": {
-                    "registry": "docker.io",
-                    "repository": "bitnami/kubectl",
-                    "tag": "",
-                    "digest": "",
-                    "imagePullPolicy": "IfNotPresent"
-                  }
-                }
+                "enabled": false
               }
-            },
-            "config": {
-              "server.config.strict_validation.enabled": "false",
-              "server.directories.plugins": "/var/lib/neo4j/labs",
-              "dbms.security.procedures.unrestricted": "apoc.*",
-              "dbms.security.procedures.allowlist": "apoc.*",
-              "dbms.security.http_strict_transport_security": "false",
-              "server.http.enabled": "false",
-              "server.bolt.enabled": "true",
-              "server.bolt.tls_level": "REQUIRED",
-              "server.bolt.listen_address": "0.0.0.0:7687",
-              "server.bolt.thread_pool_keep_alive": "10m",
-              "server.bolt.advertised_address": "{{ $.cndi.prompts.responses.neo4jDomainName }}:7687",
-              "server.https.listen_address": "0.0.0.0:7473",
-              "server.https.advertised_address": "{{ $.cndi.prompts.responses.neo4jDomainName }}:7473",
-              "dbms.ssl.policy.bolt.enabled": "true",
-              "dbms.ssl.policy.bolt.client_auth": "NONE",
-              "dbms.ssl.policy.bolt.base_directory": "/var/lib/neo4j/certificates/bolt",
-              "dbms.ssl.policy.bolt.private_key": "private.key",
-              "dbms.ssl.policy.bolt.public_certificate": "public.crt",
-              "server.https.enabled": "true",
-              "dbms.ssl.policy.https.enabled": "true",
-              "dbms.ssl.policy.https.base_directory": "/var/lib/neo4j/certificates/https",
-              "dbms.ssl.policy.https.private_key": "private.key",
-              "dbms.ssl.policy.https.public_certificate": "public.crt",
-              "dbms.ssl.policy.https.client_auth": "NONE"
-            },
-            "apoc_config": {
-              "apoc.trigger.enabled": "true",
-              "apoc.jdbc.neo4j.url": "jdbc:foo:bar",
-              "apoc.import.file.enabled": "true"
             },
             "ssl": {
               "bolt": {
@@ -254,21 +124,6 @@
                 "publicCertificate": {
                   "secretName": "cluster-issuer-private-key",
                   "subPath": "tls.crt"
-                },
-                "trustedCerts": {
-                  "sources": [
-                    {
-                      "secret": {
-                        "name": "cluster-issuer-private-key",
-                        "items": [
-                          {
-                            "key": "tls.crt",
-                            "path": "public.crt"
-                          }
-                        ]
-                      }
-                    }
-                  ]
                 }
               },
               "cluster": {
@@ -279,21 +134,6 @@
                 "publicCertificate": {
                   "secretName": "cluster-issuer-private-key",
                   "subPath": "tls.crt"
-                },
-                "trustedCerts": {
-                  "sources": [
-                    {
-                      "secret": {
-                        "name": "cluster-issuer-private-key",
-                        "items": [
-                          {
-                            "key": "tls.crt",
-                            "path": "public.crt"
-                          }
-                        ]
-                      }
-                    }
-                  ]
                 }
               }
             }

--- a/src/templates/dev/neo4j.jsonc
+++ b/src/templates/dev/neo4j.jsonc
@@ -96,49 +96,6 @@
             ]
           }
         },
-        "neo4j-ingress": {
-          "apiVersion": "networking.k8s.io/v1",
-          "kind": "Ingress",
-          "metadata": {
-            "name": "neo4j-ingress",
-            "namespace": "neo4j",
-            "annotations": {
-              "cert-manager.io/cluster-issuer": "cluster-issuer",
-              "kubernetes.io/tls-acme": "true",
-              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
-              "nginx.ingress.kubernetes.io/ssl-passthrough": "true"
-            }
-          },
-          "spec": {
-            "tls": [
-              {
-                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
-                "secretName": "cluster-issuer-private-key"
-              }
-            ],
-            "rules": [
-              {
-                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
-                "http": {
-                  "paths": [
-                    {
-                      "path": "/",
-                      "pathType": "Prefix",
-                      "backend": {
-                        "service": {
-                          "name": "neo4j",
-                          "port": {
-                            "name": "https"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
         "neo4j-auth-secret": {
           "apiVersion": "v1",
           "kind": "Secret",
@@ -174,37 +131,37 @@
               "neo4j": {
                 "enabled": false
               }
-            }
-          },
-          "ssl": {
-            "bolt": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
-              },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
-              }
             },
-            "https": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
+            "ssl": {
+              "bolt": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
-              }
-            },
-            "cluster": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
+              "https": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
+              "cluster": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               }
             }
           }
@@ -237,4 +194,4 @@
       "template_section": "## neo4j\n\nThis template deploys a fully functional [Neo4j](https://neo4j.com) cluster using the [official Neo4j Helm chart](https://helm.neo4j.com/neo4j)."
     }
   }
-}
+  }

--- a/src/templates/dev/neo4j.jsonc
+++ b/src/templates/dev/neo4j.jsonc
@@ -194,4 +194,4 @@
       "template_section": "## neo4j\n\nThis template deploys a fully functional [Neo4j](https://neo4j.com) cluster using the [official Neo4j Helm chart](https://helm.neo4j.com/neo4j)."
     }
   }
-  }
+}

--- a/src/templates/ec2/neo4j.jsonc
+++ b/src/templates/ec2/neo4j.jsonc
@@ -111,49 +111,6 @@
             ]
           }
         },
-        "neo4j-ingress": {
-          "apiVersion": "networking.k8s.io/v1",
-          "kind": "Ingress",
-          "metadata": {
-            "name": "neo4j-ingress",
-            "namespace": "neo4j",
-            "annotations": {
-              "cert-manager.io/cluster-issuer": "cluster-issuer",
-              "kubernetes.io/tls-acme": "true",
-              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
-              "nginx.ingress.kubernetes.io/ssl-passthrough": "true"
-            }
-          },
-          "spec": {
-            "tls": [
-              {
-                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
-                "secretName": "cluster-issuer-private-key"
-              }
-            ],
-            "rules": [
-              {
-                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
-                "http": {
-                  "paths": [
-                    {
-                      "path": "/",
-                      "pathType": "Prefix",
-                      "backend": {
-                        "service": {
-                          "name": "neo4j",
-                          "port": {
-                            "name": "https"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
         "neo4j-auth-secret": {
           "apiVersion": "v1",
           "kind": "Secret",
@@ -189,37 +146,37 @@
               "neo4j": {
                 "enabled": false
               }
-            }
-          },
-          "ssl": {
-            "bolt": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
-              },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
-              }
             },
-            "https": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
+            "ssl": {
+              "bolt": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
-              }
-            },
-            "cluster": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
+              "https": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
+              "cluster": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               }
             }
           }

--- a/src/templates/eks/neo4j.jsonc
+++ b/src/templates/eks/neo4j.jsonc
@@ -111,49 +111,6 @@
             ]
           }
         },
-        "neo4j-ingress": {
-          "apiVersion": "networking.k8s.io/v1",
-          "kind": "Ingress",
-          "metadata": {
-            "name": "neo4j-ingress",
-            "namespace": "neo4j",
-            "annotations": {
-              "cert-manager.io/cluster-issuer": "cluster-issuer",
-              "kubernetes.io/tls-acme": "true",
-              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
-              "nginx.ingress.kubernetes.io/ssl-passthrough": "true"
-            }
-          },
-          "spec": {
-            "tls": [
-              {
-                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
-                "secretName": "cluster-issuer-private-key"
-              }
-            ],
-            "rules": [
-              {
-                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
-                "http": {
-                  "paths": [
-                    {
-                      "path": "/",
-                      "pathType": "Prefix",
-                      "backend": {
-                        "service": {
-                          "name": "neo4j",
-                          "port": {
-                            "name": "https"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
         "neo4j-auth-secret": {
           "apiVersion": "v1",
           "kind": "Secret",
@@ -189,37 +146,37 @@
               "neo4j": {
                 "enabled": false
               }
-            }
-          },
-          "ssl": {
-            "bolt": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
-              },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
-              }
             },
-            "https": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
+            "ssl": {
+              "bolt": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
-              }
-            },
-            "cluster": {
-              "privateKey": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.key"
+              "https": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               },
-              "publicCertificate": {
-                "secretName": "cluster-issuer-private-key",
-                "subPath": "tls.crt"
+              "cluster": {
+                "privateKey": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.key"
+                },
+                "publicCertificate": {
+                  "secretName": "cluster-issuer-private-key",
+                  "subPath": "tls.crt"
+                }
               }
             }
           }

--- a/src/templates/gcp/neo4j.jsonc
+++ b/src/templates/gcp/neo4j.jsonc
@@ -111,49 +111,6 @@
             ]
           }
         },
-        "neo4j-ingress": {
-          "apiVersion": "networking.k8s.io/v1",
-          "kind": "Ingress",
-          "metadata": {
-            "name": "neo4j-ingress",
-            "namespace": "neo4j",
-            "annotations": {
-              "cert-manager.io/cluster-issuer": "cluster-issuer",
-              "kubernetes.io/tls-acme": "true",
-              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
-              "nginx.ingress.kubernetes.io/ssl-passthrough": "true"
-            }
-          },
-          "spec": {
-            "tls": [
-              {
-                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
-                "secretName": "cluster-issuer-private-key"
-              }
-            ],
-            "rules": [
-              {
-                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
-                "http": {
-                  "paths": [
-                    {
-                      "path": "/",
-                      "pathType": "Prefix",
-                      "backend": {
-                        "service": {
-                          "name": "neo4j",
-                          "port": {
-                            "name": "https"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
         "neo4j-auth-secret": {
           "apiVersion": "v1",
           "kind": "Secret",


### PR DESCRIPTION
# Related issue

#429

# Description

Connecting to a neo4j cluster from the desktop application was failing when "encrypt connection" was enabled.

# Test Instructions

1. Observe the above when deploying the Template in the `main` branch
2. Observe the issue is resolved when using the Template from this branch

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

This issue stemmed from a typo.

<!-- Additional notes that add context or help reviewers -->
