### PR TITLE
[Bug]: throws response undefined in identifier with falsy condition

### DIFF
--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -27,7 +27,6 @@ import {
 } from "./util/strings.ts";
 
 import { unsetValueForKeyPath } from "deps";
-import { getPrettyJSONString } from "src/utils.ts";
 
 type BuiltInValidator = keyof typeof BuiltInValidators;
 
@@ -694,15 +693,12 @@ async function processCNDIConfigOutput(
     cndiConfigObj = YAML.parse(output) as object;
 
     const key = output.slice(indexOpen, indexClose + 1); // get_block key which contains body
-    Deno.writeTextFileSync(`key-${ax}.yaml`, key);
     const pathToKey = findPathToKey(key, cndiConfigObj); // path to first instance of key
 
     // load value of key
     const body = getValueFromKeyPath(cndiConfigObj, pathToKey) as GetBlockBody;
 
     if (!body) {
-      console.log("responses");
-      console.log(getPrettyJSONString($cndi.getResponsesAsRecord()));
       return { error: new Error(`No value found for key: ${key}`) };
     }
 

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -212,6 +212,7 @@ Deno.test(
     // deno-lint-ignore no-explicit-any
     const parsed = YAML.parse(template.files["cndi_config.yaml"]) as any;
 
+    assert(!parsed.infrastructure?.cndi?.external_dns);
     assert(!parsed.infrastructure?.cndi?.external_dns?.enabled);
     assert(JSON.stringify(parsed.infrastructure?.cndi?.external_dns) !== "{}");
   },

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -192,3 +192,27 @@ Deno.test(
     assert(parsed.provider === "azure");
   },
 );
+
+Deno.test(
+  "template execution: when external_dns is disabled the 'basic' template should not have external_dns in cndi_config.yaml",
+  mySanity,
+  async () => {
+    // Deno.cwd() is the root of the project
+
+    const template = await useTemplate("basic", {
+      interactive: false,
+      overrides: {
+        deployment_target_provider: "azure",
+        enable_external_dns: false,
+      },
+    });
+
+    console.log(template.files["cndi_config.yaml"]);
+
+    // deno-lint-ignore no-explicit-any
+    const parsed = YAML.parse(template.files["cndi_config.yaml"]) as any;
+
+    assert(!parsed.infrastructure?.cndi?.external_dns?.enabled);
+    assert(JSON.stringify(parsed.infrastructure?.cndi?.external_dns) !== "{}");
+  },
+);

--- a/src/use-template/util/strings.ts
+++ b/src/use-template/util/strings.ts
@@ -41,6 +41,8 @@ export function removeWhitespaceBetweenBraces(input: string): string {
   });
 }
 
+// This function finds the position of the closing parenthesis of a CNDI call
+// ignoring those which occur inside curly braces {{ ... }}
 export function findPositionOfCNDICallEndToken(
   input: string,
   startPosition: number = 0,

--- a/src/use-template/util/strings.ts
+++ b/src/use-template/util/strings.ts
@@ -40,3 +40,29 @@ export function removeWhitespaceBetweenBraces(input: string): string {
     return `{{${match.slice(2, -2).replace(/\s+/g, "")}}}`;
   });
 }
+
+export function findPositionOfCNDICallEndToken(
+  input: string,
+  startPosition: number = 0,
+): number | null {
+  const stack: string[] = [];
+
+  for (let i = startPosition; i < input.length; i++) {
+    const char = input[i];
+
+    // If it's an opening curly brace, push it onto the stack
+    if (char === "{") {
+      stack.push(char);
+    } // If it's a closing curly brace and there's a corresponding opening, pop the stack
+    else if (
+      char === "}" && stack.length > 0 && stack[stack.length - 1] === "{"
+    ) {
+      stack.pop();
+    } // If it's a closing parenthesis and the stack is empty (meaning we're not inside curly braces)
+    else if (char === ")" && stack.length === 0) {
+      return i; // Return the index of the closing parenthesis
+    }
+  }
+
+  return null; // Return null if no such closing parenthesis is found
+}


### PR DESCRIPTION
# Description

- Template module could fail to resolve correctly if there were undefined prompts in the identifier component of `$cndi.get_block(identifier)` calls, even if the condition of the call is unmet.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
