### PR TITLE
nodepool terraform ids now contain suffixes for nodespec index

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -574,6 +574,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
 
     let firstNodeGroup: CDKTFProviderAWS.eksNodeGroup.EksNodeGroup | null =
       null;
+    let nodeGroupIndex = 0;
 
     for (const nodeGroup of cndi_config.infrastructure.cndi.nodes) {
       const count = nodeGroup?.count || 1;
@@ -604,7 +605,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
 
       const ng = new CDKTFProviderAWS.eksNodeGroup.EksNodeGroup(
         this,
-        "cndi_aws_eks_node_group",
+        `cndi_aws_eks_node_group_${nodeGroupIndex}`,
         {
           clusterName: eksCluster.name,
           amiType: "AL2_x86_64",
@@ -626,6 +627,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
       if (!firstNodeGroup) {
         firstNodeGroup = ng;
       }
+      nodeGroupIndex++;
     }
 
     const _helmReleaseEFSCSIDriver = new CDKTFProviderHelm.release.Release(

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -177,17 +177,19 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
       kubernetes,
     });
 
+    let nodePoolIndex = 1; // 0 is the default nodePoolSpec
     for (const nodeSpec of nodePools) {
       // all non-default nodePoolSpecs
       new CDKTFProviderAzure.kubernetesClusterNodePool
         .KubernetesClusterNodePool(
         this,
-        `cndi_azurerm_kubernetes_cluster_node_pool_${nodeSpec.name}`,
+        `cndi_azurerm_kubernetes_cluster_node_pool_${nodePoolIndex}`,
         {
           ...nodeSpec,
           kubernetesClusterId: cluster.id,
         },
       );
+      nodePoolIndex++;
     }
 
     new CDKTFProviderKubernetes.storageClass.StorageClass(

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -190,6 +190,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       kubernetes,
     );
 
+    let nodePoolIndex = 0;
     for (const nodePoolSpec of cndi_config.infrastructure.cndi.nodes) {
       const nodeCount = nodePoolSpec.count || 1;
 
@@ -235,7 +236,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       } else {
         new CDKTFProviderGCP.containerNodePool.ContainerNodePool(
           this,
-          `cndi_google_container_node_pool_${nodePoolSpec.name}`,
+          `cndi_google_container_node_pool_${nodePoolIndex}`,
           {
             cluster: gkeCluster.name,
             name: nodePoolSpec.name,
@@ -244,6 +245,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
           },
         );
       }
+      nodePoolIndex++;
     }
 
     new CDKTFProviderHelm.provider.HelmProvider(this, "cndi_provider_helm", {


### PR DESCRIPTION
# Description

- [x] fixed bug where EKS clusters would fail in `cndi ow` because they shared the same ID
- [x] all node pools IDs are now generated based on array positioning in `cndi_config.yaml` instead of by name

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
