### PR TITLE
use "with" rather than "assert" for import attrs

### DIFF
--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -1,4 +1,4 @@
-import deno_json from "../deno.json" assert { type: "json" };
+import deno_json from "../deno.json" with { type: "json" };
 import "https://deno.land/std@0.196.0/dotenv/load.ts";
 import {
   ccolors,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,7 +43,7 @@ const DEFAULT_OPEN_PORTS = [
   },
 ] as const;
 
-export { default as error_code_reference } from "../docs/error-code-reference.json" assert { type: "json" };
+export { default as error_code_reference } from "../docs/error-code-reference.json" with { type: "json" };
 
 export {
   ARGOCD_VERSION,

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,4 +1,4 @@
-import deno_json from "../../deno.json" assert { type: "json" };
+import deno_json from "../../deno.json" with { type: "json" };
 import { sha256Digest } from "src/utils.ts";
 
 interface TelemetryEvent {


### PR DESCRIPTION

# Description

- deno deprecated (suddenly) "assert" in favor of "with", so we have updated the json import attribute syntax accordingly

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
