### PR TITLE
Fix EKS Ingress Setup

### DIFF
--- a/src/outputs/custom-port-manifests/managed/ingress-service-private.ts
+++ b/src/outputs/custom-port-manifests/managed/ingress-service-private.ts
@@ -15,6 +15,7 @@ type ManagedAnnotations = {
 const MANAGED_ANNOTATIONS: ManagedAnnotations = {
   eks: {
     "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
+    "service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
   },
   gke: {
     "networking.gke.io/load-balancer-type": "Internal",


### PR DESCRIPTION
# Description

- EKS was failing to deploy due to ingress controllers timing out
- When EKS ingress controllers failed, the namespaces for those would get orphaned from Terraform 

Neither of these things are true anymore.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
