### PR TITLE
pass node_hostname into leader cloud-init

### DIFF
--- a/src/cloud-init/microk8s/follower.yml.ts
+++ b/src/cloud-init/microk8s/follower.yml.ts
@@ -46,6 +46,7 @@ const getFollowerCloudInitYaml = (
 
   // https://cloudinit.readthedocs.io/en/latest/reference/examples.html
   const content = {
+    hostname: "${node_hostname}",
     package_update: true,
     package_upgrade: false, // TODO: is package_upgrade:true better?
     packages: [

--- a/src/cloud-init/microk8s/leader.yml.ts
+++ b/src/cloud-init/microk8s/leader.yml.ts
@@ -39,7 +39,7 @@ const getMicrok8sAddons = (config: CNDIConfig): Array<Microk8sAddon> => {
     addons.push({ name: "hostpath-storage" });
   } else {
     // dev cluster addons
-    addons.push({ name: "nfs" });
+    addons.push({ name: "nfs", args: ["-n", "${node_hostname}"] });
   }
 
   const userAddons = config.infrastructure.cndi?.microk8s?.addons;
@@ -149,6 +149,7 @@ const getLeaderCloudInitYaml = (
 
   // https://cloudinit.readthedocs.io/en/latest/reference/examples.html
   const content = {
+    hostname: "${node_hostname}",
     package_update: true,
     package_upgrade: false, // TODO: is package_upgrade:true better?
     packages,

--- a/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
+++ b/src/outputs/terraform/aws-ec2/cndi_aws_instance.tf.json.ts
@@ -30,7 +30,10 @@ export default function getAWSComputeInstanceTFJSON(
     },
   ];
   const leaderAWSInstance = `aws_instance.cndi_aws_instance_${leaderNodeName}`;
-  const user_data = getUserDataTemplateFileString(role);
+  const user_data = getUserDataTemplateFileString({
+    node_hostname: name,
+    role,
+  });
   const depends_on = role !== "leader" ? [leaderAWSInstance] : [];
 
   const resource = getTFResource(

--- a/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
+++ b/src/outputs/terraform/azure/cndi_azurerm_linux_virtual_machine.tf.json.ts
@@ -25,7 +25,9 @@ export default function getAzureComputeInstanceTFJSON(
 
   // azure uses 'size' to describe the machine type, oof
   if (
-    node?.size && typeof node.size === "string" && !node?.machine_type &&
+    node?.size &&
+    typeof node.size === "string" &&
+    !node?.machine_type &&
     !node?.instance_type
   ) {
     machine_type = node.size;
@@ -73,7 +75,10 @@ export default function getAzureComputeInstanceTFJSON(
     CNDIProject: "${local.cndi_project_name}",
   };
 
-  const user_data = getUserDataTemplateFileString(role, true);
+  const user_data = getUserDataTemplateFileString(
+    { node_hostname: name, role },
+    true,
+  );
   const depends_on = role !== "leader" ? [leaderComputeInstance] : [];
 
   const resource = getTFResource(

--- a/src/outputs/terraform/dev/cndi_local_sensitive_file.tf.json.ts
+++ b/src/outputs/terraform/dev/cndi_local_sensitive_file.tf.json.ts
@@ -4,12 +4,14 @@ import {
   getUserDataTemplateFileString,
 } from "src/utils.ts";
 
-export default function getMultipassLocalSensitiveFileTFJSON(): string {
+export default function getMultipassLocalSensitiveFileTFJSON(
+  node_hostname: string,
+): string {
   const resource = getTFResource("local_sensitive_file", {
     // node_hostname is not consumed by multipass so it is empty
     content: getUserDataTemplateFileString({
       role: "leader",
-      node_hostname: "",
+      node_hostname,
     }),
     filename: "microk8s-cloud-init-leader-hardcoded-values.yml.tftpl",
   });

--- a/src/outputs/terraform/dev/cndi_local_sensitive_file.tf.json.ts
+++ b/src/outputs/terraform/dev/cndi_local_sensitive_file.tf.json.ts
@@ -6,7 +6,11 @@ import {
 
 export default function getMultipassLocalSensitiveFileTFJSON(): string {
   const resource = getTFResource("local_sensitive_file", {
-    content: getUserDataTemplateFileString("leader"),
+    // node_hostname is not consumed by multipass so it is empty
+    content: getUserDataTemplateFileString({
+      role: "leader",
+      node_hostname: "",
+    }),
     filename: "microk8s-cloud-init-leader-hardcoded-values.yml.tftpl",
   });
 

--- a/src/outputs/terraform/dev/stageAll.ts
+++ b/src/outputs/terraform/dev/stageAll.ts
@@ -40,7 +40,7 @@ export default async function stageTerraformResourcesForDev(
       ),
       stageFile(
         path.join("cndi", "terraform", "cndi_local_sensitive_file.tf.json"),
-        cndi_local_sensitive_file(),
+        cndi_local_sensitive_file(node.name),
       ),
       stageFile(
         path.join("cndi", "terraform", "cndi_outputs.tf.json"),

--- a/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
+++ b/src/outputs/terraform/gcp/cndi_google_compute_instance.tf.json.ts
@@ -37,7 +37,10 @@ export default function getGCPComputeInstanceTFJSON(
     },
   ];
 
-  const user_data = getUserDataTemplateFileString(role);
+  const user_data = getUserDataTemplateFileString({
+    role,
+    node_hostname: name,
+  });
   const depends_on = role !== "leader" ? [leaderComputeInstance] : [];
 
   const resource = getTFResource(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -552,12 +552,12 @@ function getUserDataTemplateFileString(
     // this value contains base64 encoded values for git_repo and git_ssh_private_key
     // it's required in order to support multiline values in cloud-init
     leaderString =
-      'templatefile("microk8s-cloud-init-leader.yml.tftpl",{"bootstrap_token": "${local.bootstrap_token}", "git_repo_encoded": "${base64encode(var.git_repo)}", "git_repo": "${var.git_repo}", "git_ssh_private_key": "${base64encode(var.git_ssh_private_key)}", "sealed_secrets_private_key": "${base64encode(var.sealed_secrets_private_key)}", "sealed_secrets_public_key": "${base64encode(var.sealed_secrets_public_key)}", "argocd_admin_password": "${var.argocd_admin_password}"})';
+      `templatefile("microk8s-cloud-init-leader.yml.tftpl",{"node_hostname":"${node_info.node_hostname}","bootstrap_token": "\${local.bootstrap_token}", "git_repo_encoded": "\${base64encode(var.git_repo)}", "git_repo": "\${var.git_repo}", "git_ssh_private_key": "\${base64encode(var.git_ssh_private_key)}", "sealed_secrets_private_key": "\${base64encode(var.sealed_secrets_private_key)}", "sealed_secrets_public_key": "\${base64encode(var.sealed_secrets_public_key)}", "argocd_admin_password": "\${var.argocd_admin_password}"})`;
   }
   let workerString =
-    'templatefile("microk8s-cloud-init-worker.yml.tftpl",{"bootstrap_token": "${local.bootstrap_token}", "leader_node_ip": "${local.leader_node_ip}"})';
+    `templatefile("microk8s-cloud-init-worker.yml.tftpl",{"node_hostname":"${node_info.node_hostname}","bootstrap_token": "\${local.bootstrap_token}", "leader_node_ip": "\${local.leader_node_ip}"})`;
   let controllerString =
-    'templatefile("microk8s-cloud-init-controller.yml.tftpl",{"bootstrap_token": "${local.bootstrap_token}", "leader_node_ip": "${local.leader_node_ip}"})';
+    `templatefile("microk8s-cloud-init-controller.yml.tftpl",{"node_hostname":"${node_info.node_hostname}","bootstrap_token": "\${local.bootstrap_token}", "leader_node_ip": "\${local.leader_node_ip}"})`;
 
   if (doBase64Encode) {
     leaderString = `\${base64encode(${leaderString})}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -537,12 +537,17 @@ function base10intToHex(decimal: number): string {
   return hex;
 }
 
+type UserDataNodeInfo = {
+  role?: NodeRole;
+  node_hostname: string;
+};
+
 function getUserDataTemplateFileString(
-  role?: NodeRole,
+  node_info: UserDataNodeInfo,
   doBase64Encode?: boolean,
 ) {
   let leaderString =
-    'templatefile("microk8s-cloud-init-leader.yml.tftpl",{"bootstrap_token": "${local.bootstrap_token}", "git_repo": "${var.git_repo}", "git_password": "${var.git_password}", "git_username": "${var.git_username}", "sealed_secrets_private_key": "${base64encode(var.sealed_secrets_private_key)}", "sealed_secrets_public_key": "${base64encode(var.sealed_secrets_public_key)}", "argocd_admin_password": "${var.argocd_admin_password}"})';
+    `templatefile("microk8s-cloud-init-leader.yml.tftpl",{"node_hostname":"${node_info.node_hostname}","bootstrap_token": "\${local.bootstrap_token}", "git_repo": "\${var.git_repo}", "git_password": "\${var.git_password}", "git_username": "\${var.git_username}", "sealed_secrets_private_key": "\${base64encode(var.sealed_secrets_private_key)}", "sealed_secrets_public_key": "\${base64encode(var.sealed_secrets_public_key)}", "argocd_admin_password": "\${var.argocd_admin_password}"})`;
   if (useSshRepoAuth()) {
     // this value contains base64 encoded values for git_repo and git_ssh_private_key
     // it's required in order to support multiline values in cloud-init
@@ -564,7 +569,7 @@ function getUserDataTemplateFileString(
     controllerString = `\${${controllerString}}`;
   }
 
-  switch (role) {
+  switch (node_info.role) {
     case "leader":
       return leaderString;
     case "worker":


### PR DESCRIPTION

# Description

Setting `cloud_config.hostname` so that it can be consumed downstream for things like nfs.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
