### PR TITLE
output yaml to `cndi/cluster_manifests`

### DIFF
--- a/src/cloud-init/microk8s/leader.yml.ts
+++ b/src/cloud-init/microk8s/leader.yml.ts
@@ -6,6 +6,7 @@ import getClusterRepoSecretHTTPSTemplate from "src/outputs/terraform/manifest-te
 import getRootApplicationTemplate from "src/outputs/terraform/manifest-templates/argocd_root_application_manifest.yaml.tftpl.ts";
 
 import {
+  ARGOCD_VERSION,
   DEFAULT_MICROK8S_VERSION,
   KUBESEAL_VERSION,
   MICROK8S_INSTALL_RETRY_INTERVAL,
@@ -84,7 +85,7 @@ const getLeaderCloudInitYaml = (
     "stable";
 
   const DEFAULT_ARGOCD_INSTALL_URL =
-    "https://raw.githubusercontent.com/argoproj/argo-cd/v2.4.22/manifests/install.yaml";
+    `https://raw.githubusercontent.com/argoproj/argo-cd/v${ARGOCD_VERSION}/manifests/install.yaml`;
 
   const userBefore =
     config.infrastructure.cndi?.microk8s?.["cloud-init"]?.leader_before || [];

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,10 +1,11 @@
-import { ccolors, Command, Input, path, Select, SEP, YAML } from "deps";
+import { ccolors, Command, Input, path, Select, SEP } from "deps";
 
 import {
   checkInitialized,
   emitExitEvent,
   getDeploymentTargetFromConfig,
   getPrettyJSONString,
+  getYAMLString,
   loadCndiConfig,
   persistStagedFiles,
   stageFile,
@@ -149,7 +150,7 @@ const initCommand = new Command()
       cndiConfig = templateResult.cndiConfig;
       await stageFile(
         "cndi-config.yaml",
-        YAML.stringify(cndiConfig as unknown as Record<string, unknown>),
+        getYAMLString(cndiConfig),
       );
       readme = templateResult.readme;
       env = templateResult.env;

--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -2,8 +2,8 @@ import { ccolors, Command, path } from "deps";
 
 import {
   emitExitEvent,
-  getPrettyJSONString,
   getStagingDir,
+  getYAMLString,
   loadCndiConfig,
   persistStagedFiles,
   stageFile,
@@ -140,7 +140,7 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
         path.join(
           "cndi",
           "cluster_manifests",
-          "cert-manager-cluster-issuer.json",
+          "cert-manager-cluster-issuer.yaml",
         ),
         getDevClusterIssuerManifest(),
       );
@@ -149,7 +149,7 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
         path.join(
           "cndi",
           "cluster_manifests",
-          "cert-manager-cluster-issuer.json",
+          "cert-manager-cluster-issuer.yaml",
         ),
         getProductionClusterIssuerManifest(cert_manager?.email),
       );
@@ -170,12 +170,12 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
           path.join(
             "cndi",
             "cluster_manifests",
-            "ingress-tcp-services-configmap.json",
+            "ingress-tcp-services-configmap.yaml",
           ),
           getEKSIngressTcpServicesConfigMapManifest(open_ports),
         ),
         stageFile(
-          path.join("cndi", "cluster_manifests", "ingress-service.json"),
+          path.join("cndi", "cluster_manifests", "ingress-service.yaml"),
           getEKSIngressServiceManifest(open_ports),
         ),
       ]);
@@ -185,12 +185,12 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
           path.join(
             "cndi",
             "cluster_manifests",
-            "ingress-tcp-services-configmap.json",
+            "ingress-tcp-services-configmap.yaml",
           ),
           getMicrok8sIngressTcpServicesConfigMapManifest(open_ports),
         ),
         stageFile(
-          path.join("cndi", "cluster_manifests", "ingress-daemonset.json"),
+          path.join("cndi", "cluster_manifests", "ingress-daemonset.yaml"),
           getMicrok8sIngressDaemonsetManifest(open_ports),
         ),
       ]);
