### PR TITLE
recolor message using getCliffyPrompts

### DIFF
--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -205,8 +205,10 @@ function getCliffyPrompts(
 ): Array<CliffyPrompt> {
   return promptDefinitions.map((promptDefinition) => {
     const type = PromptTypes[promptDefinition.type];
+    const message = ccolors.prompt(promptDefinition.message); // add color to prompt message
     return {
       ...promptDefinition,
+      message,
       type,
       after: async (
         result: Record<string, CNDITemplatePromptResponsePrimitive>,


### PR DESCRIPTION
# Related issue

Issue #665

# Description

The color of prompt messages was not always the same, now every prompt message is blue

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
