### PR TITLE
`--unstable` is no longer required for our usage of deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ source code as if it were the regular CLI, without colliding with the released
 
 ```bash
 # make sure the path below is correct, pointing to the main.ts file in the repo
-alias cndi-next="deno run -A --unstable ~/dev/polyseam/cndi/main.ts"
+alias cndi-next="deno run -A ~/dev/polyseam/cndi/main.ts"
 ```
 
 We're continually improving CNDI, but if you have an issue, checkout

--- a/deno.json
+++ b/deno.json
@@ -2,14 +2,14 @@
   "version": "1.13.2",
   "deno_version": "1.36.1",
   "tasks": {
-    "compile-win": "deno compile --unstable -A --target x86_64-pc-windows-msvc --output dist/cndi-win.exe main.ts",
-    "compile-linux": "deno compile --unstable -A --target x86_64-unknown-linux-gnu --output dist/cndi-linux main.ts",
-    "compile-mac": "deno compile --unstable -A --target x86_64-apple-darwin --output dist/cndi-mac main.ts",
+    "compile-win": "deno compile --allow-all --target x86_64-pc-windows-msvc --output dist/cndi-win.exe main.ts",
+    "compile-linux": "deno compile --allow-all --target x86_64-unknown-linux-gnu --output dist/cndi-linux main.ts",
+    "compile-mac": "deno compile --allow-all --target x86_64-apple-darwin --output dist/cndi-mac main.ts",
     "compile-all": "deno task compile-win && deno task compile-linux && deno task compile-mac",
     "clean-dist": "rm dist/cndi-mac dist/cndi-linux dist/cndi-win.exe || true",
     "build": "deno lint && deno fmt && deno task clean-dist && deno task compile-all",
-    "test": "deno test --unstable --allow-all",
-    "ft": "deno test --unstable --allow-all --fail-fast"
+    "test": "deno test --allow-all",
+    "ft": "deno test --allow-all --fail-fast"
   },
   "imports": {
     "src/": "./src/",

--- a/src/tests/helpers/run-cndi.ts
+++ b/src/tests/helpers/run-cndi.ts
@@ -12,7 +12,6 @@ const deno = "deno";
 const cmd = [
   "run",
   "--allow-all",
-  "--unstable",
   path.join(getProjectRootDir(), "main.ts"),
 ];
 


### PR DESCRIPTION
# Related issue

#469 


# Description

We remove `--unstable` from calls to `deno run ...`  and `deno compile ...` because we are now using stable APIs exclusively.

# Test Instructions

- [x] run `deno task build` and find no compilation errors
- [x] ensure `deno task test` passes
- [x] complete a cluster lifecycle (`cndi run` can only be properly tested __post merge!__)  

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
