### PR TITLE
[Fix] gke eks Incorrect resource_group url output

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -1226,11 +1226,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         Fn.upper(
           this.locals.aws_region.asString,
         )
-      }.console.aws.amazon.com/resource-groups/group/cndi-rg_${project_name}?region=${
-        Fn.upper(
-          this.locals.aws_region.asString,
-        )
-      }`,
+      }.console.aws.amazon.com/resource-groups/group/cndi-rg_${project_name}`,
     });
   }
 }

--- a/src/outputs/terraform/aws/AWSMicrok8sStack.ts
+++ b/src/outputs/terraform/aws/AWSMicrok8sStack.ts
@@ -318,9 +318,7 @@ export class AWSMicrok8sStack extends AWSCoreTerraformStack {
     new TerraformOutput(this, "resource_group_url", {
       value: `https://${
         Fn.upper(this.locals.aws_region.asString)
-      }.console.aws.amazon.com/resource-groups/group/cndi-rg_${project_name}?region=${
-        Fn.upper(this.locals.aws_region.asString)
-      }`,
+      }.console.aws.amazon.com/resource-groups/group/cndi-rg_${project_name}`,
     });
   }
 }

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -34,7 +34,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
     super(scope, name, cndi_config);
 
     const project_name = this.locals.cndi_project_name.asString;
-
+    const project_id = this.locals.gcp_project_id.asString;
     new CDKTFProviderTime.provider.TimeProvider(this, "cndi_time_provider", {});
     new CDKTFProviderTls.provider.TlsProvider(this, "cndi_tls_provider", {});
 
@@ -594,7 +594,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
     });
 
     new TerraformOutput(this, "resource_group_url", {
-      value: `https://console.cloud.google.com/welcome?project=${project_name}`,
+      value: `https://console.cloud.google.com/welcome?project=${project_id}`,
     });
   }
 }


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #

# Description

The previous URL would point to the wrong url for the resource group which would result in this error
![image](https://github.com/polyseam/cndi/assets/77031428/4f70411f-ca2d-44d8-983d-6f7362a070ee)

Updated the output URL for resource_group in the aws stack to point to the correct url
![image](https://github.com/polyseam/cndi/assets/77031428/a0d4ec94-2885-4a5c-919f-4cb2eebeba18)

# Test Instructions
create a cluster and click on resource_group URL Output
<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [ ] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
