### PR TITLE
prevent crashes when calling `cndi install`

### DIFF
--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -18,6 +18,7 @@ import initCommand from "src/commands/init.ts";
 import { overwriteCommand } from "src/commands/overwrite.ts";
 import terraformCommand from "src/commands/terraform.ts";
 import destroyCommand from "src/commands/destroy.ts";
+import installCommand from "src/commands/install.ts";
 
 import { emitExitEvent, removeOldBinaryIfRequired } from "src/utils.ts";
 
@@ -82,6 +83,7 @@ export default async function cndi() {
     .command("terraform", terraformCommand)
     .command("destroy", destroyCommand)
     .command("upgrade", upgradeCommand)
+    .command("install", installCommand)
     .command("completions", new CompletionsCommand().global())
     .command("help", new HelpCommand().global())
     .parse(Deno.args);

--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -4,7 +4,7 @@ import {
   ccolors,
   Command,
   CompletionsCommand,
-  existsSync,
+  ensureDirSync,
   HelpCommand,
   homedir,
   path,
@@ -46,20 +46,15 @@ export default async function cndi() {
   const timestamp = `${Date.now()}`;
   const stagingDirectory = path.join(CNDI_HOME, "staging", timestamp);
 
-  // ensure CNDI_HOME/bin directory exists before installing deps
-  if (!existsSync(path.join(CNDI_HOME, "bin"), { isDirectory: true })) {
-    Deno.mkdirSync(path.join(CNDI_HOME, "bin"), { recursive: true });
-  } else {
-    // if cndi was updated in the previous execution, remove the old unused binary
-    // this is necessary because Windows will not allow you to delete a binary while it is running
-    await removeOldBinaryIfRequired(CNDI_HOME);
-  }
+  // if cndi was updated in the previous execution, remove the old unused binary
+  // this is necessary because Windows will not allow you to delete a binary while it is running
+  await removeOldBinaryIfRequired(CNDI_HOME);
 
   Deno.env.set("CNDI_STAGING_DIRECTORY", stagingDirectory);
   Deno.env.set("CNDI_HOME", CNDI_HOME);
 
   try {
-    Deno.mkdirSync(stagingDirectory, { recursive: true });
+    ensureDirSync(stagingDirectory);
   } catch (failedToCreateStagingDirectoryError) {
     console.error(
       cndiLabel,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,0 +1,15 @@
+import { Command } from "deps";
+/**
+ * COMMAND cndi install
+ * Installs CNDI dependencies to CNDI_HOME
+ */
+const installCommand = new Command()
+  .description(`DEPRECATED: Install cndi dependencies.`)
+  .hidden()
+  .action(async () => {
+    // TODO: remove this command
+    // cndi install is no longer required
+    // dependencies are included in the tarball
+  });
+
+export default installCommand;

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -9,6 +9,7 @@ export { walk } from "https://deno.land/std@0.201.0/fs/mod.ts";
 export * as JSONC from "https://deno.land/std@0.201.0/jsonc/mod.ts";
 export { delay } from "https://deno.land/std@0.201.0/async/delay.ts";
 export { exists } from "https://deno.land/std@0.201.0/fs/mod.ts";
+export { ensureDirSync } from "https://deno.land/std@0.201.0/fs/ensure_dir.ts";
 export { existsSync } from "https://deno.land/std@0.201.0/fs/mod.ts";
 export { load as loadEnv } from "https://deno.land/std@0.205.0/dotenv/mod.ts";
 export { walkSync } from "https://deno.land/std@0.201.0/fs/walk.ts";

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -54,10 +54,6 @@ const cndiWorkflowObj = {
           uses: "polyseam/setup-cndi@v2",
         },
         {
-          name: "cndi install",
-          run: "cndi install", // even though we install automatically in run.ts, we expect this has more performant caching
-        },
-        {
           name: "cndi run",
           env: {
             ARM_REGION: "${{ vars.ARM_REGION }}",


### PR DESCRIPTION
# Description

Since adopting tarballs it is no longer necessary to run `cndi install`, however existing GitHub Actions scripts will call this command. This PR enables those existing scripts to succeed, while removing the call from all scripts going forward.

This PR also enables pulling the latest `2.x` version of `setup-cndi` in GitHub Actions, instead of being pinned exclusively to `v2.0.0`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