@@ -204,7 +204,7 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
 
     if (manifestObj?.kind && manifestObj.kind === "Secret") {
       const secret = cluster_manifests[key] as KubernetesSecret;
-      const secretName = `${key}.json`;
+      const secretName = `${key}.yaml`;
       const sealedSecretManifest = await getSealedSecretManifest(secret, {
         publicKeyFilePath: tempPublicKeyFilePath,
         dotEnvPath,
@@ -222,10 +222,10 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
       }
       continue;
     }
-    const manifestFilename = `${key}.json`;
+    const manifestFilename = `${key}.yaml`;
     await stageFile(
       path.join("cndi", "cluster_manifests", manifestFilename),
-      getPrettyJSONString(manifestObj),
+      getYAMLString(manifestObj),
     );
     console.log(
       ccolors.success("staged manifest:"),
@@ -240,7 +240,7 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
 
   const { applications } = config;
 
-  // write the `cndi/cluster_manifests/applications/${applicationName}.application.json` file for each application
+  // write the `cndi/cluster_manifests/applications/${applicationName}.application.yaml` file for each application
   for (const releaseName in applications) {
     const applicationSpec = applications[releaseName];
     const [manifestContent, filename] = getApplicationManifest(
@@ -284,7 +284,7 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
  * Creates a CNDI cluster by reading the contents of ./cndi
  */
 const overwriteCommand = new Command()
-  .description(`Update cndi project files using cndi-config.jsonc file.`)
+  .description(`Update cndi project files using cndi-config.yaml file.`)
   .alias("ow")
   .option("-f, --file <file:string>", "Path to your cndi-config file.")
   .option(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 const TERRAFORM_VERSION = "1.5.5";
 const KUBESEAL_VERSION = "0.21.0";
 const DEFAULT_MICROK8S_VERSION = "1.27";
+const ARGOCD_VERSION = "2.7.12";
 
 const DEFAULT_INSTANCE_TYPES = {
   aws: "t3.large" as const,
@@ -35,6 +36,7 @@ const DEFAULT_OPEN_PORTS = [
 ] as const;
 
 export {
+  ARGOCD_VERSION,
   DEFAULT_INSTANCE_TYPES,
   DEFAULT_MICROK8S_VERSION,
   DEFAULT_NODE_DISK_SIZE,

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -58,7 +58,7 @@ const manifestFramework = {
     source: {
       helm: {
         version: DEFAULT_HELM_VERSION,
-        values: {},
+        valuesObject: {},
       },
     },
     destination: {
@@ -72,7 +72,7 @@ const getApplicationManifest = (
   releaseName: string,
   applicationSpec: CNDIApplicationSpec,
 ): [string, string] => {
-  const values = applicationSpec?.values || {};
+  const valuesObject = applicationSpec?.values || {};
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
 
@@ -109,7 +109,7 @@ const getApplicationManifest = (
         targetRevision: applicationSpec.targetRevision,
         helm: {
           ...manifestFramework.spec.source.helm,
-          values,
+          valuesObject,
         },
       },
       destination: {

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -58,7 +58,6 @@ const manifestFramework = {
     source: {
       helm: {
         version: DEFAULT_HELM_VERSION,
-        valuesObject: {},
       },
     },
     destination: {
@@ -72,7 +71,7 @@ const getApplicationManifest = (
   releaseName: string,
   applicationSpec: CNDIApplicationSpec,
 ): [string, string] => {
-  const valuesObject = applicationSpec?.values || {};
+  const values = getYAMLString(applicationSpec?.values || {});
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
 
@@ -106,10 +105,11 @@ const getApplicationManifest = (
         ...manifestFramework.spec.source,
         repoURL: applicationSpec.repoURL,
         path: applicationSpec.path,
+        chart: applicationSpec.chart,
         targetRevision: applicationSpec.targetRevision,
         helm: {
           ...manifestFramework.spec.source.helm,
-          valuesObject,
+          values, // TODO: use valuesObject it's a bit more readable etc.
         },
       },
       destination: {

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -1,6 +1,6 @@
 import { ccolors } from "deps";
+import { getYAMLString } from "src/utils.ts";
 
-import { getPrettyJSONString } from "src/utils.ts";
 export interface CNDIApplicationSpec {
   targetRevision: string;
   repoURL: string;
@@ -58,6 +58,7 @@ const manifestFramework = {
     source: {
       helm: {
         version: DEFAULT_HELM_VERSION,
+        values: {},
       },
     },
     destination: {
@@ -71,10 +72,7 @@ const getApplicationManifest = (
   releaseName: string,
   applicationSpec: CNDIApplicationSpec,
 ): [string, string] => {
-  // TODO: helm and argo require that values be passed into argocd as a string when using a helm chart repo instead of git
-  // This means that we need to have this very ugly string in the manifests that we generate
-  const values = JSON.stringify(applicationSpec.values ?? {});
-
+  const values = applicationSpec?.values || {};
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
 
@@ -109,7 +107,6 @@ const getApplicationManifest = (
         repoURL: applicationSpec.repoURL,
         path: applicationSpec.path,
         targetRevision: applicationSpec.targetRevision,
-        chart: applicationSpec.chart,
         helm: {
           ...manifestFramework.spec.source.helm,
           values,
@@ -121,7 +118,8 @@ const getApplicationManifest = (
       },
     },
   };
-  return [getPrettyJSONString(manifest), `${releaseName}.application.json`];
+
+  return [getYAMLString(manifest), `${releaseName}.application.yaml`];
 };
 
 export default getApplicationManifest;

--- a/src/outputs/cert-manager-manifests/production-cluster-issuer.ts
+++ b/src/outputs/cert-manager-manifests/production-cluster-issuer.ts
@@ -1,5 +1,5 @@
 import { ccolors } from "deps";
-import { getPrettyJSONString } from "src/utils.ts";
+import { getYAMLString } from "src/utils.ts";
 
 const _productionClusterIssuerManifestLabel = ccolors.faded(
   "\nsrc/outputs/production-cluster-issuer.ts:",
@@ -34,7 +34,7 @@ const getProductionClusterIssuerManifest = (
     },
   };
 
-  return getPrettyJSONString(manifest);
+  return getYAMLString(manifest);
 };
 
 export default getProductionClusterIssuerManifest;

--- a/src/outputs/cert-manager-manifests/self-signed/dev-cluster-issuer.ts
+++ b/src/outputs/cert-manager-manifests/self-signed/dev-cluster-issuer.ts
@@ -1,5 +1,5 @@
 import { ccolors } from "deps";
-import { getPrettyJSONString } from "src/utils.ts";
+import { getYAMLString } from "src/utils.ts";
 
 const _devClusterIssuerManifestLabel = ccolors.faded(
   "\nsrc/outputs/self-signed/dev-cluster-issuer.ts:",
@@ -16,7 +16,7 @@ const getDevClusterIssuerManifest = (): string => {
       selfSigned: {},
     },
   };
-  return getPrettyJSONString(manifest);
+  return getYAMLString(manifest);
 };
 
 export default getDevClusterIssuerManifest;

--- a/src/outputs/custom-port-manifests/eks/ingress-service.ts
+++ b/src/outputs/custom-port-manifests/eks/ingress-service.ts
@@ -1,7 +1,7 @@
 import { ccolors } from "deps";
 
-import { getPrettyJSONString } from "src/utils.ts";
 import { CNDIPort } from "src/types.ts";
+import { getYAMLString } from "src/utils.ts";
 
 const ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
   "\nsrc/outputs/custom-port-manifests/eks/ingress-service.ts:",
@@ -91,7 +91,7 @@ const getIngressServiceManifest = (
     },
   };
 
-  return getPrettyJSONString(manifest);
+  return getYAMLString(manifest);
 };
 
 export default getIngressServiceManifest;

--- a/src/outputs/custom-port-manifests/eks/ingress-tcp-services-configmap.ts
+++ b/src/outputs/custom-port-manifests/eks/ingress-tcp-services-configmap.ts
@@ -1,7 +1,7 @@
 import { ccolors } from "deps";
 
-import { getPrettyJSONString } from "src/utils.ts";
 import { CNDIPort } from "src/types.ts";
+import { getYAMLString } from "src/utils.ts";
 
 const ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
   "\nsrc/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts:",
@@ -62,7 +62,7 @@ const getIngressTcpServicesConfigMapManifest = (
       `${port.namespace}/${port.service}:${port.number}`;
   });
 
-  return getPrettyJSONString(manifest);
+  return getYAMLString(manifest);
 };
 
 export default getIngressTcpServicesConfigMapManifest;

--- a/src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts
+++ b/src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts
@@ -1,7 +1,7 @@
 import { ccolors } from "deps";
 
-import { getPrettyJSONString } from "src/utils.ts";
 import { CNDIPort } from "src/types.ts";
+import { getYAMLString } from "src/utils.ts";
 
 const _ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
   "\nsrc/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts:",
@@ -177,7 +177,7 @@ const getIngressDaemonSetManifest = (
     },
   };
 
-  return getPrettyJSONString(manifest);
+  return getYAMLString(manifest);
 };
 
 export default getIngressDaemonSetManifest;

--- a/src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts
+++ b/src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts
@@ -1,7 +1,7 @@
 import { ccolors } from "deps";
 
-import { getPrettyJSONString } from "src/utils.ts";
 import { CNDIPort } from "src/types.ts";
+import { getYAMLString } from "src/utils.ts";
 
 const ingressTcpServicesConfigMapManifestLabel = ccolors.faded(
   "\nsrc/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts:",
@@ -62,7 +62,7 @@ const getIngressTcpServicesConfigMapManifest = (
       `${port.namespace}/${port.service}:${port.number}`;
   });
 
-  return getPrettyJSONString(manifest);
+  return getYAMLString(manifest);
 };
 
 export default getIngressTcpServicesConfigMapManifest;

--- a/src/outputs/sealed-secret-manifest.ts
+++ b/src/outputs/sealed-secret-manifest.ts
@@ -3,7 +3,7 @@ import { KubernetesSecret, KubernetesSecretWithStringData } from "src/types.ts";
 import {
   emitExitEvent,
   getPathToKubesealBinary,
-  getPrettyJSONString,
+  getYAMLString,
 } from "src/utils.ts";
 
 const CNDI_SECRETS_PREFIX = "$.cndi.secrets.seal(";
@@ -213,7 +213,7 @@ const getSealedSecretManifest = async (
 
   await Deno.writeTextFile(
     secretPath,
-    getPrettyJSONString(secretWithStringData),
+    getYAMLString(secretWithStringData),
     secretFileOptions,
   );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,6 +24,15 @@ import emitTelemetryEvent from "src/telemetry/telemetry.ts";
 
 const utilsLabel = ccolors.faded("src/utils.ts:");
 
+// YAML.stringify but easier to work with
+function getYAMLString(object: unknown, skipInvalid = true): string {
+  // if the object contains an undefined, skipInvalid will not write the key
+  // skipInvalid: true is most similar to JSON.stringify
+  return YAML.stringify(object as Record<string, unknown>, {
+    skipInvalid,
+  });
+}
+
 async function sha256Digest(message: string): Promise<string> {
   const msgUint8 = new TextEncoder().encode(message); // encode as (utf-8) Uint8Array
   const hashBuffer = await crypto.subtle.digest("SHA-256", msgUint8); // hash the message
@@ -447,9 +456,7 @@ async function persistStagedFiles(targetDirectory: string) {
   await Deno.remove(stagingDirectory, { recursive: true });
 }
 
-async function checkInstalled(
-  CNDI_HOME: string,
-) {
+async function checkInstalled(CNDI_HOME: string) {
   try {
     // if any of these files/folders don't exist, return false
     await Promise.all([
@@ -609,6 +616,7 @@ export {
   getTFData,
   getTFResource,
   getUserDataTemplateFileString,
+  getYAMLString,
   loadCndiConfig,
   loadJSONC,
   loadYAML,

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -229,8 +229,8 @@ export default async function validateConfig(
     Deno.exit(906);
   }
 
-  const numberOfNodesWithRoleLeader =
-    config?.infrastructure?.cndi?.nodes?.filter(
+  const numberOfNodesWithRoleLeader = config?.infrastructure?.cndi?.nodes
+    ?.filter(
       ({ role }) => role === "leader",
     ).length;
 


### PR DESCRIPTION
# Related issue

#477 

# Description

When we are writing Kubernetes manifests we now output YAML strings to files instead of JSON strings.

# Test Instructions

- Run `cndi ow` and ensure the resulting files are valid YAML for Kubernetes to read

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

