### PR TITLE
[Bug]: EKS Nodes are not tagged with CNDIProject

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -782,6 +782,10 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           scalingConfig,
           capacityType: "ON_DEMAND",
           subnetIds: [subnetPrivateA.id],
+          launchTemplate: {
+            id: nodegroupLaunchTemplate.id,
+            version: nodegroupLaunchTemplate.latestVersion,
+          },
           updateConfig: { maxUnavailable: 1 },
           dependsOn: [
             workerNodePolicyAttachment,

--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -748,7 +748,27 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
       if (minCount) {
         scalingConfig.minSize = minCount;
       }
-
+      const nodegroupLaunchTemplate = new CDKTFProviderAWS.launchTemplate
+        .LaunchTemplate(
+        this,
+        `cndi_aws_launch_template_${nodeGroupIndex}`,
+        {
+          name: `cndi-${nodeGroupName}-${nodeGroupIndex}`,
+          tagSpecifications: [
+            {
+              resourceType: "instance",
+              tags: {
+                Name: `cndi-${project_name}-${nodeGroupName}-workers`,
+              },
+            },
+          ],
+          dependsOn: [
+            workerNodePolicyAttachment,
+            cniPolicyAttachment,
+            containerRegistryAttachment,
+          ],
+        },
+      );
       const ng = new CDKTFProviderAWS.eksNodeGroup.EksNodeGroup(
         this,
         `cndi_aws_eks_node_group_${nodeGroupIndex}`,
@@ -767,6 +787,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
             workerNodePolicyAttachment,
             cniPolicyAttachment,
             containerRegistryAttachment,
+            nodegroupLaunchTemplate,
           ],
         },
       );

--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -731,7 +731,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
       const instanceType = nodeGroup?.instance_type ||
         DEFAULT_INSTANCE_TYPES.aws;
 
-      const diskSize = nodeGroup?.volume_size ||
+      const volumeSize = nodeGroup?.volume_size ||
         nodeGroup?.disk_size ||
         nodeGroup?.disk_size_gb ||
         DEFAULT_NODE_DISK_SIZE_MANAGED;
@@ -754,11 +754,20 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         `cndi_aws_launch_template_${nodeGroupIndex}`,
         {
           name: `cndi-${nodeGroupName}-${nodeGroupIndex}`,
+          blockDeviceMappings: [
+            {
+              deviceName: "/dev/sdf",
+              ebs: {
+                volumeSize,
+              },
+            },
+          ],
           tagSpecifications: [
             {
               resourceType: "instance",
               tags: {
-                Name: `cndi-${project_name}-${nodeGroupName}-workers`,
+                Name: nodeGroupName,
+                CNDIProject: project_name,
               },
             },
           ],
@@ -775,7 +784,6 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         {
           clusterName: eksCluster.name,
           amiType: "AL2_x86_64",
-          diskSize, // GiB
           instanceTypes: [instanceType],
           nodeGroupName,
           nodeRoleArn: computeRole.arn,


### PR DESCRIPTION
# Add Name and CNDIProject Tag to EKS Nodegroup Instances
# Issue  
#431

# Description
Created a new launch template resource that includes configurations for disk size, and tagging with CNDIProject.
Updated the aws_eks_node_group resource to reference the new launch template.

# Test Instructions

added two nodegroups x-node-group(3 instances) and y-node-group(1instance)
![image](https://github.com/polyseam/cndi/assets/77031428/e54631a8-f062-4375-926b-47aaf7d4631b)

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [ ] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
