### PR TITLE
`cndi ow` will now only generate a diff if configuration changes

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1112,6 +1112,7 @@
     "https://deno.land/std@0.214.0/io/buf_reader.ts": "c73aad99491ee6db3d6b001fa4a780e9245c67b9296f5bad9c0fa7384e35d47a",
     "https://deno.land/std@0.214.0/io/copy.ts": "63c6a4acf71fb1e89f5e47a7b3b2972f9d2c56dd645560975ead72db7eb23f61",
     "https://deno.land/std@0.214.0/io/read_all.ts": "876c1cb20adea15349c72afc86cecd3573335845ae778967aefb5e55fe5a8a4a",
+    "https://deno.land/std@0.214.0/io/types.ts": "748bbb3ac96abda03594ef5a0db15ce5450dcc6c0d841c8906f8b10ac8d32c96",
     "https://deno.land/std@0.214.0/path/_common/assert_path.ts": "2ca275f36ac1788b2acb60fb2b79cb06027198bc2ba6fb7e163efaedde98c297",
     "https://deno.land/std@0.214.0/path/_common/basename.ts": "569744855bc8445f3a56087fd2aed56bdad39da971a8d92b138c9913aecc5fa2",
     "https://deno.land/std@0.214.0/path/_common/common.ts": "6157c7ec1f4db2b4a9a187efd6ce76dcaf1e61cfd49f87e40d4ea102818df031",

--- a/src/actions/overwrite.ts
+++ b/src/actions/overwrite.ts
@@ -2,9 +2,11 @@ import { ccolors, loadEnv, path } from "deps";
 
 import {
   emitExitEvent,
+  getPrettyJSONString,
   getStagingDir,
   getYAMLString,
   loadCndiConfig,
+  loadJSONC,
   persistStagedFiles,
   stageFile,
 } from "src/utils.ts";
@@ -15,7 +17,7 @@ import { loadArgoUIAdminPassword } from "src/initialize/argoUIAdminPassword.ts";
 
 import getApplicationManifest from "src/outputs/application-manifest.ts";
 import RootChartYaml from "src/outputs/root-chart.ts";
-import getSealedSecretManifest from "src/outputs/sealed-secret-manifest.ts";
+import getSealedSecretManifestWithKSC from "src/outputs/sealed-secret-manifest.ts";
 
 import getMicrok8sIngressTcpServicesConfigMapManifest from "src/outputs/custom-port-manifests/microk8s/ingress-tcp-services-configmap.ts";
 import getMicrok8sIngressDaemonsetManifest from "src/outputs/custom-port-manifests/microk8s/ingress-daemonset.ts";
@@ -111,6 +113,31 @@ export const overwriteAction = async (options: OverwriteActionArgs) => {
   }
 
   const cluster_manifests = config?.cluster_manifests || {};
+
+  // ⚠️ ks_checks.json being loaded here is the one from the previous overwrite
+  let ks_checks: Record<string, string> = {};
+
+  try {
+    const ksc = await loadJSONC(
+      path.join(options.output, "cndi", "ks_checks.json"),
+    ) as Record<string, string>;
+
+    // restage the SealedSecret yaml file for every key in ks_checks.json
+    for (const key in ksc) {
+      ks_checks[key] = ksc[key];
+
+      const sealedManifest = await Deno.readTextFileSync(
+        path.join(options.output, "cndi", "cluster_manifests", `${key}.yaml`),
+      );
+
+      await stageFile(
+        path.join("cndi", "cluster_manifests", `${key}.yaml`),
+        sealedManifest,
+      );
+    }
+  } catch (_errorLoadingKSC) {
+    // ks_checks.json did not exist or was malformed
+  }
 
   try {
     // remove all files in cndi/cluster
@@ -230,20 +257,34 @@ export const overwriteAction = async (options: OverwriteActionArgs) => {
 
     if (manifestObj?.kind && manifestObj.kind === "Secret") {
       const secret = cluster_manifests[key] as KubernetesSecret;
-      const secretName = `${key}.yaml`;
-      const sealedSecretManifest = await getSealedSecretManifest(secret, {
-        publicKeyFilePath: tempPublicKeyFilePath,
-        envPath,
-      });
+      const secretFileName = `${key}.yaml`;
+      const sealedSecretManifestWithKSC = await getSealedSecretManifestWithKSC(
+        secret,
+        {
+          publicKeyFilePath: tempPublicKeyFilePath,
+          envPath,
+          ks_checks,
+          secretFileName,
+        },
+      );
+
+      const sealedSecretManifest = sealedSecretManifestWithKSC?.manifest;
 
       if (sealedSecretManifest) {
+        // add the ksc to the ks_checks object
+        ks_checks = {
+          ...ks_checks,
+          ...sealedSecretManifestWithKSC.ksc,
+        };
+
         await stageFile(
-          path.join("cndi", "cluster_manifests", secretName),
+          path.join("cndi", "cluster_manifests", secretFileName),
           sealedSecretManifest,
         );
+
         console.log(
           ccolors.success(`staged encrypted secret:`),
-          ccolors.key_name(secretName),
+          ccolors.key_name(secretFileName),
         );
       }
       continue;
@@ -258,6 +299,16 @@ export const overwriteAction = async (options: OverwriteActionArgs) => {
       ccolors.key_name(manifestFilename),
     );
   }
+
+  await stageFile(
+    path.join("cndi", "ks_checks.json"),
+    getPrettyJSONString(ks_checks),
+  );
+
+  console.log(
+    ccolors.success("staged metadata:"),
+    ccolors.key_name("ks_checks.json"),
+  );
 
   const skipExternalDNS =
     config?.infrastructure?.cndi?.external_dns?.enabled === false;

--- a/src/actions/overwrite.ts
+++ b/src/actions/overwrite.ts
@@ -152,11 +152,14 @@ export const overwriteAction = async (options: OverwriteActionArgs) => {
     }
 
     try {
-      if (sealedManifest) {
+      if (sealedManifest && cluster_manifests?.[key]) {
         await stageFile(
           path.join("cndi", "cluster_manifests", `${key}.yaml`),
           sealedManifest,
         );
+      } else {
+        // sealedManifest either did not exist or is no longer in cluster_manifests
+        delete ks_checks[key];
       }
     } catch {
       // failed to stage sealedManifest from ks_checks.json

--- a/src/types.ts
+++ b/src/types.ts
@@ -290,6 +290,7 @@ interface KubernetesSecret extends KubernetesManifest {
   };
   metadata: {
     name: string;
+    namespace?: string;
   };
   isPlaceholder: boolean;
 }


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #688

# Description

When `cndi ow` is executed we call out to the `kubeseal` binary to ingest user-provided secrets and create encrypted manifests using them. For fundamental security reasons, `kubeseal` is not idempotent, resealing a Secret will generate a new SealedSecret even if the material has not changed.

CNDI now stores a map of checksums for each file of secret material such that we can skip executing `kubeseal` if the underlying material has not changed. This means `cndi ow` will now only generate a git diff if the substantial configuration changes.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
