### PR TITLE
do not throw error when old-bin is absent

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,18 +58,7 @@ const removeOldBinaryIfRequired = async (
 
   try {
     await Deno.remove(pathToGarbageBinary);
-  } catch (error) {
-    if (!(error instanceof Deno.errors.NotFound)) {
-      console.error(
-        utilsLabel,
-        ccolors.error("\nfailed to delete old"),
-        ccolors.key_name("cndi"),
-        ccolors.error("binary, please try again"),
-      );
-      console.log(ccolors.caught(error, 302));
-      await emitExitEvent(302);
-      Deno.exit(302);
-    }
+  } catch {
     return false;
   }
   return true;


### PR DESCRIPTION
# Description

There should be no error thrown if we go to clean up an old binary and we don't find one

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
