### PR TITLE
strips quotes on response calls only when necessary

### DIFF
--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -11,6 +11,7 @@ import {
 import CNDITemplateComparators from "./comparators.ts";
 import { BuiltInValidators } from "./validators.ts";
 import {
+  characterAtPositionIsQuote,
   getObjectKeysRecursively,
   homedir,
   isValidUrl,
@@ -384,13 +385,21 @@ export function literalizeTemplateWithResponseValues(
           `${fn}::${key};`,
         );
       } else {
-        const indexOfOpenWrappingQuote = indexOfOpeningBraces - 1;
-        const indexOfClosingWrappingQuoteInclusive = indexOfClosingBraces + 3;
+        let start = indexOfOpeningBraces;
+        let end = indexOfClosingBraces + 2;
+
+        if (
+          characterAtPositionIsQuote(literalizedString, start - 1)
+        ) start--;
+
+        if (
+          characterAtPositionIsQuote(literalizedString, end)
+        ) end++;
 
         literalizedString = replaceRange(
           literalizedString,
-          indexOfOpenWrappingQuote,
-          indexOfClosingWrappingQuoteInclusive,
+          start,
+          end,
           valueToSubstitute,
         );
       }

--- a/src/templates/util.ts
+++ b/src/templates/util.ts
@@ -84,7 +84,12 @@ function unwrapQuotes(s: string): string {
   return s;
 }
 
+function characterAtPositionIsQuote(str: string, pos: number): boolean {
+  return str.charAt(pos) === '"' || str.charAt(pos) === "'";
+}
+
 export {
+  characterAtPositionIsQuote,
   getObjectKeysRecursively,
   homedir,
   isValidUrl,


### PR DESCRIPTION
# Related issue

Issue #659 

# Description

- updated template parser to handle using non-string responses interpolated in strings correctly

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
