### PR TITLE
set permissions in Action so it works without touching repo settings

### DIFF
--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -9,6 +9,8 @@ const cndiWorkflowObj = {
   },
   jobs: {
     "cndi-run": {
+      // TODO: determine min scope
+      permissions: "read-all|write-all",
       "runs-on": "ubuntu-20.04",
       env: {
         GIT_REPO: "${{ secrets.GIT_REPO }}",

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -10,7 +10,7 @@ const cndiWorkflowObj = {
   jobs: {
     "cndi-run": {
       // TODO: determine min scope
-      permissions: "read-all|write-all",
+      permissions: "write-all",
       "runs-on": "ubuntu-20.04",
       env: {
         GIT_REPO: "${{ secrets.GIT_REPO }}",


### PR DESCRIPTION
# Related issue

#472 

# Description

When deploying to a fresh repo in a fresh GitHub Account the `cndi-run` Action can fail in the `lock` step due to the default repo settings around Action permissions. This should be avoided by declaring the permission required in the Action itself.

# Test Instructions

- [ ] Create a fresh repo with no write permissions and prove the action will run anyway.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

Discovered when running on Sheldon's GitHub where readonly permission is the default.
