### PR TITLE
try to remove old binary at entry

### DIFF
--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -21,7 +21,7 @@ import destroyCommand from "src/commands/destroy.ts";
 import installDependenciesIfRequired from "src/install.ts";
 import installCommand from "src/commands/install.ts";
 
-import { emitExitEvent } from "src/utils.ts";
+import { emitExitEvent, removeOldBinaryIfRequired } from "src/utils.ts";
 
 const cndiLabel = ccolors.faded("\nsrc/cndi.ts:");
 
@@ -40,6 +40,10 @@ export default async function cndi() {
   // ensure CNDI_HOME/bin directory exists before installing deps
   if (!existsSync(path.join(CNDI_HOME, "bin"), { isDirectory: true })) {
     Deno.mkdirSync(path.join(CNDI_HOME, "bin"), { recursive: true });
+  } else {
+    // if cndi was updated in the previous execution, remove the old unused binary
+    // this is necessary because Windows will not allow you to delete a binary while it is running
+    await removeOldBinaryIfRequired(CNDI_HOME);
   }
 
   Deno.env.set("CNDI_STAGING_DIRECTORY", stagingDirectory);

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,4 +1,4 @@
-import { ccolors, path, platform, SpinnerTypes, TerminalSpinner } from "deps";
+import { ccolors, SpinnerTypes, TerminalSpinner } from "deps";
 
 import {
   checkInstalled,
@@ -24,27 +24,6 @@ export default async function installDependenciesIfRequired(
   }: InstallDependenciesIfRequiredOptions,
   force?: boolean,
 ) {
-  const isWindows = platform() === "win32";
-  const pathToGarbageBinary = isWindows
-    ? path.join(CNDI_HOME, "bin", "cndi-old.exe")
-    : path.join(CNDI_HOME, "bin", "cndi-old");
-
-  try {
-    await Deno.remove(pathToGarbageBinary);
-  } catch (error) {
-    if (!(error instanceof Deno.errors.NotFound)) {
-      console.error(
-        installLabel,
-        ccolors.error("\nfailed to delete old"),
-        ccolors.key_name("cndi"),
-        ccolors.error("binary, please try again"),
-      );
-      console.log(ccolors.caught(error, 302));
-      await emitExitEvent(302);
-      Deno.exit(302);
-    }
-  }
-
   if (force || !(await checkInstalled(CNDI_HOME))) {
     console.log(force ? "" : "cndi dependencies not installed!\n");
 


### PR DESCRIPTION
# Description

CNDI now cleans up it's old binary upon launch of the CLI, should that binary exist. This was the intended behaviour but some shuffling was required to ensure that action will succeed.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

