### PR TITLE
More open ports

### DIFF
--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -174,24 +174,14 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
   ) {
     const managedKind = kind as ManagedNodeKind; //aks
 
-    const ingressServicePrivate = getEKSIngressServiceManifestPrivate(
-      open_ports,
-      managedKind,
-    );
-
     await stageFile(
       path.join("cndi", "cluster_manifests", "ingress-service-private.yaml"),
-      ingressServicePrivate,
-    );
-
-    const ingressServicePublic = getEKSIngressServiceManifestPublic(
-      open_ports,
-      managedKind,
+      getEKSIngressServiceManifestPrivate(open_ports, managedKind),
     );
 
     await stageFile(
       path.join("cndi", "cluster_manifests", "ingress-service-public.yaml"),
-      ingressServicePublic,
+      getEKSIngressServiceManifestPublic(open_ports, managedKind),
     );
 
     await stageFile(

--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -179,24 +179,20 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
       managedKind,
     );
 
-    if (ingressServicePrivate) {
-      await stageFile(
-        path.join("cndi", "cluster_manifests", "ingress-service-private.yaml"),
-        ingressServicePrivate,
-      );
-    }
+    await stageFile(
+      path.join("cndi", "cluster_manifests", "ingress-service-private.yaml"),
+      ingressServicePrivate,
+    );
 
     const ingressServicePublic = getEKSIngressServiceManifestPublic(
       open_ports,
       managedKind,
     );
 
-    if (ingressServicePublic) {
-      await stageFile(
-        path.join("cndi", "cluster_manifests", "ingress-service-public.yaml"),
-        ingressServicePublic,
-      );
-    }
+    await stageFile(
+      path.join("cndi", "cluster_manifests", "ingress-service-public.yaml"),
+      ingressServicePublic,
+    );
 
     await stageFile(
       path.join(

--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -23,8 +23,11 @@ import getMicrok8sIngressDaemonsetManifest from "src/outputs/custom-port-manifes
 import getProductionClusterIssuerManifest from "src/outputs/cert-manager-manifests/production-cluster-issuer.ts";
 import getDevClusterIssuerManifest from "src/outputs/cert-manager-manifests/self-signed/dev-cluster-issuer.ts";
 
-import getEKSIngressServiceManifest from "../outputs/custom-port-manifests/managed/ingress-service-public.ts";
-import getEKSIngressTcpServicesConfigMapManifest from "../outputs/custom-port-manifests/managed/ingress-tcp-services-configmap-public.ts";
+import getEKSIngressServiceManifestPublic from "../outputs/custom-port-manifests/managed/ingress-service-public.ts";
+import getEKSIngressTcpServicesConfigMapManifestPublic from "../outputs/custom-port-manifests/managed/ingress-tcp-services-configmap-public.ts";
+
+import getEKSIngressServiceManifestPrivate from "../outputs/custom-port-manifests/managed/ingress-service-private.ts";
+import getEKSIngressTcpServicesConfigMapManifestPrivate from "../outputs/custom-port-manifests/managed/ingress-tcp-services-configmap-private.ts";
 
 import stageTerraformResourcesForConfig from "src/outputs/terraform/stageTerraformResourcesForConfig.ts";
 
@@ -169,24 +172,48 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
   if (
     isNotMicrok8sCluster // currently only EKS, AKS, GKE
   ) {
-    const managedKind = kind as ManagedNodeKind;
-    const ingressService = getEKSIngressServiceManifest(
+    const managedKind = kind as ManagedNodeKind; //aks
+
+    const ingressServicePrivate = getEKSIngressServiceManifestPrivate(
       open_ports,
       managedKind,
     );
-    if (ingressService) {
+
+    if (ingressServicePrivate) {
       await stageFile(
-        path.join("cndi", "cluster_manifests", "ingress-service.yaml"),
-        ingressService,
+        path.join("cndi", "cluster_manifests", "ingress-service-private.yaml"),
+        ingressServicePrivate,
       );
     }
+
+    const ingressServicePublic = getEKSIngressServiceManifestPublic(
+      open_ports,
+      managedKind,
+    );
+
+    if (ingressServicePublic) {
+      await stageFile(
+        path.join("cndi", "cluster_manifests", "ingress-service-public.yaml"),
+        ingressServicePublic,
+      );
+    }
+
     await stageFile(
       path.join(
         "cndi",
         "cluster_manifests",
-        "ingress-tcp-services-configmap.yaml",
+        "ingress-tcp-services-configmap-public.yaml",
       ),
-      getEKSIngressTcpServicesConfigMapManifest(open_ports),
+      getEKSIngressTcpServicesConfigMapManifestPublic(open_ports),
+    );
+
+    await stageFile(
+      path.join(
+        "cndi",
+        "cluster_manifests",
+        "ingress-tcp-services-configmap-private.yaml",
+      ),
+      getEKSIngressTcpServicesConfigMapManifestPrivate(open_ports),
     );
   } else {
     await Promise.all([

--- a/src/outputs/custom-port-manifests/managed/ingress-service-private.ts
+++ b/src/outputs/custom-port-manifests/managed/ingress-service-private.ts
@@ -34,7 +34,7 @@ interface IngressService {
   };
   spec: {
     type: "LoadBalancer";
-    ports: Array<ServicePort>;
+    ports?: Array<ServicePort>;
   };
 }
 
@@ -63,7 +63,7 @@ type ServicePort = {
 const getIngressServiceManifest = (
   user_ports: Array<CNDIPort>,
   kind: ManagedNodeKind,
-): string | null => {
+): string => {
   const ports: Array<ServicePort> = [...default_ports];
 
   user_ports.forEach((port) => {
@@ -101,11 +101,6 @@ const getIngressServiceManifest = (
     }
   });
 
-  if (ports.length === 0) {
-    // don't create service
-    return null;
-  }
-
   const manifest: IngressService = {
     apiVersion: "v1",
     kind: "Service",
@@ -116,9 +111,12 @@ const getIngressServiceManifest = (
     },
     spec: {
       type: "LoadBalancer",
-      ports,
     },
   };
+
+  if (ports.length > 0) {
+    manifest.spec.ports = ports;
+  }
 
   return getYAMLString(manifest);
 };

--- a/src/outputs/custom-port-manifests/managed/ingress-service-public.ts
+++ b/src/outputs/custom-port-manifests/managed/ingress-service-public.ts
@@ -103,7 +103,19 @@ const getIngressServiceManifest = (
 
   if (ports.length === 0) {
     // don't create service
-    return null;
+    return getYAMLString({
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        "name": "ingress-nginx-controller-public",
+        "namespace": "ingress",
+        "annotations": MANAGED_ANNOTATIONS[kind],
+      },
+      spec: {
+        type: "LoadBalancer",
+        ports,
+      },
+    });
   }
 
   const manifest: IngressService = {


### PR DESCRIPTION


# Description

- first deployment on managed clusters will not respect disabled default ports 80 and 443

this is solved by rendering a service on top of the default nginx chart even if there are 0 ports open


# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
