### PR TITLE
[Bug]: Prompts of type `File` fail to ingest contents

### DIFF
--- a/src/outputs/sealed-secret-manifest.ts
+++ b/src/outputs/sealed-secret-manifest.ts
@@ -188,7 +188,7 @@ function addSecretPlaceholder(secretEnvName: string, dotEnvPath: string) {
     if (needsHeading) {
       dotEnvLines.push(`\n${secretHeading}\n${secretEnvName}='${placeholder}'`);
     } else {
-      dotEnvLines.push(`\n${secretEnvName}='${placeholder}'`);
+      dotEnvLines.push(`${secretEnvName}='${placeholder}'`);
     }
 
     Deno.writeTextFileSync(dotEnvPath, dotEnvLines.join("\n"));

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -907,10 +907,10 @@ async function processCNDIEnvOutput(envSpecRaw: Record<string, unknown>) {
         for (const blockKey in block) {
           envSpec[blockKey] = block[blockKey];
         }
-      } catch (error) {
-        console.log("error processing block .env", error);
-        console.log(obj.value);
-        return { error: new Error("block imports must return YAML Objects") };
+      } catch {
+        return {
+          error: new Error("'.env' get_block calls must return YAML Objects"),
+        };
       }
     }
   }


### PR DESCRIPTION
# Description

- [x] Prompts with `type: File` will now return file contents as the response value instead of the raw path

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
