### PR TITLE
Fix ingress and add eks lb output

### DIFF
--- a/src/outputs/cert-manager-manifests/production-cluster-issuer.ts
+++ b/src/outputs/cert-manager-manifests/production-cluster-issuer.ts
@@ -25,7 +25,7 @@ const getProductionClusterIssuerManifest = (
           {
             http01: {
               ingress: {
-                class: "public",
+                ingressClassName: "public",
               },
             },
           },

--- a/src/outputs/terraform/aws-eks/cndi_argocd_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_argocd_helm_chart.tf.json.ts
@@ -15,7 +15,7 @@ export default function getArgoATFJSON(firstNodeGroupName: string): string {
     namespace: "argocd",
     replace: true,
     repository: "https://argoproj.github.io/argo-helm",
-    version: "5.26.3",
+    version: "5.45.0",
   }, "cndi_argocd_helm_chart");
   return getPrettyJSONString(resource);
 }

--- a/src/outputs/terraform/aws-eks/cndi_cert_manager_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_cert_manager_helm_chart.tf.json.ts
@@ -13,7 +13,7 @@ export default function getCertManagerTFJSON(
     namespace: "cert-manager",
     repository: "https://charts.jetstack.io",
     set: [{ name: "installCRDs", value: "true" }],
-    version: "1.11.1",
+    version: "1.12.3",
     timeout: "600",
     atomic: true,
   }, "cndi_cert_manager_helm_chart");

--- a/src/outputs/terraform/aws-eks/cndi_ebs_driver_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_ebs_driver_helm_chart.tf.json.ts
@@ -21,7 +21,7 @@ export default function getEBSCSIDriverTFJSON(): string {
         value: "${aws_iam_role.cndi_aws_iam_role_web_identity_policy.arn}",
       },
     ],
-    version: "2.17.2",
+    version: "2.22.0",
   }, "cndi_ebs_driver_helm_chart");
   return getPrettyJSONString(resource);
 }

--- a/src/outputs/terraform/aws-eks/cndi_efs_driver_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_efs_driver_helm_chart.tf.json.ts
@@ -51,7 +51,7 @@ export default function getEFSCSIDriverTFJSON(): string {
         value: "700",
       },
     ],
-    version: "2.4.1",
+    version: "2.4.9",
   }, "cndi_efs_driver_helm_chart");
   return getPrettyJSONString(resource);
 }

--- a/src/outputs/terraform/aws-eks/cndi_nginx_controller_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_nginx_controller_helm_chart.tf.json.ts
@@ -33,7 +33,7 @@ export default function getNginxControllerTFJSON(
         "value": "ingress/ingress-nginx-controller",
       },
     ],
-    version: "4.6.0",
+    version: "4.7.1",
   }, "cndi_nginx_controller_helm_chart");
   return getPrettyJSONString(resource);
 }

--- a/src/outputs/terraform/aws-eks/cndi_outputs.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_outputs.tf.json.ts
@@ -7,6 +7,10 @@ export default function getOutputTFJSON(): string {
         value:
           "https://${upper(local.aws_region)}.console.aws.amazon.com/resource-groups/group/CNDIResourceGroup_${local.cndi_project_name}?region=${upper(local.aws_region)}",
       },
+      public_host: {
+        value:
+          "${replace(data.aws_lb.cndi_aws_lb.dns_name,local.aws_region,upper(local.aws_region))}",
+      },
     },
   });
 }

--- a/src/outputs/terraform/aws-eks/cndi_sealed_secrets_helm_chart.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/cndi_sealed_secrets_helm_chart.tf.json.ts
@@ -12,7 +12,7 @@ export default function getSealedSecretsTFJSON(
     name: "sealed-secrets",
     namespace: "kube-system",
     repository: "https://bitnami-labs.github.io/sealed-secrets",
-    version: "2.7.0",
+    version: "2.12.0",
   }, "cndi_sealed_secrets_helm_chart");
   return getPrettyJSONString(resource);
 }

--- a/src/outputs/terraform/aws-eks/data.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/data.tf.json.ts
@@ -13,6 +13,9 @@ export default function getAWSDataTFJSON(): string {
           tags: {
             "kubernetes.io/cluster/${local.cndi_project_name}": "owned",
           },
+          depends_on: [
+            "helm_release.cndi_nginx_controller_helm_chart",
+          ],
         },
       },
       aws_eks_cluster_auth: {

--- a/src/outputs/terraform/aws-eks/data.tf.json.ts
+++ b/src/outputs/terraform/aws-eks/data.tf.json.ts
@@ -8,7 +8,13 @@ export default function getAWSDataTFJSON(): string {
           name: "${aws_eks_cluster.cndi_aws_eks_cluster.name}",
         },
       },
-
+      aws_lb: {
+        cndi_aws_lb: {
+          tags: {
+            "kubernetes.io/cluster/${local.cndi_project_name}": "owned",
+          },
+        },
+      },
       aws_eks_cluster_auth: {
         cndi_aws_eks_cluster_auth: {
           name: "${aws_eks_cluster.cndi_aws_eks_cluster.name}",


### PR DESCRIPTION
# Related issue
Solving issue where ingress and cert manager wasn't resolving

# Description
Updating helm charts for eks to the latest version
Changing the ingress class to ingressClassName for all clouds to meet the new standard
(https://cert-manager.io/docs/configuration/acme/http01/)

# Test Instructions

Run an eks and ec2 cluster and connect to your argocd domain
# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
