### PR TITLE
[Fix] gke node pool incorrect node count

### DIFF
--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -152,14 +152,14 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
         ],
       },
     );
-  
+
     const gkeCluster = new CDKTFProviderGCP.containerCluster.ContainerCluster(
       this,
       "cndi_google_container_cluster",
       {
         name: project_name,
         location: this.locals.gcp_region.asString,
-        nodeLocations:[this.locals.gcp_zone.asString],
+        nodeLocations: [this.locals.gcp_zone.asString],
         // https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#example-usage---with-a-separately-managed-node-pool-recommended
         // "We can't create a cluster with no node pool defined, but we want to only use
         // separately managed node pools. So we create the smallest possible default

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -159,6 +159,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       {
         name: project_name,
         location: this.locals.gcp_region.asString,
+        node_locations:[`${this.locals.gcp_region.asString}-a`,`${this.locals.gcp_region.asString}-b`],
         // https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#example-usage---with-a-separately-managed-node-pool-recommended
         // "We can't create a cluster with no node pool defined, but we want to only use
         // separately managed node pools. So we create the smallest possible default

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -152,14 +152,14 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
         ],
       },
     );
-
+  
     const gkeCluster = new CDKTFProviderGCP.containerCluster.ContainerCluster(
       this,
       "cndi_google_container_cluster",
       {
         name: project_name,
         location: this.locals.gcp_region.asString,
-        node_locations:[`${this.locals.gcp_region.asString}-a`,`${this.locals.gcp_region.asString}-b`],
+        nodeLocations:[this.locals.gcp_zone.asString],
         // https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#example-usage---with-a-separately-managed-node-pool-recommended
         // "We can't create a cluster with no node pool defined, but we want to only use
         // separately managed node pools. So we create the smallest possible default


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue # BugFix

# Description

The default configuration of one of our node pools incorrectly spawns 9 nodes, whereas it should only be initiating 3 nodes as per our specifications
![image](https://github.com/polyseam/cndi/assets/77031428/bff08c0a-c9e6-43a4-9287-6fc25c1f7c25)


# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [ x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
