### PR TITLE
fix kubeseal binary address by version

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 const TERRAFORM_VERSION = "1.5.5";
-const KUBESEAL_VERSION = "2.13.3";
+const KUBESEAL_VERSION = "0.21.0"; // used to install binary on client
+const SEALED_SECRETS_VERSION = "2.13.3"; // used to install controller on cluster
 const DEFAULT_MICROK8S_VERSION = "1.28";
 const ARGOCD_VERSION = "2.7.12";
 const RELOADER_VERSION = "1.0.52";
@@ -52,5 +53,6 @@ export {
   MICROK8S_INSTALL_RETRY_INTERVAL,
   NODE_DISK_SIZE_KEY,
   RELOADER_VERSION,
+  SEALED_SECRETS_VERSION,
   TERRAFORM_VERSION,
 };

--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -2,8 +2,8 @@ import { CNDIConfig } from "src/types.ts";
 import {
   DEFAULT_INSTANCE_TYPES,
   DEFAULT_NODE_DISK_SIZE_MANAGED,
-  KUBESEAL_VERSION,
   RELOADER_VERSION,
+  SEALED_SECRETS_VERSION,
 } from "consts";
 import {
   App,
@@ -984,7 +984,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         name: "sealed-secrets",
         namespace: "kube-system",
         repository: "https://bitnami-labs.github.io/sealed-secrets",
-        version: KUBESEAL_VERSION,
+        version: SEALED_SECRETS_VERSION,
         timeout: 300,
         atomic: true,
       },

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -17,13 +17,12 @@ import {
 import {
   DEFAULT_INSTANCE_TYPES,
   DEFAULT_NODE_DISK_SIZE_MANAGED,
-  KUBESEAL_VERSION,
   RELOADER_VERSION,
+  SEALED_SECRETS_VERSION,
 } from "consts";
 
 import {
   getCDKTFAppConfig,
-  // getPrettyJSONString,
   resolveCNDIPorts,
   stageCDKTFStack,
   useSshRepoAuth,
@@ -554,7 +553,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
         name: "sealed-secrets",
         namespace: "kube-system",
         repository: "https://bitnami-labs.github.io/sealed-secrets",
-        version: KUBESEAL_VERSION,
+        version: SEALED_SECRETS_VERSION,
         timeout: 300,
         atomic: true,
       },

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -15,8 +15,8 @@ import {
 import {
   DEFAULT_INSTANCE_TYPES,
   DEFAULT_NODE_DISK_SIZE_MANAGED,
-  KUBESEAL_VERSION,
   RELOADER_VERSION,
+  SEALED_SECRETS_VERSION,
 } from "consts";
 
 import {
@@ -408,7 +408,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
         name: "sealed-secrets",
         namespace: "kube-system",
         repository: "https://bitnami-labs.github.io/sealed-secrets",
-        version: KUBESEAL_VERSION,
+        version: SEALED_SECRETS_VERSION,
         timeout: 300,
         atomic: true,
       },


### PR DESCRIPTION
# Description

We discovered that kubeseal was failing to install because I conflated the sealed-secrets version with the kubeseal CLI version


<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
