### PR TITLE
disable argocd HA mode because it requires >2 nodes

### DIFF
--- a/src/cloud-init/microk8s/leader.yml.ts
+++ b/src/cloud-init/microk8s/leader.yml.ts
@@ -82,7 +82,7 @@ const getLeaderCloudInitYaml = (
     "stable";
 
   const DEFAULT_ARGOCD_INSTALL_URL =
-    `https://raw.githubusercontent.com/argoproj/argo-cd/v${ARGOCD_VERSION}/manifests/ha/install.yaml`;
+    `https://raw.githubusercontent.com/argoproj/argo-cd/v${ARGOCD_VERSION}/manifests/install.yaml`;
 
   const userBefore =
     config.infrastructure.cndi?.microk8s?.["cloud-init"]?.leader_before || [];


### PR DESCRIPTION
# Description

ArgoCD was configured to use HA, but we've since learned this causes it to fail in a cluster with fewer than 3 nodes.

We would like to conditionally enable it when there are 3 nodes available, but first we will return to the previous non-HA mode until then.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
