### PR TITLE
add test with -l and -k

### DIFF
--- a/src/tests/commands/init_test.ts
+++ b/src/tests/commands/init_test.ts
@@ -1,6 +1,6 @@
 import { assert /*beforeEach, describe, it*/ } from "test-deps";
 
-import { path } from "deps";
+import { path, YAML } from "deps";
 
 import { runCndi } from "src/tests/helpers/run-cndi.ts";
 
@@ -190,6 +190,35 @@ Deno.test(
       assert(dotenv.indexOf(`AWS_SECRET_ACCESS_KEY`) > -1);
       assert(dotenv.indexOf(`AWS_ACCESS_KEY_ID`) > -1);
       // assert(status.success);
+    });
+    await t.step("cleanup", async () => {
+      Deno.chdir("..");
+      await Deno.remove(dir, { recursive: true });
+    });
+  },
+);
+
+Deno.test(
+  "'cndi init -t airflow -l aws/microk8s' should generate a cndi_responses.yaml which parses successfully",
+  async (t) => {
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
+    await t.step("test", async () => {
+      /* const { status } = */ await runCndi(
+        "init",
+        "-t",
+        "airflow",
+        "-l",
+        "aws/microk8s",
+        "-k"
+      );
+
+      const cndi_responses = Deno.readTextFileSync(path.join(Deno.cwd(), `cndi_responses.yaml`));
+      assert(YAML.parse(cndi_responses));
     });
     await t.step("cleanup", async () => {
       Deno.chdir("..");

--- a/src/tests/commands/init_test.ts
+++ b/src/tests/commands/init_test.ts
@@ -214,10 +214,12 @@ Deno.test(
         "airflow",
         "-l",
         "aws/microk8s",
-        "-k"
+        "-k",
       );
 
-      const cndi_responses = Deno.readTextFileSync(path.join(Deno.cwd(), `cndi_responses.yaml`));
+      const cndi_responses = Deno.readTextFileSync(
+        path.join(Deno.cwd(), `cndi_responses.yaml`),
+      );
       assert(YAML.parse(cndi_responses));
     });
     await t.step("cleanup", async () => {


### PR DESCRIPTION
# Description

- [x] add test which verifies `cndi init -k -l aws/microk8s -t airflow` runs successfully and generates a valid `cndi_responses.yaml`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
