### PR TITLE
Eks multi nodegroup

### DIFF
--- a/src/outputs/terraform/aws-eks/cndi_argocd_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_argocd_helm_chart.tf.json.ts
@@ -1,13 +1,13 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 
-export default function getArgoATFJSON(): string {
+export default function getArgoATFJSON(firstNodeGroupName: string): string {
   const resource = getTFResource("helm_release", {
     chart: "argo-cd",
     cleanup_on_fail: true,
     create_namespace: "true",
     depends_on: [
       "aws_efs_file_system.cndi_aws_efs_file_system",
-      "aws_eks_node_group.cndi_aws_eks_node_group",
+      `aws_eks_node_group.cndi_aws_eks_node_group_${firstNodeGroupName}`,
     ],
     timeout: "600",
     atomic: true,

--- a/src/outputs/terraform/aws-eks/cndi_aws_eks_node_group.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_aws_eks_node_group.tf.json.ts
@@ -16,7 +16,7 @@ export default function getAWSEKServiceNodeGroupTFJSON(
     ami_type: "AL2_x86_64",
     disk_size,
     instance_types: [instance_type],
-    node_group_name: node?.name,
+    node_group_name: node.name,
     node_role_arn: "${aws_iam_role.cndi_aws_iam_role_eks_ec2.arn}",
     scaling_config: [{ desired_size, max_size, min_size }],
     capacity_type: "ON_DEMAND",
@@ -29,7 +29,7 @@ export default function getAWSEKServiceNodeGroupTFJSON(
       "aws_iam_role_policy_attachment.cndi_aws_iam_role_policy_attachment_eks_cni_policy",
       "aws_iam_role_policy_attachment.cndi_aws_iam_role_policy_attachment_ec2_container_registry_readonly",
     ],
-  });
+  }, `cndi_aws_eks_node_group_${node.name}`);
 
   return getPrettyJSONString(resource);
 }

