### PR TITLE
[Bug]: `cnpg` and `airflow` templates fail when `external_dns` is disabled

### DIFF
--- a/templates/airflow.yaml
+++ b/templates/airflow.yaml
@@ -149,8 +149,11 @@ outputs:
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
     infrastructure:
       cndi:
-        external_dns:
-          provider: "{{ $cndi.get_prompt_response(dns_provider) }}"
+        $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/config/{{ $cndi.get_prompt_response(dns_provider) }}/cndi.yaml):
+          condition:
+            - "{{ $cndi.get_prompt_response(enable_autodns) }}"
+            - ==
+            - true
         cert_manager:
           email: "{{ $cndi.get_prompt_response(cert_manager_email) }}"
         nodes:
@@ -160,7 +163,7 @@ outputs:
     cluster_manifests:
       $cndi.comment(external-dns-secret): External DNS Credentials
       external-dns-secret: 
-        $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/{{ $cndi.get_prompt_response(dns_provider) }}.yaml):
+        $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/secret/{{ $cndi.get_prompt_response(dns_provider) }}.yaml):
           condition:
             - "{{ $cndi.get_prompt_response(enable_autodns) }}"
             - ==

--- a/templates/airflow.yaml
+++ b/templates/airflow.yaml
@@ -151,7 +151,7 @@ outputs:
       cndi:
         $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/config/{{ $cndi.get_prompt_response(dns_provider) }}/cndi.yaml):
           condition:
-            - "{{ $cndi.get_prompt_response(enable_autodns) }}"
+            - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
             - ==
             - true
         cert_manager:
@@ -165,7 +165,7 @@ outputs:
       external-dns-secret: 
         $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/secret/{{ $cndi.get_prompt_response(dns_provider) }}.yaml):
           condition:
-            - "{{ $cndi.get_prompt_response(enable_autodns) }}"
+            - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
             - ==
             - true
       $cndi.comment(airflow-git-sync-secret): Airflow Credentials

--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -198,7 +198,7 @@ outputs:
       cndi:
         $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/config/{{ $cndi.get_prompt_response(dns_provider) }}/cndi.yaml):
           condition:
-            - "{{ $cndi.get_prompt_response(enable_autodns) }}"
+            - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
             - ==
             - true
         cert_manager:
@@ -217,7 +217,7 @@ outputs:
       external-dns-secret: 
         $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/secret/{{ $cndi.get_prompt_response(dns_provider) }}.yaml):
           condition:
-            - "{{ $cndi.get_prompt_response(enable_autodns) }}"
+            - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
             - ==
             - true
       cnpg-namespace:

--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -196,8 +196,11 @@ outputs:
     # this is a template comment
     infrastructure:
       cndi:
-        external_dns:
-          provider: "{{ $cndi.get_prompt_response(dns_provider) }}"
+        $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/config/{{ $cndi.get_prompt_response(dns_provider) }}/cndi.yaml):
+          condition:
+            - "{{ $cndi.get_prompt_response(enable_autodns) }}"
+            - ==
+            - true
         cert_manager:
           email: "{{ $cndi.get_prompt_response(cert_manager_email) }}"
         open_ports:
@@ -212,7 +215,7 @@ outputs:
     cluster_manifests:
       $cndi.comment(external-dns-secret): External DNS Credentials
       external-dns-secret: 
-        $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/{{ $cndi.get_prompt_response(dns_provider) }}.yaml):
+        $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/external-dns/secret/{{ $cndi.get_prompt_response(dns_provider) }}.yaml):
           condition:
             - "{{ $cndi.get_prompt_response(enable_autodns) }}"
             - ==


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #722 

# Description

- airflow and cnpg templates both only render external_dns config if the user has enabled it

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
