### PR TITLE
typescript points to new v2 template dir

### DIFF
--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -20,7 +20,7 @@ import {
 
 // TODO: make this real/remote
 export const POLYSEAM_TEMPLATE_DIRECTORY =
-  "https://raw.githubusercontent.com/polyseam/cndi/main/src/templates/";
+  "https://raw.githubusercontent.com/polyseam/cndi/main/templates/";
 
 interface SealedSecretsKeys {
   sealed_secrets_private_key: string;


### PR DESCRIPTION
This points the `main` build branch of `cndi` aka `cndi-next` to the v2 templates when `cndi init` is called.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
