### PR TITLE
make argo pw sensitive in helm_release

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -870,23 +870,25 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         replace: true,
         repository: "https://argoproj.github.io/argo-helm",
         version: "5.45.0",
+        setSensitive: [
+          {
+            name: "configs.secret.argocdServerAdminPassword",
+            value: Fn.sensitive(argocdAdminPasswordHashed),
+          },
+        ],
         set: [
           {
             name: "server.service.annotations.redeployTime",
             value: argocdAdminPasswordMtime.id,
           },
           {
-            name: "configs.secret.argocdServerAdminPassword",
-            value: argocdAdminPasswordHashed,
-          },
-          {
             name: "configs.secret.argocdServerAdminPasswordMtime",
             value: argocdAdminPasswordMtime.id,
           },
           {
-            "name":
+            name:
               "server.deploymentAnnotations.configmap\\.reloader\\.stakater\\.com/reload",
-            "value": "argocd-cm",
+            value: "argocd-cm",
           },
         ],
       },

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -440,23 +440,25 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
         replace: true,
         repository: "https://argoproj.github.io/argo-helm",
         version: "5.45.0",
+        setSensitive: [
+          {
+            name: "configs.secret.argocdServerAdminPassword",
+            value: Fn.sensitive(argocdAdminPasswordHashed),
+          },
+        ],
         set: [
           {
             name: "server.service.annotations.redeployTime",
             value: argocdAdminPasswordMtime.id,
           },
           {
-            name: "configs.secret.argocdServerAdminPassword",
-            value: argocdAdminPasswordHashed,
-          },
-          {
             name: "configs.secret.argocdServerAdminPasswordMtime",
             value: argocdAdminPasswordMtime.id,
           },
           {
-            "name":
+            name:
               "server.deploymentAnnotations.configmap\\.reloader\\.stakater\\.com/reload",
-            "value": "argocd-cm",
+            value: "argocd-cm",
           },
         ],
       },

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -311,23 +311,25 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
         replace: true,
         repository: "https://argoproj.github.io/argo-helm",
         version: "5.45.0",
+        setSensitive: [
+          {
+            name: "configs.secret.argocdServerAdminPassword",
+            value: Fn.sensitive(argocdAdminPasswordHashed),
+          },
+        ],
         set: [
           {
             name: "server.service.annotations.redeployTime",
             value: argocdAdminPasswordMtime.id,
           },
           {
-            name: "configs.secret.argocdServerAdminPassword",
-            value: argocdAdminPasswordHashed,
-          },
-          {
             name: "configs.secret.argocdServerAdminPasswordMtime",
             value: argocdAdminPasswordMtime.id,
           },
           {
-            "name":
+            name:
               "server.deploymentAnnotations.configmap\\.reloader\\.stakater\\.com/reload",
-            "value": "argocd-cm",
+            value: "argocd-cm",
           },
         ],
       },


### PR DESCRIPTION
# Description

Argo's previous admin password was visible in the logs of terraform apply when the argo_helm release was updated, now it is omited by using `setSensitive`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