--- a/src/outputs/terraform/aws-eks/cndi_cert_manager_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_cert_manager_helm_chart.tf.json.ts
@@ -1,10 +1,14 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 
-export default function getCertManagerTFJSON(): string {
+export default function getCertManagerTFJSON(
+  firstNodeGroupName: string,
+): string {
   const resource = getTFResource("helm_release", {
     chart: "cert-manager",
     create_namespace: true,
-    depends_on: ["aws_eks_node_group.cndi_aws_eks_node_group"],
+    depends_on: [
+      `aws_eks_node_group.cndi_aws_eks_node_group_${firstNodeGroupName}`,
+    ],
     name: "cert-manager",
     namespace: "cert-manager",
     repository: "https://charts.jetstack.io",

--- a/src/outputs/terraform/aws-eks/cndi_nginx_controller_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_nginx_controller_helm_chart.tf.json.ts
@@ -1,10 +1,14 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 
-export default function getNginxControllerTFJSON(): string {
+export default function getNginxControllerTFJSON(
+  firstNodeGroupName: string,
+): string {
   const resource = getTFResource("helm_release", {
     chart: "ingress-nginx",
     create_namespace: true,
-    depends_on: ["aws_eks_node_group.cndi_aws_eks_node_group"],
+    depends_on: [
+      `aws_eks_node_group.cndi_aws_eks_node_group_${firstNodeGroupName}`,
+    ],
     name: "ingress-nginx",
     namespace: "ingress",
     repository: "https://kubernetes.github.io/ingress-nginx",

--- a/src/outputs/terraform/aws-eks/cndi_sealed_secrets_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_sealed_secrets_helm_chart.tf.json.ts
@@ -1,10 +1,12 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 
-export default function getSealedSecretsTFJSON(): string {
+export default function getSealedSecretsTFJSON(
+  firstNodeGroupName: string,
+): string {
   const resource = getTFResource("helm_release", {
     chart: "sealed-secrets",
     depends_on: [
-      "aws_eks_node_group.cndi_aws_eks_node_group",
+      `aws_eks_node_group.cndi_aws_eks_node_group_${firstNodeGroupName}`,
       "kubectl_manifest.cndi_sealed_secrets_secret_manifest",
     ],
     name: "sealed-secrets",

--- a/src/outputs/terraform/aws-eks/cndi_sealed_secrets_secret_manifest.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_sealed_secrets_secret_manifest.tf.json.ts
@@ -1,8 +1,12 @@
 import { getPrettyJSONString, getTFResource } from "src/utils.ts";
 
-export default function getSecretSealedSecretsTFJSON(): string {
+export default function getSecretSealedSecretsTFJSON(
+  firstNodeGroupName: string,
+): string {
   const resource = getTFResource("kubectl_manifest", {
-    depends_on: ["aws_eks_node_group.cndi_aws_eks_node_group"],
+    depends_on: [
+      `aws_eks_node_group.cndi_aws_eks_node_group_${firstNodeGroupName}`,
+    ],
     yaml_body: "${data.template_file.sealed_secrets_secret_manifest.rendered}",
   }, "cndi_sealed_secrets_secret_manifest");
   return getPrettyJSONString(resource);

--- a/src/outputs/terraform/aws-eks/data.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/data.tf.json.ts
@@ -2,104 +2,96 @@ import { getPrettyJSONString } from "src/utils.ts";
 
 export default function getAWSDataTFJSON(): string {
   return getPrettyJSONString({
-    "data": {
-      "aws_eks_cluster": {
-        "cndi_aws_eks_cluster": {
-          "name": "${aws_eks_cluster.cndi_aws_eks_cluster.name}",
+    data: {
+      aws_eks_cluster: {
+        cndi_aws_eks_cluster: {
+          name: "${aws_eks_cluster.cndi_aws_eks_cluster.name}",
         },
       },
 
-      "aws_eks_cluster_auth": {
-        "cndi_aws_eks_cluster_auth": {
-          "name": "${aws_eks_cluster.cndi_aws_eks_cluster.name}",
+      aws_eks_cluster_auth: {
+        cndi_aws_eks_cluster_auth: {
+          name: "${aws_eks_cluster.cndi_aws_eks_cluster.name}",
         },
       },
 
-      "tls_certificate": {
-        "cndi_tls_certificate": {
-          "url":
+      tls_certificate: {
+        cndi_tls_certificate: {
+          url:
             "${aws_eks_cluster.cndi_aws_eks_cluster.identity[0].oidc[0].issuer}",
         },
       },
 
-      "aws_availability_zones": {
-        "cndi_aws_availability_zones": {
-          "state": "available",
+      aws_availability_zones: {
+        cndi_aws_availability_zones: {
+          state: "available",
         },
       },
 
-      "aws_eks_node_group": {
-        "cndi_aws_eks_node_group": {
-          "cluster_name": "${aws_eks_cluster.cndi_aws_eks_cluster.name}",
-          "node_group_name":
-            "${aws_eks_node_group.cndi_aws_eks_node_group.node_group_name}",
-        },
-      },
+      // TODO: figure out why this was here
+      // aws_eks_node_group: {
+      //   cndi_aws_eks_node_group: {
+      //     cluster_name: "${aws_eks_cluster.cndi_aws_eks_cluster.name}",
+      //     node_group_name: `\${aws_eks_node_group.${firstNodeGroupName}.node_group_name}`,
+      //   },
+      // },
 
-      "aws_caller_identity": {
-        "cndi_aws_caller_identity": {},
+      aws_caller_identity: {
+        cndi_aws_caller_identity: {},
       },
-      "aws_iam_policy_document": {
-        "cndi_aws_iam_policy_document_eks_ec2_role": {
-          "statement": [
+      aws_iam_policy_document: {
+        cndi_aws_iam_policy_document_eks_ec2_role: {
+          statement: [
             {
-              "actions": [
-                "sts:AssumeRole",
-              ],
-              "effect": "Allow",
-              "principals": [
+              actions: ["sts:AssumeRole"],
+              effect: "Allow",
+              principals: [
                 {
-                  "identifiers": [
-                    "eks.amazonaws.com",
-                  ],
-                  "type": "Service",
+                  identifiers: ["eks.amazonaws.com"],
+                  type: "Service",
                 },
                 {
-                  "identifiers": [
-                    "ec2.amazonaws.com",
-                  ],
-                  "type": "Service",
+                  identifiers: ["ec2.amazonaws.com"],
+                  type: "Service",
                 },
               ],
             },
           ],
         },
-        "cndi_aws_iam_policy_document_web_identity_policy": {
-          "depends_on": [
+        cndi_aws_iam_policy_document_web_identity_policy: {
+          depends_on: [
             "aws_iam_openid_connect_provider.cndi_aws_iam_openid_connect_provider",
           ],
-          "statement": [
+          statement: [
             {
-              "actions": [
-                "sts:AssumeRoleWithWebIdentity",
-              ],
-              "condition": [
+              actions: ["sts:AssumeRoleWithWebIdentity"],
+              condition: [
                 {
-                  "test": "StringEquals",
-                  "values": [
+                  test: "StringEquals",
+                  values: [
                     "system:serviceaccount:kube-system:efs-csi-controller-sa",
                     "system:serviceaccount:kube-system:ebs-csi-controller-sa",
                   ],
-                  "variable":
+                  variable:
                     '${replace(aws_iam_openid_connect_provider.cndi_aws_iam_openid_connect_provider.url, "https://", "")}:sub',
                 },
               ],
-              "effect": "Allow",
-              "principals": [
+              effect: "Allow",
+              principals: [
                 {
-                  "identifiers": [
+                  identifiers: [
                     "${aws_iam_openid_connect_provider.cndi_aws_iam_openid_connect_provider.arn}",
                   ],
-                  "type": "Federated",
+                  type: "Federated",
                 },
               ],
             },
           ],
         },
-        "cndi_aws_iam_policy_document_permissions": {
-          "statement": [
+        cndi_aws_iam_policy_document_permissions: {
+          statement: [
             {
-              "actions": [
+              actions: [
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
                 "autoscaling:DescribeLaunchConfigurations",
@@ -123,100 +115,79 @@ export default function getAWSDataTFJSON(): string {
                 "elasticfilesystem:DescribeMountTargets",
                 "ec2:DescribeAvailabilityZones",
               ],
-              "effect": "Allow",
-              "resources": [
-                "*",
-              ],
+              effect: "Allow",
+              resources: ["*"],
             },
             {
-              "actions": [
-                "elasticfilesystem:CreateAccessPoint",
-              ],
-              "condition": [
+              actions: ["elasticfilesystem:CreateAccessPoint"],
+              condition: [
                 {
-                  "test": "StringLike",
-                  "values": [
-                    "true",
-                  ],
-                  "variable": "aws:RequestTag/efs.csi.aws.com/cluster",
+                  test: "StringLike",
+                  values: ["true"],
+                  variable: "aws:RequestTag/efs.csi.aws.com/cluster",
                 },
               ],
-              "effect": "Allow",
-              "resources": [
-                "*",
-              ],
+              effect: "Allow",
+              resources: ["*"],
             },
             {
-              "actions": [
-                "elasticfilesystem:TagResource",
-              ],
-              "condition": [
+              actions: ["elasticfilesystem:TagResource"],
+              condition: [
                 {
-                  "test": "StringLike",
-                  "values": [
-                    "true",
-                  ],
-                  "variable": "aws:ResourceTag/efs.csi.aws.com/cluster",
+                  test: "StringLike",
+                  values: ["true"],
+                  variable: "aws:ResourceTag/efs.csi.aws.com/cluster",
                 },
               ],
-              "effect": "Allow",
-              "resources": [
-                "*",
-              ],
+              effect: "Allow",
+              resources: ["*"],
             },
             {
-              "actions": [
-                "elasticfilesystem:DeleteAccessPoint",
-              ],
-              "condition": [
+              actions: ["elasticfilesystem:DeleteAccessPoint"],
+              condition: [
                 {
-                  "test": "StringEquals",
-                  "values": [
-                    "true",
-                  ],
-                  "variable": "aws:ResourceTag/efs.csi.aws.com/cluster",
+                  test: "StringEquals",
+                  values: ["true"],
+                  variable: "aws:ResourceTag/efs.csi.aws.com/cluster",
                 },
               ],
-              "effect": "Allow",
-              "resources": [
-                "*",
-              ],
+              effect: "Allow",
+              resources: ["*"],
             },
           ],
         },
       },
-      "template_file": {
-        "argocd_private_repo_secret_manifest": {
-          "template":
-            '${file("argocd_private_repo_secret_manifest.yaml.tftpl")}',
-          "vars": {
-            "git_password": "${var.git_password}",
-            "git_repo": "${var.git_repo}",
-            "git_username": "${var.git_username}",
+      template_file: {
+        argocd_private_repo_secret_manifest: {
+          template: '${file("argocd_private_repo_secret_manifest.yaml.tftpl")}',
+          vars: {
+            git_password: "${var.git_password}",
+            git_repo: "${var.git_repo}",
+            git_username: "${var.git_username}",
           },
         },
-        "sealed_secrets_secret_manifest": {
-          "template": '${file("sealed_secrets_secret_manifest.yaml.tftpl")}',
-          "vars": {
-            "sealed_secret_cert_pem":
+        sealed_secrets_secret_manifest: {
+          template: '${file("sealed_secrets_secret_manifest.yaml.tftpl")}',
+          vars: {
+            sealed_secret_cert_pem:
               "${base64encode(var.sealed_secrets_public_key)}",
-            "sealed_secret_private_key_pem":
+            sealed_secret_private_key_pem:
               "${base64encode(var.sealed_secrets_private_key)}",
           },
         },
-        "argocd_root_application_manifest": {
-          "template": '${file("argocd_root_application_manifest.yaml.tftpl")}',
-          "vars": {
-            "git_repo": "${var.git_repo}",
+        argocd_root_application_manifest: {
+          template: '${file("argocd_root_application_manifest.yaml.tftpl")}',
+          vars: {
+            git_repo: "${var.git_repo}",
           },
         },
-        "argocd_admin_password_secret_manifest": {
-          "template":
+        argocd_admin_password_secret_manifest: {
+          template:
             '${file("argocd_admin_password_secret_manifest.yaml.tftpl")}',
-          "vars": {
-            "admin_password_time":
+          vars: {
+            admin_password_time:
               '${time_static.cndi_time_static_admin_password_update.id}")}',
-            "argocd_admin_password":
+            argocd_admin_password:
               "${bcrypt_hash.cndi_bcrypt_hash_argocd_admin_password.id}",
           },
         },

--- a/src/outputs/terraform/aws-eks/stageAll.ts
+++ b/src/outputs/terraform/aws-eks/stageAll.ts
@@ -81,6 +81,10 @@ export default async function stageTerraformResourcesForAWS(
     )
   );
 
+  // we want all k8s manifests to wait until the first node group is ready
+  // so we pull the node group name from the first entry in the nodes array
+  const firstNodeGroupName = config.infrastructure.cndi.nodes[0].name;
+
   const privateRepoSecret = useSshRepoAuth()
     ? getArgoPrivateRepoSecretSSHYamlTftpl()
     : getArgoPrivateRepoSecretHTTPSYamlTftpl();
@@ -99,18 +103,12 @@ export default async function stageTerraformResourcesForAWS(
           aws_region,
         }),
       ),
-      stageFile(
-        path.join("cndi", "terraform", "provider.tf.json"),
-        provider(),
-      ),
+      stageFile(path.join("cndi", "terraform", "provider.tf.json"), provider()),
       stageFile(
         path.join("cndi", "terraform", "terraform.tf.json"),
         terraform(),
       ),
-      stageFile(
-        path.join("cndi", "terraform", "data.tf.json"),
-        data(),
-      ),
+      stageFile(path.join("cndi", "terraform", "data.tf.json"), data()),
       stageFile(
         path.join(
           "cndi",
@@ -161,7 +159,7 @@ export default async function stageTerraformResourcesForAWS(
           "terraform",
           "cndi_sealed_secrets_secret_manifest.tf.json",
         ),
-        cndi_sealed_secrets_secret_manifest(),
+        cndi_sealed_secrets_secret_manifest(firstNodeGroupName),
       ),
       stageFile(
         path.join(
@@ -180,12 +178,8 @@ export default async function stageTerraformResourcesForAWS(
         cndi_argocd_root_application_manifest(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_argocd_helm_chart.tf.json",
-        ),
-        cndi_argocd_helm_chart(),
+        path.join("cndi", "terraform", "cndi_argocd_helm_chart.tf.json"),
+        cndi_argocd_helm_chart(firstNodeGroupName),
       ),
       stageFile(
         path.join(
@@ -193,30 +187,18 @@ export default async function stageTerraformResourcesForAWS(
           "terraform",
           "cndi_sealed_secrets_helm_chart.tf.json",
         ),
-        cndi_sealed_secrets_helm_chart(),
+        cndi_sealed_secrets_helm_chart(firstNodeGroupName),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_cert_manager_helm_chart.tf.json",
-        ),
-        cndi_cert_manager_helm_chart(),
+        path.join("cndi", "terraform", "cndi_cert_manager_helm_chart.tf.json"),
+        cndi_cert_manager_helm_chart(firstNodeGroupName),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_ebs_driver_helm_chart.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_ebs_driver_helm_chart.tf.json"),
         cndi_ebs_driver_helm_chart(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_efs_driver_helm_chart.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_efs_driver_helm_chart.tf.json"),
         cndi_efs_driver_helm_chart(),
       ),
       stageFile(
@@ -225,15 +207,11 @@ export default async function stageTerraformResourcesForAWS(
           "terraform",
           "cndi_nginx_controller_helm_chart.tf.json",
         ),
-        cndi_nginx_controller_helm_chart(),
+        cndi_nginx_controller_helm_chart(firstNodeGroupName),
       ),
 
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_internet_gateway.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_internet_gateway.tf.json"),
         cndi_aws_internet_gateway(),
       ),
 
@@ -254,19 +232,11 @@ export default async function stageTerraformResourcesForAWS(
         cndi_bcrypt_hash_argocd_admin_password(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_efs_access_point.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_efs_access_point.tf.json"),
         cndi_aws_efs_access_point(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_efs_file_system.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_efs_file_system.tf.json"),
         cndi_aws_efs_file_system(),
       ),
       stageFile(
@@ -342,11 +312,7 @@ export default async function stageTerraformResourcesForAWS(
         cndi_aws_iam_openid_connect_provider(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_iam_role_eks_ec2.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_iam_role_eks_ec2.tf.json"),
         cndi_aws_iam_role_eks_ec2(),
       ),
 
@@ -359,28 +325,16 @@ export default async function stageTerraformResourcesForAWS(
         cndi_aws_iam_role_web_identity_policy(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_efs_mount_target_a.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_efs_mount_target_a.tf.json"),
         cndi_aws_efs_mount_target_a(),
       ),
 
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_eip.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_eip.tf.json"),
         cndi_aws_eip(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_eks_cluster.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_eks_cluster.tf.json"),
         cndi_aws_eks_cluster(),
       ),
       stageFile(
@@ -392,11 +346,7 @@ export default async function stageTerraformResourcesForAWS(
         cndi_aws_iam_openid_connect_provider(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_nat_gateway.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_nat_gateway.tf.json"),
         cndi_aws_nat_gateway(),
       ),
       stageFile(
@@ -424,19 +374,11 @@ export default async function stageTerraformResourcesForAWS(
         cndi_aws_route_table_association_private_b(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_route_table_private.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_route_table_private.tf.json"),
         cndi_aws_route_table_private(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_route_table_public.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_route_table_public.tf.json"),
         cndi_aws_route_table_public(),
       ),
       stageFile(
@@ -448,11 +390,7 @@ export default async function stageTerraformResourcesForAWS(
         cndi_aws_route_public(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_security_group.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_security_group.tf.json"),
         cndi_aws_security_group(ports),
       ),
       stageFile(
@@ -468,11 +406,7 @@ export default async function stageTerraformResourcesForAWS(
         cndi_aws_subnet_private_b(),
       ),
       stageFile(
-        path.join(
-          "cndi",
-          "terraform",
-          "cndi_aws_vpc.tf.json",
-        ),
+        path.join("cndi", "terraform", "cndi_aws_vpc.tf.json"),
         cndi_aws_vpc(),
       ),
     ]);

--- a/src/tests/commands/init_test.ts
+++ b/src/tests/commands/init_test.ts
@@ -630,6 +630,18 @@ Deno.test(
 );
 
 Deno.test(
+  "'cndi init -t eks/neo4j' should generate terraform files such that the filenames and resource names are the same",
+  async (t) => {
+    await t.step(setup);
+    await t.step("test", async () => {
+      const { status } = await runCndi("init", "-t", "eks/neo4j");
+      assert(status.success);
+      await ensureResourceNamesMatchFileNames();
+    });
+  },
+);
+
+Deno.test(
   "'cndi init -t eks/airflow' should generate a .env file with AWS credentials",
   async (t) => {
     await t.step(setup);


### PR DESCRIPTION
# Description

EKS was previously only allowed a single node entry in CNDI config, used to declare a node group. This PR enables multiple entries, each entry corresponding to a node group. To support this, helm_release resources now depend on the first node group instead of the _only_ node group.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
