### PR TITLE
fix schema and outputs lnks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ It's also possible to specify a Template URL to initialize with. A Template URL
 resolves to a CNDI Template file, this means that you are not limited to only
 Templates the CNDI team has put together, you can point to any arbitrary
 template file that follows the
-[Template Schema](/src/schemas/cndi-template.schema.json).
+[Template Schema](/src/schemas/cndi_template.schema.json).
 
 These Template URLs can be `file://` URLs which have an absolute path to the
 file locally, or typical remote or `https://` URLs over the net.
@@ -115,7 +115,7 @@ you want to learn about what CNDI is really creating, the best file to look at
 is the `cndi_config.yaml` file in the root of your repository.
 
 We break down all of the generated files later in this document in the
-[outputs](#outputs-📂) section.
+[outputs](#outputs-) section.
 
 The next step for our one-time project setup is to make sure that we have all
 the required environment variables for our project in our `.env` file that CNDI


### PR DESCRIPTION

# Description

README had broken links to the #outputs section and the "cndi_template" json schema

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
