### PR TITLE
do not replace ec2 node if `user_data` changes

### DIFF
--- a/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
@@ -45,7 +45,7 @@ export default function getAWSComputeInstanceTFJSON(
       root_block_device,
       subnet_id,
       vpc_security_group_ids,
-      user_data_replace_on_change: true, // TODO: decide if this is the right default
+      user_data_replace_on_change: false,
       user_data,
       depends_on,
     },


### PR DESCRIPTION
# Description

EC2 instances were configured to redeploy when their `#cloud-config` file changed. This made sense for debugging, however if the file was edited in a future version of CNDI and overwritten, this node replacement could represent downtime or even lost data.


# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
