### PR TITLE
root-chart Chart.yaml overrideable

### DIFF
--- a/src/commands/overwrite.ts
+++ b/src/commands/overwrite.ts
@@ -217,6 +217,11 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
   }
   console.log(ccolors.success("staged open ports manifests"));
 
+  await stageFile(
+    path.join("cndi", "cluster_manifests", "Chart.yaml"),
+    RootChartYaml,
+  );
+
   // write each manifest in the "cluster_manifests" section of the config to `cndi/cluster_manifests`
   for (const key in cluster_manifests) {
     const manifestObj = cluster_manifests[key] as KubernetesManifest;
@@ -251,11 +256,6 @@ const overwriteAction = async (options: OverwriteActionArgs) => {
       ccolors.key_name(manifestFilename),
     );
   }
-
-  await stageFile(
-    path.join("cndi", "cluster_manifests", "Chart.yaml"),
-    RootChartYaml,
-  );
 
   const { applications } = config;
 


### PR DESCRIPTION
# Description

`cluster_manifests/Chart.yaml` can now be overridden

<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
