### PR TITLE
upgrade deno version to `1.38.0`

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.36.1
+          deno-version: v1.38.0
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main-latest.yaml
+++ b/.github/workflows/main-latest.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.36.1
+          deno-version: v1.38.0
 
       - run: deno lint
 
@@ -28,7 +28,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.36.1
+          deno-version: v1.38.0
 
       - run: deno task build
           

--- a/.github/workflows/main-pull.yml
+++ b/.github/workflows/main-pull.yml
@@ -12,7 +12,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.36.1
+          deno-version: v1.38.0
       
       - name: Check formatting
         run: deno fmt --check

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "version": "1.16.0",
-  "deno_version": "1.36.4",
+  "deno_version": "1.38.0",
   "tasks": {
     "compile-win": "deno compile --allow-all --target x86_64-pc-windows-msvc --output dist/cndi-win.exe main.ts",
     "compile-linux": "deno compile --allow-all --target x86_64-unknown-linux-gnu --output dist/cndi-linux main.ts",

--- a/docs/cloud-setup-guide/aws/aws-setup.md
+++ b/docs/cloud-setup-guide/aws/aws-setup.md
@@ -86,11 +86,9 @@ have access keys, you can create them from the AWS Management Console.
 
 In the end you should have all the credentials for a cluster deployment on AWS
 
-- **Access key ID** - Access keys pair
-  \
+- **Access key ID** - Access keys pair\
   Example access key ID : _AKIAIOSFODNN7EXAMPLEID_
-- **Secret access key** - Access keys pair
-  \
+- **Secret access key** - Access keys pair\
   Example secret access key: _wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY_
 
 ## Conclusion

--- a/docs/cloud-setup-guide/azure/azure-setup.md
+++ b/docs/cloud-setup-guide/azure/azure-setup.md
@@ -122,8 +122,7 @@ contributor role once you finish adding the Contributor role
 
 ![Assign role](/docs/cloud-setup-guide/azure/img/review-assign.png)
 
-6. Click Review + assign to assign the role.
-   \
+6. Click Review + assign to assign the role.\
    After a few moments, the security principal is assigned the role at the
    selected scope.
 

--- a/src/tests/commands/init_test.ts
+++ b/src/tests/commands/init_test.ts
@@ -9,11 +9,7 @@ import gcpKeyFile from "src/tests/mocks/example-gcp-key.ts";
 
 import { getPrettyJSONString } from "src/utils.ts";
 
-import {
-  getRunningCNDIProcess,
-  runCndi,
-  //   runCndiLoud,
-} from "src/tests/helpers/run-cndi.ts";
+import { getRunningCNDIProcess, runCndi } from "src/tests/helpers/run-cndi.ts";
 
 import processInteractiveEntries from "src/tests/helpers/processInteractiveEntries.ts";
 
@@ -27,19 +23,9 @@ import getProjectRootDir from "get-project-root";
 
 Deno.env.set("CNDI_TELEMETRY", "debug");
 
-// get a clean empty sandbox for each test
-function prepareSandbox() {
+Deno.test("'cndi init' with cndi-config.yaml", async (t) => {
   const dir = Deno.makeTempDirSync();
   Deno.chdir(dir);
-}
-
-const setup = {
-  fn: prepareSandbox,
-  name: "setup",
-};
-
-Deno.test("'cndi init' with cndi-config.yaml", async (t) => {
-  await t.step(setup);
   await t.step("test", async () => {
     const initFileList = new Set([
       "cndi-config.yaml",
@@ -65,10 +51,13 @@ Deno.test("'cndi init' with cndi-config.yaml", async (t) => {
     assert(initFileList.size === 0); // if the set is empty, all files were created
     assert(status.success);
   });
+  Deno.chdir("..");
+  Deno.removeSync(dir, { recursive: true });
 });
 
 Deno.test("'cndi init' with cndi-config.jsonc", async (t) => {
-  await t.step(setup);
+  const dir = Deno.makeTempDirSync();
+  Deno.chdir(dir);
   await t.step("test", async () => {
     const initFileList = new Set([
       "cndi-config.jsonc",
@@ -94,25 +83,31 @@ Deno.test("'cndi init' with cndi-config.jsonc", async (t) => {
     assert(initFileList.size === 0); // if the set is empty, all files were created
     assert(status.success);
   });
+  Deno.chdir("..");
+  Deno.removeSync(dir, { recursive: true });
 });
 
 Deno.test(
   "'cndi init -d' should set CNDI_TELEMETRY=debug in .env",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "aws/airflow", "-d");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
       assert(dotenv.indexOf(`CNDI_TELEMETRY=debug`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init' without any flags or config files present should fail",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -121,13 +116,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init' should create a readme that begins with the 'project_name'",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const project_name = "my-foo-project";
       Deno.writeTextFileSync(
@@ -139,13 +137,16 @@ Deno.test(
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
       assert(readme.startsWith(`# ${project_name}`));
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init' should fail if no cndi-config file or flags are present",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -154,13 +155,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are multiple nodes where kind=='dev'",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.jsonc`),
@@ -181,13 +185,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there is no 'project_name'",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.jsonc`),
@@ -204,13 +211,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are no cndi nodes",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const nodelessCndiConfig = {
         ...basicAWSCndiConfig,
@@ -227,13 +237,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are multiple different node kinds",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "cndi" },
@@ -257,13 +270,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there is no cndi node where role=='leader'",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "cndi" },
@@ -287,13 +303,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are more than one cndi node where role=='leader'",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "cndi", role: "leader" },
@@ -317,13 +336,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are multiple cndi nodes with the same 'name'",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "foo", role: "leader" },
@@ -347,13 +369,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if open_ports are not correctly specified",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const stringOpenPortsConfig = {
         ...basicAWSCndiConfig,
@@ -372,13 +397,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config: should allow 'open_ports' for infrastructure only (no manifests)",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.jsonc`),
@@ -404,13 +432,16 @@ Deno.test(
         })),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "cndi-config: 'open_ports' should work properly when fully specified",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.yaml`),
@@ -442,13 +473,16 @@ Deno.test(
         })),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t foo' should throw an error because 'foo' is not a valid template",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -457,13 +491,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t ec2/foo' should throw an error because 'ec2/foo' is not a valid template",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -478,7 +515,8 @@ Deno.test(
 Deno.test(
   "'cndi init -t https://example.com/does-not-exist.jsonc' should throw an error because there is no template found there",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -491,13 +529,16 @@ Deno.test(
         }),
       );
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t $VALID_JSONC_TEMPLATE_URL' should generate a project successfully",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const initFileList = new Set([
         "cndi-config.yaml",
@@ -523,13 +564,16 @@ Deno.test(
       assert(initFileList.size === 0); // if the set is empty, all files were created
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t $VALID_YAML_TEMPLATE_URL' should generate a project successfully",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const initFileList = new Set([
         "cndi-config.yaml",
@@ -555,13 +599,16 @@ Deno.test(
       assert(initFileList.size === 0); // if the set is empty, all files were created
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t file://path/to/valid/template.yaml' should generate a project successfully",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const initFileList = new Set([
         "cndi-config.yaml",
@@ -597,13 +644,16 @@ Deno.test(
       assert(initFileList.size === 0); // if the set is empty, all files were created
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t ec2/airflow' should generate a README.md that references Airflow and ec2",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "ec2/airflow");
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
@@ -617,7 +667,8 @@ Deno.test(
 Deno.test(
   "'cndi init -t ec2/airflow' should generate a .env file with AWS credentials",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "ec2/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -627,13 +678,16 @@ Deno.test(
       assert(dotenv.indexOf(`AWS_ACCESS_KEY_ID`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t eks/neo4j' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "eks/neo4j");
       assert(status.success);
@@ -645,7 +699,8 @@ Deno.test(
 Deno.test(
   "'cndi init -t eks/airflow' should generate a .env file with AWS credentials",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "eks/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -655,13 +710,16 @@ Deno.test(
       assert(dotenv.indexOf(`AWS_ACCESS_KEY_ID`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t ec2/airflow' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "ec2/airflow");
       assert(status.success);
@@ -673,7 +731,8 @@ Deno.test(
 Deno.test(
   "'cndi init -t gcp/neo4j' should generate a README.md that references Neo4j and GCP",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gcp/neo4j");
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
@@ -681,13 +740,16 @@ Deno.test(
       assert(readme.indexOf(`## gcp`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t gcp/neo4j' should generate a .env file with GCP credentials",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gcp/neo4j");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -696,37 +758,46 @@ Deno.test(
       assert(dotenv.indexOf(`GOOGLE_CREDENTIALS`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t gce/neo4j' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gce/neo4j");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t gke/neo4j' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gke/neo4j");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t azure/mongodb' should generate a README.md that references MongoDB and Azure",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "azure/mongodb");
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
@@ -734,13 +805,16 @@ Deno.test(
       assert(readme.indexOf(`## azure`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t avm/airflow' should generate a .env file with Azure credentials",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "avm/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -752,13 +826,16 @@ Deno.test(
       assert(dotenv.indexOf(`ARM_SUBSCRIPTION_ID`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t aks/airflow' should generate a .env file with Azure credentials",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "aks/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -770,37 +847,46 @@ Deno.test(
       assert(dotenv.indexOf(`ARM_SUBSCRIPTION_ID`) > -1);
       assert(status.success);
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t avm/mongodb' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "avm/mongodb");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -t aks/airflow' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "aks/airflow");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -i -t azure/basic' should generate a project given interactive input",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "azure/basic");
 
@@ -838,13 +924,16 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -i -t ec2/basic' should generate a project given interactive input",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "ec2/basic");
 
@@ -880,13 +969,16 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -i -t eks/basic' should generate a project given interactive input",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "eks/basic");
       // this object is ordered!!
@@ -921,13 +1013,16 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );
 
 Deno.test(
   "'cndi init -i -t gcp/basic' should generate a project given interactive input",
   async (t) => {
-    await t.step(setup);
+    const dir = Deno.makeTempDirSync();
+    Deno.chdir(dir);
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "gcp/basic");
 
@@ -965,5 +1060,7 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
+    Deno.chdir("..");
+    Deno.removeSync(dir, { recursive: true });
   },
 );

--- a/src/tests/commands/init_test.ts
+++ b/src/tests/commands/init_test.ts
@@ -24,8 +24,12 @@ import getProjectRootDir from "get-project-root";
 Deno.env.set("CNDI_TELEMETRY", "debug");
 
 Deno.test("'cndi init' with cndi-config.yaml", async (t) => {
-  const dir = Deno.makeTempDirSync();
-  Deno.chdir(dir);
+  let dir = "";
+  await t.step("setup", async () => {
+    dir = await Deno.makeTempDir();
+    Deno.chdir(dir);
+  });
+
   await t.step("test", async () => {
     const initFileList = new Set([
       "cndi-config.yaml",
@@ -51,13 +55,19 @@ Deno.test("'cndi init' with cndi-config.yaml", async (t) => {
     assert(initFileList.size === 0); // if the set is empty, all files were created
     assert(status.success);
   });
-  Deno.chdir("..");
-  Deno.removeSync(dir, { recursive: true });
+  await t.step("cleanup", async () => {
+    Deno.chdir("..");
+    await Deno.remove(dir, { recursive: true });
+  });
 });
 
 Deno.test("'cndi init' with cndi-config.jsonc", async (t) => {
-  const dir = Deno.makeTempDirSync();
-  Deno.chdir(dir);
+  let dir = "";
+  await t.step("setup", async () => {
+    dir = await Deno.makeTempDir();
+    Deno.chdir(dir);
+  });
+
   await t.step("test", async () => {
     const initFileList = new Set([
       "cndi-config.jsonc",
@@ -83,23 +93,31 @@ Deno.test("'cndi init' with cndi-config.jsonc", async (t) => {
     assert(initFileList.size === 0); // if the set is empty, all files were created
     assert(status.success);
   });
-  Deno.chdir("..");
-  Deno.removeSync(dir, { recursive: true });
+  await t.step("cleanup", async () => {
+    Deno.chdir("..");
+    await Deno.remove(dir, { recursive: true });
+  });
 });
 
 Deno.test(
   "'cndi init -d' should set CNDI_TELEMETRY=debug in .env",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "aws/airflow", "-d");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
       assert(dotenv.indexOf(`CNDI_TELEMETRY=debug`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("setup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
@@ -116,16 +134,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init' should create a readme that begins with the 'project_name'",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const project_name = "my-foo-project";
       Deno.writeTextFileSync(
@@ -137,16 +161,22 @@ Deno.test(
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
       assert(readme.startsWith(`# ${project_name}`));
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init' should fail if no cndi-config file or flags are present",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -155,16 +185,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are multiple nodes where kind=='dev'",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.jsonc`),
@@ -185,16 +221,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there is no 'project_name'",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.jsonc`),
@@ -211,16 +253,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are no cndi nodes",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const nodelessCndiConfig = {
         ...basicAWSCndiConfig,
@@ -237,16 +285,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are multiple different node kinds",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "cndi" },
@@ -270,16 +324,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there is no cndi node where role=='leader'",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "cndi" },
@@ -303,16 +363,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are more than one cndi node where role=='leader'",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "cndi", role: "leader" },
@@ -336,16 +402,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if there are multiple cndi nodes with the same 'name'",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const nodes = [
         { kind: "gcp", name: "foo", role: "leader" },
@@ -369,16 +441,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config validation: should fail if open_ports are not correctly specified",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const stringOpenPortsConfig = {
         ...basicAWSCndiConfig,
@@ -397,16 +475,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config: should allow 'open_ports' for infrastructure only (no manifests)",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.jsonc`),
@@ -432,16 +516,22 @@ Deno.test(
         })),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "cndi-config: 'open_ports' should work properly when fully specified",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       Deno.writeTextFileSync(
         path.join(Deno.cwd(), `cndi-config.yaml`),
@@ -473,16 +563,22 @@ Deno.test(
         })),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t foo' should throw an error because 'foo' is not a valid template",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -491,16 +587,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t ec2/foo' should throw an error because 'ec2/foo' is not a valid template",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       assert(
         await hasSameFilesAfter(async () => {
@@ -529,16 +631,22 @@ Deno.test(
         }),
       );
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t $VALID_JSONC_TEMPLATE_URL' should generate a project successfully",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const initFileList = new Set([
         "cndi-config.yaml",
@@ -564,16 +672,22 @@ Deno.test(
       assert(initFileList.size === 0); // if the set is empty, all files were created
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t $VALID_YAML_TEMPLATE_URL' should generate a project successfully",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const initFileList = new Set([
         "cndi-config.yaml",
@@ -599,16 +713,22 @@ Deno.test(
       assert(initFileList.size === 0); // if the set is empty, all files were created
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t file://path/to/valid/template.yaml' should generate a project successfully",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const initFileList = new Set([
         "cndi-config.yaml",
@@ -644,16 +764,22 @@ Deno.test(
       assert(initFileList.size === 0); // if the set is empty, all files were created
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t ec2/airflow' should generate a README.md that references Airflow and ec2",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "ec2/airflow");
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
@@ -667,8 +793,12 @@ Deno.test(
 Deno.test(
   "'cndi init -t ec2/airflow' should generate a .env file with AWS credentials",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "ec2/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -678,16 +808,22 @@ Deno.test(
       assert(dotenv.indexOf(`AWS_ACCESS_KEY_ID`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t eks/neo4j' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "eks/neo4j");
       assert(status.success);
@@ -699,8 +835,12 @@ Deno.test(
 Deno.test(
   "'cndi init -t eks/airflow' should generate a .env file with AWS credentials",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "eks/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -710,16 +850,22 @@ Deno.test(
       assert(dotenv.indexOf(`AWS_ACCESS_KEY_ID`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t ec2/airflow' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "ec2/airflow");
       assert(status.success);
@@ -731,8 +877,12 @@ Deno.test(
 Deno.test(
   "'cndi init -t gcp/neo4j' should generate a README.md that references Neo4j and GCP",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gcp/neo4j");
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
@@ -740,16 +890,22 @@ Deno.test(
       assert(readme.indexOf(`## gcp`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t gcp/neo4j' should generate a .env file with GCP credentials",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gcp/neo4j");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -758,46 +914,64 @@ Deno.test(
       assert(dotenv.indexOf(`GOOGLE_CREDENTIALS`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t gce/neo4j' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gce/neo4j");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t gke/neo4j' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "gke/neo4j");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t azure/mongodb' should generate a README.md that references MongoDB and Azure",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "azure/mongodb");
       const readme = Deno.readTextFileSync(path.join(Deno.cwd(), `README.md`));
@@ -805,16 +979,22 @@ Deno.test(
       assert(readme.indexOf(`## azure`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t avm/airflow' should generate a .env file with Azure credentials",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "avm/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -826,16 +1006,22 @@ Deno.test(
       assert(dotenv.indexOf(`ARM_SUBSCRIPTION_ID`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t aks/airflow' should generate a .env file with Azure credentials",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "aks/airflow");
       const dotenv = Deno.readTextFileSync(path.join(Deno.cwd(), `.env`));
@@ -847,46 +1033,64 @@ Deno.test(
       assert(dotenv.indexOf(`ARM_SUBSCRIPTION_ID`) > -1);
       assert(status.success);
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t avm/mongodb' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "avm/mongodb");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -t aks/airflow' should generate terraform files such that the filenames and resource names are the same",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const { status } = await runCndi("init", "-t", "aks/airflow");
       assert(status.success);
       await ensureResourceNamesMatchFileNames();
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -i -t azure/basic' should generate a project given interactive input",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "azure/basic");
 
@@ -924,16 +1128,22 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -i -t ec2/basic' should generate a project given interactive input",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "ec2/basic");
 
@@ -969,16 +1179,22 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -i -t eks/basic' should generate a project given interactive input",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "eks/basic");
       // this object is ordered!!
@@ -1013,16 +1229,23 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );
 
 Deno.test(
   "'cndi init -i -t gcp/basic' should generate a project given interactive input",
   async (t) => {
-    const dir = Deno.makeTempDirSync();
-    Deno.chdir(dir);
+    let dir = "";
+
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
     await t.step("test", async () => {
       const p = getRunningCNDIProcess("init", "-i", "-t", "gcp/basic");
 
@@ -1060,7 +1283,9 @@ Deno.test(
       assert(status.success);
       assert(initFileList.size === 0); // if the set is empty, all files were created
     });
-    Deno.chdir("..");
-    Deno.removeSync(dir, { recursive: true });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
   },
 );

--- a/src/tests/helpers/run-cndi.ts
+++ b/src/tests/helpers/run-cndi.ts
@@ -60,9 +60,6 @@ async function runCndi(...args: string[]) {
       success: output.code === 0,
     };
 
-    console.log(decoder.decode(output.stdout));
-    console.error(decoder.decode(output.stderr));
-
     return {
       status,
       output: decoder.decode(output.stdout),

--- a/src/tests/helpers/run-cndi.ts
+++ b/src/tests/helpers/run-cndi.ts
@@ -60,6 +60,9 @@ async function runCndi(...args: string[]) {
       success: output.code === 0,
     };
 
+    console.log(decoder.decode(output.stdout));
+    console.error(decoder.decode(output.stderr));
+
     return {
       status,
       output: decoder.decode(output.stdout),


### PR DESCRIPTION
# upgrade to v1.38.0

CNDI is currently using deno v1.36.4. Breaking changes were introduced in v1.37.0 that must be fixed before we upgrade deno beyond 1.36.4.

# testing steps

1. checkout this branch
2. run `deno upgrade`
3. run `deno task test`
4. ensure tests pass

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
