### PR TITLE
EKS Template Fixes

### DIFF
--- a/src/templates/eks/basic.yaml
+++ b/src/templates/eks/basic.yaml
@@ -17,6 +17,7 @@ outputs:
         nodes:
           - name: my-nodes
             kind: eks
+            instance_type: t3.large
             volume_size: 128
             max_count: 3
     cluster_manifests:

--- a/src/templates/eks/cnpg.yaml
+++ b/src/templates/eks/cnpg.yaml
@@ -46,7 +46,7 @@ outputs:
             namespace: '{{ $.cndi.prompts.responses.pgNamespace }}'
             service: '{{ $.cndi.prompts.responses.postgresqlClusterName }}-rw'
         nodes:
-          - name: pg-nodes
+          - name: cnpg-nodes
             kind: eks
             instance_type: t3.large
             volume_size: 128

--- a/src/templates/eks/mongodb.yaml
+++ b/src/templates/eks/mongodb.yaml
@@ -46,7 +46,7 @@ outputs:
             namespace: '{{ $.cndi.prompts.responses.mongodbNamespace }}'
             service: mongodb-replica-set-svc
         nodes:
-          - name: pg-nodes
+          - name: mongodb-nodes
             kind: eks
             instance_type: t3.large
             volume_size: 128

--- a/src/templates/eks/mysql.yaml
+++ b/src/templates/eks/mysql.yaml
@@ -40,8 +40,9 @@ outputs:
             namespace: '{{ $.cndi.prompts.responses.innodbNamespace }}'
             service: '{{ $.cndi.prompts.responses.clusterServiceName}}'
         nodes:
-          - name: my-nodes
+          - name: mysql-nodes
             kind: eks
+            instance_type: t3.large
             volume_size: 128
             max_count: 3
     cluster_manifests:

--- a/src/templates/eks/neo4j.yaml
+++ b/src/templates/eks/neo4j.yaml
@@ -32,16 +32,11 @@ outputs:
             service: neo4j
             namespace: neo4j
         nodes:
-          - name: neo4j-main
+          - name: neo4j-nodes
             kind: eks
-            role: leader
+            instance_type: t3.large
             volume_size: 128
-          - name: neo4j-a
-            kind: eks
-            volume_size: 128
-          - name: neo4j-b
-            kind: eks
-            volume_size: 128
+            max_count: 3
     cluster_manifests:
       neo4j-auth-secret:
         apiVersion: v1


### PR DESCRIPTION
# Related issue

#486 

# Description

- The `eks/neo4j` used to deliver a `nodes` array which would result in a failed deployment. It now renders a node_group like the other `eks` templates.
- Other Templates were also tweaked to have better node group names
- `instance_type` is literal instead of implicit for transparencies sake

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct
