### PR TITLE
Fix [Bug]: Neo4j Template TLS Disabled (more)

### DIFF
--- a/src/templates/azure/neo4j.jsonc
+++ b/src/templates/azure/neo4j.jsonc
@@ -80,6 +80,93 @@
           "stringData": {
             "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
           }
+        },
+        "neo4j-ingress": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "neo4j-ingress",
+            "namespace": "neo4j",
+            "annotations": {
+              "cert-manager.io/cluster-issuer": "cluster-issuer",
+              "kubernetes.io/tls-acme": "true",
+              "nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+            }
+          },
+          "spec": {
+            // required for Bolt and secure Neo4j Web Browser
+            "tls": [
+              {
+                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
+                "secretName": "cluster-issuer-private-key"
+              }
+            ],
+            "rules": [
+              {
+                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
+                "http": {
+                  "paths": [
+                    {
+                      "path": "/",
+                      "pathType": "Prefix",
+                      "backend": {
+                        "service": {
+                          "name": "neo4j",
+                          "port": {
+                            "number": 7473
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "argo-ingress": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "argocd-server-ingress",
+            "namespace": "argocd",
+            "annotations": {
+              "cert-manager.io/cluster-issuer": "cluster-issuer",
+              "kubernetes.io/tls-acme": "true",
+              "nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+            }
+          },
+          "spec": {
+            "tls": [
+              {
+                "hosts": ["{{ $.cndi.prompts.responses.argocdDomainName }}"],
+                "secretName": "cluster-issuer-private-key"
+              }
+            ],
+            "rules": [
+              {
+                "host": "{{ $.cndi.prompts.responses.argocdDomainName }}",
+                "http": {
+                  "paths": [
+                    {
+                      "path": "/",
+                      "pathType": "Prefix",
+                      "backend": {
+                        "service": {
+                          "name": "argocd-server",
+                          "port": {
+                            "name": "https"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
         }
       },
       "applications": {

--- a/src/templates/dev/neo4j.jsonc
+++ b/src/templates/dev/neo4j.jsonc
@@ -53,6 +53,62 @@
         }
       },
       "cluster_manifests": {
+        "neo4j-auth-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "neo4j-auth-secret",
+            "namespace": "neo4j"
+          },
+          "type": "Opaque",
+          "stringData": {
+            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
+          }
+        },
+        "neo4j-ingress": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "neo4j-ingress",
+            "namespace": "neo4j",
+            "annotations": {
+              "cert-manager.io/cluster-issuer": "cluster-issuer",
+              "kubernetes.io/tls-acme": "true",
+              "nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+            }
+          },
+          "spec": {
+            // required for Bolt and secure Neo4j Web Browser
+            "tls": [
+              {
+                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
+                "secretName": "cluster-issuer-private-key"
+              }
+            ],
+            "rules": [
+              {
+                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
+                "http": {
+                  "paths": [
+                    {
+                      "path": "/",
+                      "pathType": "Prefix",
+                      "backend": {
+                        "service": {
+                          "name": "neo4j",
+                          "port": {
+                            "number": 7473
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
         "argo-ingress": {
           "apiVersion": "networking.k8s.io/v1",
           "kind": "Ingress",
@@ -94,18 +150,6 @@
                 }
               }
             ]
-          }
-        },
-        "neo4j-auth-secret": {
-          "apiVersion": "v1",
-          "kind": "Secret",
-          "metadata": {
-            "name": "neo4j-auth-secret",
-            "namespace": "neo4j"
-          },
-          "type": "Opaque",
-          "stringData": {
-            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
           }
         }
       },

--- a/src/templates/ec2/neo4j.jsonc
+++ b/src/templates/ec2/neo4j.jsonc
@@ -68,6 +68,62 @@
         }
       },
       "cluster_manifests": {
+        "neo4j-auth-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "neo4j-auth-secret",
+            "namespace": "neo4j"
+          },
+          "type": "Opaque",
+          "stringData": {
+            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
+          }
+        },
+        "neo4j-ingress": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "neo4j-ingress",
+            "namespace": "neo4j",
+            "annotations": {
+              "cert-manager.io/cluster-issuer": "cluster-issuer",
+              "kubernetes.io/tls-acme": "true",
+              "nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+            }
+          },
+          "spec": {
+            // required for Bolt and secure Neo4j Web Browser
+            "tls": [
+              {
+                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
+                "secretName": "cluster-issuer-private-key"
+              }
+            ],
+            "rules": [
+              {
+                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
+                "http": {
+                  "paths": [
+                    {
+                      "path": "/",
+                      "pathType": "Prefix",
+                      "backend": {
+                        "service": {
+                          "name": "neo4j",
+                          "port": {
+                            "number": 7473
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
         "argo-ingress": {
           "apiVersion": "networking.k8s.io/v1",
           "kind": "Ingress",
@@ -109,18 +165,6 @@
                 }
               }
             ]
-          }
-        },
-        "neo4j-auth-secret": {
-          "apiVersion": "v1",
-          "kind": "Secret",
-          "metadata": {
-            "name": "neo4j-auth-secret",
-            "namespace": "neo4j"
-          },
-          "type": "Opaque",
-          "stringData": {
-            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
           }
         }
       },

--- a/src/templates/eks/neo4j.jsonc
+++ b/src/templates/eks/neo4j.jsonc
@@ -68,6 +68,62 @@
         }
       },
       "cluster_manifests": {
+        "neo4j-auth-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "neo4j-auth-secret",
+            "namespace": "neo4j"
+          },
+          "type": "Opaque",
+          "stringData": {
+            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
+          }
+        },
+        "neo4j-ingress": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "neo4j-ingress",
+            "namespace": "neo4j",
+            "annotations": {
+              "cert-manager.io/cluster-issuer": "cluster-issuer",
+              "kubernetes.io/tls-acme": "true",
+              "nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+            }
+          },
+          "spec": {
+            // required for Bolt and secure Neo4j Web Browser
+            "tls": [
+              {
+                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
+                "secretName": "cluster-issuer-private-key"
+              }
+            ],
+            "rules": [
+              {
+                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
+                "http": {
+                  "paths": [
+                    {
+                      "path": "/",
+                      "pathType": "Prefix",
+                      "backend": {
+                        "service": {
+                          "name": "neo4j",
+                          "port": {
+                            "number": 7473
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
         "argo-ingress": {
           "apiVersion": "networking.k8s.io/v1",
           "kind": "Ingress",
@@ -109,18 +165,6 @@
                 }
               }
             ]
-          }
-        },
-        "neo4j-auth-secret": {
-          "apiVersion": "v1",
-          "kind": "Secret",
-          "metadata": {
-            "name": "neo4j-auth-secret",
-            "namespace": "neo4j"
-          },
-          "type": "Opaque",
-          "stringData": {
-            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
           }
         }
       },

--- a/src/templates/gcp/neo4j.jsonc
+++ b/src/templates/gcp/neo4j.jsonc
@@ -68,6 +68,62 @@
         }
       },
       "cluster_manifests": {
+        "neo4j-auth-secret": {
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": "neo4j-auth-secret",
+            "namespace": "neo4j"
+          },
+          "type": "Opaque",
+          "stringData": {
+            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
+          }
+        },
+        "neo4j-ingress": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "neo4j-ingress",
+            "namespace": "neo4j",
+            "annotations": {
+              "cert-manager.io/cluster-issuer": "cluster-issuer",
+              "kubernetes.io/tls-acme": "true",
+              "nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+              "nginx.ingress.kubernetes.io/backend-protocol": "HTTPS"
+            }
+          },
+          "spec": {
+            // required for Bolt and secure Neo4j Web Browser
+            "tls": [
+              {
+                "hosts": ["{{ $.cndi.prompts.responses.neo4jDomainName }}"],
+                "secretName": "cluster-issuer-private-key"
+              }
+            ],
+            "rules": [
+              {
+                "host": "{{ $.cndi.prompts.responses.neo4jDomainName }}",
+                "http": {
+                  "paths": [
+                    {
+                      "path": "/",
+                      "pathType": "Prefix",
+                      "backend": {
+                        "service": {
+                          "name": "neo4j",
+                          "port": {
+                            "number": 7473
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
         "argo-ingress": {
           "apiVersion": "networking.k8s.io/v1",
           "kind": "Ingress",
@@ -109,18 +165,6 @@
                 }
               }
             ]
-          }
-        },
-        "neo4j-auth-secret": {
-          "apiVersion": "v1",
-          "kind": "Secret",
-          "metadata": {
-            "name": "neo4j-auth-secret",
-            "namespace": "neo4j"
-          },
-          "type": "Opaque",
-          "stringData": {
-            "NEO4J_AUTH": "$.cndi.secrets.seal(NEO4J_PASSWORD)"
           }
         }
       },


### PR DESCRIPTION
# Related issue

#430

# Description

Neo4j Ingress is required to route web traffic into the web GUI, but also in order to bring the TLS secret into scope of the database itself, limited to the domain name supplied in Ingress.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
