### PR TITLE
[Bug]: fix some multiline env values can fail to parse

### DIFF
--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -930,7 +930,7 @@ async function processCNDIEnvOutput(envSpecRaw: Record<string, unknown>) {
       envLines.push(`\n# ${val}`);
     } else if (key.startsWith("$cndi.get_block")) {
       // do nothing, already handled
-    } else if (val === "") {
+    } else if (val === "" || val === "''") {
       const placeholder = `__${key}_PLACEHOLDER__`;
       envLines.push(`${key}=${placeholder}`);
     } else {

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -902,14 +902,22 @@ async function processCNDIEnvOutput(envSpecRaw: Record<string, unknown>) {
       // so we call the literalize function on each value in the block instead
       // and wrap the result in quotes
 
-      const block = YAML.parse(obj.value) as Record<string, unknown>;
       try {
+        const block = YAML.parse(obj.value) as Record<string, unknown>;
         for (const blockKey in block) {
-          envSpec[blockKey] = `'${literalizeGetPromptResponseCalls(`${block[blockKey]}`)}'`;
+          envSpec[blockKey] = `'${
+            literalizeGetPromptResponseCalls(`${block[blockKey]}`)
+          }'`;
         }
-      } catch(_error) {
+      } catch (error) {
         return {
-          error: new Error("'.env' get_block calls must return YAML Objects"),
+          error: new Error([
+            templatesLabel,
+            "template error:\n",
+            `template error: '$cndi.get_block(${identifier})' call in outputs.env must return a flat YAML string`,
+            ccolors.caught(error),
+          ].join(" ")),
+          cause: 4501,
         };
       }
     }


### PR DESCRIPTION
# Description

- Some multiline environment variables could fail to parse because the string substitution logic did not properly account for YAML indentation in some cases

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
