### PR TITLE
downgrade to npm:@cdktf/provider-kubernetes@9

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -8,7 +8,9 @@
       "npm:@cdktf/provider-google@13.3.0": "npm:@cdktf/provider-google@13.3.0_cdktf@0.20.3__constructs@10.3.0_constructs@10.3.0",
       "npm:@cdktf/provider-helm": "npm:@cdktf/provider-helm@9.0.0_cdktf@0.19.0__constructs@10.3.0_constructs@10.3.0",
       "npm:@cdktf/provider-kubernetes": "npm:@cdktf/provider-kubernetes@10.0.0_cdktf@0.19.0__constructs@10.3.0_constructs@10.3.0",
+      "npm:@cdktf/provider-kubernetes@10": "npm:@cdktf/provider-kubernetes@10.1.1_cdktf@0.19.0__constructs@10.3.0_constructs@10.3.0",
       "npm:@cdktf/provider-kubernetes@10.1.1": "npm:@cdktf/provider-kubernetes@10.1.1_cdktf@0.19.0__constructs@10.3.0_constructs@10.3.0",
+      "npm:@cdktf/provider-kubernetes@9": "npm:@cdktf/provider-kubernetes@9.0.0_cdktf@0.18.2__constructs@10.3.0_constructs@10.3.0",
       "npm:@cdktf/provider-local": "npm:@cdktf/provider-local@9.0.1_cdktf@0.19.0__constructs@10.3.0_constructs@10.3.0",
       "npm:@cdktf/provider-null": "npm:@cdktf/provider-null@9.0.0_cdktf@0.19.0__constructs@10.3.0_constructs@10.3.0",
       "npm:@cdktf/provider-random": "npm:@cdktf/provider-random@10.0.0_cdktf@0.19.0__constructs@10.3.0_constructs@10.3.0",
@@ -72,6 +74,13 @@
         "integrity": "sha512-Z8SvVCKps4+lGEtiaoTfj7IVeYSRqkdcyImvSy4bAebXenCmH7dZc4jyubb7DPXUyTx7J+NJuDZzjsYpUQXo5w==",
         "dependencies": {
           "cdktf": "cdktf@0.19.0_constructs@10.3.0",
+          "constructs": "constructs@10.3.0"
+        }
+      },
+      "@cdktf/provider-kubernetes@9.0.0_cdktf@0.18.2__constructs@10.3.0_constructs@10.3.0": {
+        "integrity": "sha512-jOL6yTcCNtjyKmcugLOpDBRATFx/wiEJ7Q6cw4dmDg5mjrkxnd0XgNI1Vr6LBSKCMhFc0ScH5gojC3lx8AfrPQ==",
+        "dependencies": {
+          "cdktf": "cdktf@0.18.2_constructs@10.3.0",
           "constructs": "constructs@10.3.0"
         }
       },
@@ -372,6 +381,15 @@
           "archiver": "archiver@5.3.1",
           "constructs": "constructs@10.3.0",
           "json-stable-stringify": "json-stable-stringify@1.0.2",
+          "semver": "semver@7.5.4"
+        }
+      },
+      "cdktf@0.18.2_constructs@10.3.0": {
+        "integrity": "sha512-ohCsfFwEjXbF4bGbzkx/YB/aq6spceAPtKBXfdF/kNjUx1hVH28lQDS5ykJbnxAAnvrUA8FWz034buun7uPrdQ==",
+        "dependencies": {
+          "archiver": "archiver@5.3.1",
+          "constructs": "constructs@10.3.0",
+          "json-stable-stringify": "json-stable-stringify@1.1.0",
           "semver": "semver@7.5.4"
         }
       },

--- a/src/outputs/terraform/cdktf-deps.ts
+++ b/src/outputs/terraform/cdktf-deps.ts
@@ -17,7 +17,7 @@ export * as CDKTFProviderAWS from "npm:@cdktf/provider-aws";
 export * as CDKTFProviderAzure from "npm:@cdktf/provider-azurerm";
 export * as CDKTFProviderGCP from "npm:@cdktf/provider-google";
 export * as CDKTFProviderHelm from "npm:@cdktf/provider-helm";
-export * as CDKTFProviderKubernetes from "npm:@cdktf/provider-kubernetes";
+export * as CDKTFProviderKubernetes from "npm:@cdktf/provider-kubernetes@9";
 export * as CDKTFProviderTime from "npm:@cdktf/provider-time";
 export * as CDKTFProviderTls from "npm:@cdktf/provider-tls";
 export * as CDKTFProviderLocal from "npm:@cdktf/provider-local";


### PR DESCRIPTION
# Description
- function signature has changed when using the Kubernetes provider in EKS due to the K8s provider having been upgraded, this PR rejects that upgrade by pinning `@cdktf/provider-kubernetes@9`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

- [ ] deploy an EKS cluster

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
