### PR TITLE
enable specifying a cndi git ref to use in the gh workflow

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -52,6 +52,13 @@ const initCommand = new Command()
   .option("-d, --debug", "Create a cndi project in debug mode.", {
     hidden: true,
   })
+  .option(
+    "-w, --workflow-ref <ref:string>",
+    "Specify a ref to build a cndi workflow with",
+    {
+      hidden: true,
+    },
+  )
   .action(async (options) => {
     let template: string | undefined = options.template;
     let cndiConfig: CNDIConfig;
@@ -203,7 +210,7 @@ const initCommand = new Command()
 
     await stageFile(
       path.join(".github", "workflows", "cndi-run.yaml"),
-      getCndiRunGitHubWorkflowYamlContents(),
+      getCndiRunGitHubWorkflowYamlContents(options?.workflowRef),
     );
 
     await stageFile(".gitignore", getGitignoreContents());

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -97,5 +97,104 @@ const cndiWorkflowObj = {
   },
 };
 
-const getWorkflowYaml = () => YAML.stringify(cndiWorkflowObj);
+const getWorkflowYaml = (sourceRef?: string) => {
+  // export action which uses pre-built cndi binaries
+  if (!sourceRef) return YAML.stringify(cndiWorkflowObj);
+
+  // export action which builds cndi on the fly to verify a particular git ref
+  const steps = [
+    {
+      name: "welcome",
+      run: `echo "welcome to cndi@${sourceRef}!"`,
+    },
+    {
+      id: "lock-check",
+      uses: "github/lock@v2.0.1",
+      with: {
+        mode: "check",
+        environment: "global",
+      },
+    },
+    {
+      name: "fail if locked",
+      if: "${{ steps.lock-check.outputs.locked != 'false' }}",
+      run: "echo \"cndi cannot 'run': deployment in progress\" && exit 1",
+    },
+    {
+      id: "lock-acquire",
+      uses: "github/lock@v2.0.1",
+      with: {
+        mode: "lock",
+        environment: "global",
+      },
+    },
+    {
+      name: "checkout cndi repo",
+      uses: "actions/checkout@v3",
+      with: {
+        repository: "polyseam/cndi",
+        "fetch-depth": 0,
+        ref: sourceRef,
+      },
+    },
+    {
+      name: "setup deno",
+      uses: "denoland/setup-deno@v1",
+    },
+    {
+      name: "build cndi",
+      run: "deno task build",
+    },
+    {
+      name: "persist cndi",
+      run:
+        "mkdir -p $HOME/.cndi/bin && mv ./dist/cndi-linux $HOME/.cndi/bin/cndi",
+    },
+    {
+      name: "cndi install",
+      run: "$HOME/.cndi/bin/cndi install", // even though we install automatically in run.ts, we expect this has more performant caching
+    },
+    {
+      name: "checkout repo",
+      uses: "actions/checkout@v3",
+      with: {
+        "fetch-depth": 0,
+      },
+    },
+    {
+      name: "cndi run",
+      run: "$HOME/.cndi/bin/cndi run",
+      env: {
+        GIT_USERNAME: "${{ secrets.GIT_USERNAME }}",
+        GIT_PASSWORD: "${{ secrets.GIT_PASSWORD }}",
+        GIT_SSH_PRIVATE_KEY: "${{ secrets.GIT_SSH_PRIVATE_KEY }}",
+        TERRAFORM_STATE_PASSPHRASE: "${{ secrets.TERRAFORM_STATE_PASSPHRASE }}",
+        SEALED_SECRETS_PRIVATE_KEY: "${{ secrets.SEALED_SECRETS_PRIVATE_KEY }}",
+        SEALED_SECRETS_PUBLIC_KEY: "${{ secrets.SEALED_SECRETS_PUBLIC_KEY }}",
+        ARGOCD_ADMIN_PASSWORD: "${{ secrets.ARGOCD_ADMIN_PASSWORD }}",
+        AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}",
+        AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+        AWS_REGION: "${{ secrets.AWS_REGION }}",
+        GOOGLE_CREDENTIALS: "${{ secrets.GOOGLE_CREDENTIALS }}",
+        ARM_REGION: "${{ secrets.ARM_REGION }}",
+        ARM_SUBSCRIPTION_ID: "${{ secrets.ARM_SUBSCRIPTION_ID }}",
+        ARM_TENANT_ID: "${{ secrets.ARM_TENANT_ID }}",
+        ARM_CLIENT_ID: "${{ secrets.ARM_CLIENT_ID }}",
+        ARM_CLIENT_SECRET: "${{ secrets.ARM_CLIENT_SECRET }}",
+        CNDI_TELEMETRY: "${{ secrets.CNDI_TELEMETRY }}",
+      },
+    },
+    {
+      id: "lock-release",
+      uses: "github/lock@v2.0.1",
+      if: "always()", // always release the lock even if `cndi run` fails
+      with: {
+        mode: "unlock",
+        environment: "global",
+      },
+    },
+  ];
+  cndiWorkflowObj.jobs["cndi-run"].steps = steps;
+  return YAML.stringify(cndiWorkflowObj);
+};
 export default getWorkflowYaml;


### PR DESCRIPTION
# Description

Before this change it was not possible to test any uncompiled version of CNDI. The workflow called in actions would only support downloading compiled versions of CNDI, which included `"main"` and any release tag.

This pull request circumvents the issue by providing a flag to use when initializing the cndi repo:

```bash
cndi init -i -d -w my-branchname
# or use a commit SHA
cndi init -i -d -w 66549a892394acaba1a57065e86787820987a380
# or any other valid git ref
```

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
