### PR TITLE
[Bug]: install awscli v1 to fix `aws/eks` deployments

### DIFF
--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -54,6 +54,10 @@ const cndiWorkflowObj = {
           uses: "polyseam/setup-cndi@v2",
         },
         {
+          name: "install awscli 1",
+          run: "pip install -U awscli",
+        },
+        {
           name: "cndi run",
           env: {
             ARM_REGION: "${{ vars.ARM_REGION }}",
@@ -157,6 +161,10 @@ const getWorkflowYaml = (sourceRef?: string) => {
       with: {
         "fetch-depth": 0,
       },
+    },
+    {
+      name: "install awscli 1",
+      run: "pip install -U awscli",
     },
     {
       name: "cndi run",


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #731 

# Description

`aws/eks` clusters were failing to deploy using the version of the `aws` cli installed by default in the GitHub Actions runtime, we can solve this _temporarily_ by running `pip install -U awscli` to replace that default 2.x installation with a 1.x installation

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
