### PR TITLE
[Bug]:`git_credentials_mode: ssh` is missing cloud-init template

### DIFF
--- a/cndi_config.yaml
+++ b/cndi_config.yaml
@@ -4,6 +4,8 @@ provider: aws
 distribution: microk8s
 infrastructure:
   cndi:
+    functions:
+      myfunc: $cndi_on_ow.load_func(mytypescript.ts)
     cert_manager:
       email: matt.johnston@polyseam.io
     nodes:
@@ -15,3 +17,7 @@ infrastructure:
         disk_size: 100
 cluster_manifests: {}
 applications: {}
+
+# function(Request) => Response.ts
+
+# gcloud functions deploy myfunc.ts

--- a/cndi_config.yaml
+++ b/cndi_config.yaml
@@ -17,7 +17,3 @@ infrastructure:
         disk_size: 100
 cluster_manifests: {}
 applications: {}
-
-# function(Request) => Response.ts
-
-# gcloud functions deploy myfunc.ts

--- a/src/outputs/terraform/aws/AWSMicrok8sStack.ts
+++ b/src/outputs/terraform/aws/AWSMicrok8sStack.ts
@@ -182,7 +182,7 @@ export class AWSMicrok8sStack extends AWSCoreTerraformStack {
       if (role === "leader") {
         if (useSshRepoAuth()) {
           userData = Fn.templatefile(
-            "microk8s-cloud-init-leader-ssh.yml.tftpl",
+            "microk8s-cloud-init-leader.yml.tftpl",
             {
               bootstrap_token: this.locals.bootstrap_token.asString!,
               git_repo_encoded: Fn.base64encode(

--- a/src/outputs/terraform/azure/AzureMicrok8sStack.ts
+++ b/src/outputs/terraform/azure/AzureMicrok8sStack.ts
@@ -273,7 +273,7 @@ export class AzureMicrok8sStack extends AzureCoreTerraformStack {
         if (role === "leader") {
           if (useSshRepoAuth()) {
             userData = Fn.base64encode(
-              Fn.templatefile("microk8s-cloud-init-leader-ssh.yml.tftpl", {
+              Fn.templatefile("microk8s-cloud-init-leader.yml.tftpl", {
                 bootstrap_token: this.locals.bootstrap_token.asString!,
                 git_repo_encoded: Fn.base64encode(
                   this.variables.git_repo.stringValue,

--- a/src/outputs/terraform/dev/DevMultipassMicrok8sStack.ts
+++ b/src/outputs/terraform/dev/DevMultipassMicrok8sStack.ts
@@ -51,7 +51,7 @@ export class DevMultipassMicrok8sStack extends CNDITerraformStack {
 
     if (useSshRepoAuth()) {
       userData = Fn.templatefile(
-        "microk8s-cloud-init-leader-ssh.yml.tftpl",
+        "microk8s-cloud-init-leader.yml.tftpl",
         {
           bootstrap_token: this.locals.bootstrap_token.asString!,
           git_repo_encoded: Fn.base64encode(

--- a/src/outputs/terraform/gcp/GCPMicrok8sStack.ts
+++ b/src/outputs/terraform/gcp/GCPMicrok8sStack.ts
@@ -192,7 +192,7 @@ export class GCPMicrok8sStack extends GCPCoreTerraformStack {
         if (role === "leader") {
           if (useSshRepoAuth()) {
             userData = Fn.templatefile(
-              "microk8s-cloud-init-leader-ssh.yml.tftpl",
+              "microk8s-cloud-init-leader.yml.tftpl",
               {
                 bootstrap_token: this.locals.bootstrap_token.asString!,
                 git_repo_encoded: Fn.base64encode(


### PR DESCRIPTION
# Description

- New CNDI Projects initialized with `git_credentials_mode: ssh` would fail due to a naming error in cloud-init templates

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
