### PR TITLE
readme get_block -> get_string

### DIFF
--- a/templates/airflow.yaml
+++ b/templates/airflow.yaml
@@ -323,7 +323,7 @@ outputs:
         - false
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/basic.yaml
+++ b/templates/basic.yaml
@@ -61,7 +61,7 @@ outputs:
       {}
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -215,7 +215,7 @@ outputs:
     POSTGRESQL_CLUSTER_SUPERUSER: "{{ $cndi.get_prompt_response(postgres_admin_username) }}"
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/hop.yaml
+++ b/templates/hop.yaml
@@ -148,7 +148,7 @@ outputs:
     HOP_SERVER_PASSWORD:  "{{ $cndi.get_prompt_response(hop_server_password) }}"
   
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/mongodb.yaml
+++ b/templates/mongodb.yaml
@@ -191,7 +191,7 @@ outputs:
     MONGODB_REPLICA_SETS: "{{ $cndi.get_prompt_response(mongodb_replica_sets) }}"
     MONGODB_NAMESPACE: "{{ $cndi.get_prompt_response(mongodb_namespace) }}"
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/mssqlserver.yaml
+++ b/templates/mssqlserver.yaml
@@ -219,7 +219,7 @@ outputs:
     MSSQL_SA_PASSWORD: "{{ $cndi.get_prompt_response(mssql_sa_password) }}"
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/mysql.yaml
+++ b/templates/mysql.yaml
@@ -181,7 +181,7 @@ outputs:
     ROOT_PASSWORD: "{{ $cndi.get_prompt_response(rootPassword) }}"
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/neo4j.yaml
+++ b/templates/neo4j.yaml
@@ -163,7 +163,7 @@ outputs:
     NEO4J_PASSWORD: "neo4j/{{ $cndi.get_prompt_response(neo4j_password) }}"
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/proxy.yaml
+++ b/templates/proxy.yaml
@@ -145,7 +145,7 @@ outputs:
       {}
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -283,7 +283,7 @@ outputs:
     $cndi.comment(redis-heading): Redis Connection Parameters
     REDISPASSWORD: "{{ $cndi.get_prompt_response(default_user_password) }}" 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}

--- a/templates/superset.yaml
+++ b/templates/superset.yaml
@@ -325,7 +325,7 @@ outputs:
     POSTGRESQL_USER_PASSWORD: "{{ $cndi.get_prompt_response(database_user_password) }}"
 
   readme:
-    $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
+    $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-readme.md):
       {}
     $cndi.get_string(https://raw.githubusercontent.com/polyseam/common-blocks/main/{{ $cndi.get_prompt_response(deployment_target_provider) }}/{{ $cndi.get_prompt_response(deployment_target_distribution) }}/readme-section.md):
       {}


### PR DESCRIPTION
# Description

Templates were pulling in readme blocks with `get_block` and should have been `get_string` because the contents are not YAML.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
