### PR TITLE
[Bug]: `gcp/microk8s` clusters required multiple `cndi run` executions to succeed

### DIFF
--- a/src/outputs/terraform/gcp/GCPMicrok8sStack.ts
+++ b/src/outputs/terraform/gcp/GCPMicrok8sStack.ts
@@ -64,22 +64,13 @@ export class GCPMicrok8sStack extends GCPCoreTerraformStack {
       },
     );
 
-    const projectServicesReady = new CDKTFProviderTime.sleep.Sleep(
-      this,
-      "cndi_time_sleep_services_ready",
-      {
-        createDuration: "60s",
-        dependsOn: [projectServiceCloudResourceManager, projectServiceCompute],
-      },
-    );
-
     const computeNetwork = new CDKTFProviderGCP.computeNetwork.ComputeNetwork(
       this,
       "cndi_google_compute_network",
       {
         name: "cndi-compute-network", // rename to cndi-compute-network
         autoCreateSubnetworks: false,
-        dependsOn: [projectServicesReady],
+        dependsOn: [projectServiceCompute],
       },
     );
 
@@ -195,7 +186,7 @@ export class GCPMicrok8sStack extends GCPCoreTerraformStack {
             size: volumeSize,
             zone: this.locals.gcp_zone.asString,
             type: "pd-ssd",
-            dependsOn: [projectServicesReady],
+            dependsOn: [projectServiceCompute],
           },
         );
 
@@ -307,7 +298,7 @@ export class GCPMicrok8sStack extends GCPCoreTerraformStack {
         tcpHealthCheck: {
           port: 80,
         },
-        dependsOn: [projectServicesReady],
+        dependsOn: [projectServiceCompute],
       },
     );
 


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #736 

# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
