### PR TITLE
fix: ensure block arguments respect non-string prompt response types

### DIFF
--- a/src/use-template/util/strings.ts
+++ b/src/use-template/util/strings.ts
@@ -19,7 +19,12 @@ export function processBlockBodyArgs(
   for (const key in args) {
     if (blk.indexOf(`{{$cndi.get_arg(${key})}}`) > -1) {
       const val = args[key];
-      blk = blk.replaceAll(`{{$cndi.get_arg(${key})}}`, `${val}`);
+      if (typeof val !== "string") {
+        blk = blk.replaceAll(`'{{$cndi.get_arg(${key})}}'`, `${val}`);
+        blk = blk.replaceAll(`"{{$cndi.get_arg(${key})}}"`, `${val}`);
+      } else {
+        blk = blk.replaceAll(`{{$cndi.get_arg(${key})}}`, `${val}`);
+      }
     }
   }
   return blk;


### PR DESCRIPTION
# Description

- [x] block body processor removes quotes around prompt responses which are not strings

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
