### PR TITLE
[Enhancement]: add `--responses-file` to `cndi create`

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -47,6 +47,7 @@ type EchoCreateOptions = {
   nonInteractive?: unknown;
   output?: string;
   deploymentTargetLabel?: string;
+  responses: string;
 };
 
 const echoCreate = (options: EchoCreateOptions, slug?: string) => {
@@ -82,6 +83,13 @@ const createCommand = new Command()
   .option(
     "-t, --template <template:string>",
     "CNDI Template to use for the new project.",
+  )
+  .option(
+    "-r, --responses <responses:string>",
+    "Responses file to use for the new project.",
+    {
+      default: path.join(Deno.cwd(), "cndi_responses.yaml"),
+    },
   )
   .option(
     `-s, --set <set>`,
@@ -173,7 +181,7 @@ const createCommand = new Command()
     let responsesFileText = "";
     try {
       responsesFileText = await Deno.readTextFile(
-        path.join(destinationDirectory, "cndi_responses.yaml"),
+        options.responses,
       );
     } catch (errorLoadingResponses) {
       if (errorLoadingResponses instanceof Deno.errors.NotFound) {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -47,7 +47,7 @@ type EchoCreateOptions = {
   nonInteractive?: unknown;
   output?: string;
   deploymentTargetLabel?: string;
-  responses: string;
+  responsesFile: string;
 };
 
 const echoCreate = (options: EchoCreateOptions, slug?: string) => {
@@ -85,8 +85,8 @@ const createCommand = new Command()
     "CNDI Template to use for the new project.",
   )
   .option(
-    "-r, --responses <responses:string>",
-    "Responses file to use for the new project.",
+    "-r, --responses-file <responses_file:string>",
+    "Path to YAML 'responses file' to supply to Template prompts.",
     {
       default: path.join(Deno.cwd(), "cndi_responses.yaml"),
     },
@@ -181,7 +181,7 @@ const createCommand = new Command()
     let responsesFileText = "";
     try {
       responsesFileText = await Deno.readTextFile(
-        options.responses,
+        options.responsesFile,
       );
     } catch (errorLoadingResponses) {
       if (errorLoadingResponses instanceof Deno.errors.NotFound) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -81,7 +81,7 @@ const initCommand = new Command()
   })
   .option(
     "-r, --responses-file <responses_file:string>",
-    "A path to a set of responses to supply to your template",
+    "Path to YAML 'responses file' to supply to Template prompts.",
     {
       default: defaultResponsesFilePath,
     },


### PR DESCRIPTION
# Description

Though initially omitted to simplify the user-facing surface of `cndi create`, I've added `--responses-file` to the options because the default file `cndi_responses.yaml` is not likely to exist and be relevant in the _parent_ folder of the new project.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
