### PR TITLE
[Enhancement]: use kia (mit licensed) for spinners

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -2,7 +2,7 @@ import {
   ccolors,
   GithubProvider,
   platform,
-  SpinnerTypes,
+  Spinners,
   TerminalSpinner,
   UpgradeCommand,
   UpgradeOptions,
@@ -26,7 +26,7 @@ class GitHubBinaryUpgradeProvider extends GithubProvider {
       text: `Upgrading ${name} from ${from} to version ${to}...`,
       color: "cyan",
       indent: 2,
-      spinner: SpinnerTypes.windows,
+      spinner: Spinners.windows,
       writer: Deno.stdout,
     });
 

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -45,11 +45,11 @@ export { simpleGit } from "npm:simple-git@3.18.0";
 //  - crypto-js
 import CryptoJS from "npm:crypto-js@4.1.1";
 
-//  - spinners
+// spinners
 export {
-  SpinnerTypes,
-  TerminalSpinner,
-} from "https://deno.land/x/spinners@v1.1.2/mod.ts";
+  default as TerminalSpinner,
+  Spinners,
+} from "https://deno.land/x/kia@0.4.1/mod.ts";
 
 // import/export required
 export { CryptoJS };

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,4 +1,4 @@
-import { ccolors, SpinnerTypes, TerminalSpinner } from "deps";
+import { ccolors, Spinners, TerminalSpinner } from "deps";
 
 import {
   checkInstalled,
@@ -33,7 +33,7 @@ export default async function installDependenciesIfRequired(
       text: "installing cndi dependencies...",
       color: "cyan",
       indent: 2,
-      spinner: SpinnerTypes.windows,
+      spinner: Spinners.windows,
       writer: Deno.stdout,
     });
 


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #519

# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

We were previously using a library called [spinners](https://github.com/michael-spengler/spinners) which had no OSS license. It really just wrapped Kia and so we replaced it with Kia.

# Test Instructions

- Ensure CNDI displays a nice spinner when `cndi upgrade --force` is called

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
