### PR TITLE
[Enhancement] use a single k8s version in `consts`

### DIFF
--- a/src/cloud-init/microk8s/follower.yml.ts
+++ b/src/cloud-init/microk8s/follower.yml.ts
@@ -1,9 +1,6 @@
 import { YAML } from "deps";
 import { CNDIConfig } from "src/types.ts";
-import {
-  DEFAULT_MICROK8S_VERSION,
-  MICROK8S_INSTALL_RETRY_INTERVAL,
-} from "consts";
+import { DEFAULT_K8S_VERSION, MICROK8S_INSTALL_RETRY_INTERVAL } from "consts";
 
 type GetFollowerCloudInitOptions = {
   isWorker: boolean;
@@ -37,7 +34,7 @@ const getFollowerCloudInitYaml = (
   );
 
   const microk8sVersion = config.infrastructure.cndi?.microk8s?.version ||
-    DEFAULT_MICROK8S_VERSION;
+    DEFAULT_K8S_VERSION;
   const microk8sChannel = config.infrastructure.cndi?.microk8s?.channel ||
     "stable";
 

--- a/src/cloud-init/microk8s/leader.yml.ts
+++ b/src/cloud-init/microk8s/leader.yml.ts
@@ -7,7 +7,7 @@ import getRootApplicationTemplate from "src/outputs/terraform/manifest-templates
 
 import {
   ARGOCD_VERSION,
-  DEFAULT_MICROK8S_VERSION,
+  DEFAULT_K8S_VERSION,
   MICROK8S_INSTALL_RETRY_INTERVAL,
   RELOADER_VERSION,
   SEALED_SECRETS_VERSION,
@@ -83,7 +83,7 @@ const getLeaderCloudInitYaml = (
 ) => {
   const addons = getMicrok8sAddons(config);
   const microk8sVersion = config.infrastructure.cndi?.microk8s?.version ||
-    DEFAULT_MICROK8S_VERSION;
+    DEFAULT_K8S_VERSION;
   const microk8sChannel = config.infrastructure.cndi?.microk8s?.channel ||
     "stable";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 const TERRAFORM_VERSION = "1.5.5";
 const KUBESEAL_VERSION = "0.21.0"; // used to install binary on client
 const SEALED_SECRETS_VERSION = "2.13.3"; // used to install controller on cluster
-const DEFAULT_MICROK8S_VERSION = "1.28";
+const DEFAULT_K8S_VERSION = "1.28";
 const ARGOCD_VERSION = "2.7.12";
 const RELOADER_VERSION = "1.0.52";
 const LARSTOBI_MULTIPASS_PROVIDER_VERSION = "1.4.2";
@@ -48,7 +48,7 @@ export { default as error_code_reference } from "../docs/error-code-reference.js
 export {
   ARGOCD_VERSION,
   DEFAULT_INSTANCE_TYPES,
-  DEFAULT_MICROK8S_VERSION,
+  DEFAULT_K8S_VERSION,
   DEFAULT_NODE_DISK_SIZE_MANAGED,
   DEFAULT_NODE_DISK_SIZE_UNMANAGED,
   DEFAULT_OPEN_PORTS,

--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -1,6 +1,7 @@
 import { CNDIConfig, TFBlocks } from "src/types.ts";
 import {
   DEFAULT_INSTANCE_TYPES,
+  DEFAULT_K8S_VERSION,
   DEFAULT_NODE_DISK_SIZE_MANAGED,
   RELOADER_VERSION,
   SEALED_SECRETS_VERSION,
@@ -400,7 +401,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
       {
         name: project_name!,
         roleArn: computeRole.arn,
-        version: "1.25",
+        version: DEFAULT_K8S_VERSION,
         vpcConfig: {
           endpointPrivateAccess: true,
           endpointPublicAccess: true,

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   DEFAULT_INSTANCE_TYPES,
+  DEFAULT_K8S_VERSION,
   DEFAULT_NODE_DISK_SIZE_MANAGED,
   RELOADER_VERSION,
   SEALED_SECRETS_VERSION,
@@ -196,7 +197,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
       {
         location: this.locals.arm_region.asString,
         name: `cndi-aks-cluster-${project_name}`,
-        kubernetesVersion: "1.27",
+        kubernetesVersion: DEFAULT_K8S_VERSION,
         resourceGroupName: this.rg.name,
         defaultNodePool: {
           ...defaultNodePool,
@@ -211,6 +212,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
           networkPlugin: "azure",
           networkPolicy: "azure",
         },
+        automaticChannelUpgrade: "patch",
         roleBasedAccessControlEnabled: false, // Tamika
         storageProfile: {
           fileDriverEnabled: true,


### PR DESCRIPTION
# Description

- all kubernetes installs now use the same version of kubernetes, except GCP, which uses the latest available
- azure now patches the version of kubernetes it uses automatically

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
