### PR TITLE
enable "cndi init -t foo" where foo is not listed

### DIFF
--- a/src/templates/templates.ts
+++ b/src/templates/templates.ts
@@ -938,13 +938,19 @@ export async function useTemplate(
         const templateResponse = await fetch(
           `${POLYSEAM_TEMPLATE_DIRECTORY}${templateIdentifier}.yaml`,
         );
-        if (!templateResponse.ok) throw new Error("Template not found");
-        templateContents = await templateResponse.text();
+
+        if (!templateResponse.ok) {
+          throw new Error(
+            `${templateResponse.status} - ${templateResponse.statusText}`,
+          );
+        } else {
+          templateContents = await templateResponse.text();
+        }
       } catch (fetchError) {
         console.log(
           templatesLabel,
           ccolors.error("CNDI Template not found for identifier:"),
-          ccolors.user_input(`"${templateIdentifier}"`),
+          ccolors.user_input(`"${templateIdentifier}"\n`),
         );
         console.log(ccolors.caught(fetchError, 1200));
         await emitExitEvent(1200);


### PR DESCRIPTION
# Description

- there are a number of templates found in [/templates](https://github.com/polyseam/cndi/tree/main/templates) which are not yet listed in interactive mode, those templates can now be called by name eg. `cndi init -i -t hop`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

- ensure `cndi init -i -t hop` is successful
- ensure `cndi init -i -t non-existent-foo-template` provides a useful error message then crashes

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
