### PR TITLE
[Enhancement]: Run `cndi --help` immediately after `cndi upgrade` to ensure fast performance upon exit

### DIFF
--- a/src/cliffy-provider-gh-releases/mod.ts
+++ b/src/cliffy-provider-gh-releases/mod.ts
@@ -311,7 +311,7 @@ export class GithubReleasesProvider extends Provider {
         const fromMsg = from ? ` from version ${colors.yellow(from)}` : "";
         console.log(
           `Successfully upgraded ${
-            colors.green(
+            colors.cyan(
               name,
             )
           }${fromMsg} to version ${colors.green(to)}!\n`,

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -5,7 +5,6 @@ import {
 } from "src/cliffy-provider-gh-releases/mod.ts";
 
 import { emitExitEvent, getPathToCndiBinary } from "src/utils.ts";
-import { ccolors } from "deps";
 
 const destinationDir = "~/.cndi/bin";
 
@@ -23,19 +22,16 @@ const upgradeCommand = new GithubReleasesUpgradeCommand({
       await emitExitEvent(exit_code);
       Deno.exit(exit_code);
     },
-    onComplete: async ({ to, from }, spinner) => {
+    onComplete: async (_metadata, printSuccessMessage) => {
       const pathToCndiBinary = getPathToCndiBinary();
+      // preheat binary before logging success message
       const cmd = new Deno.Command(pathToCndiBinary, { args: ["--help"] });
-      await cmd.output(); // wait for warm bin before logging success message
-      spinner.stop();
-      const fromMsg = from ? ` from version ${ccolors.warn(from)}` : "";
-      console.log(
-        `Successfully upgraded ${
-          ccolors.success(
-            "cndi",
-          )
-        }${fromMsg} to version ${ccolors.success(to)}!\n`,
-      );
+      await cmd.output();
+
+      // print success message
+      printSuccessMessage();
+
+      // exit successfully
       await emitExitEvent(0);
       Deno.exit(0);
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -566,6 +566,16 @@ const getProjectDirectoryFromFlag = (value: string | boolean) => {
   return typeof value === "boolean" ? Deno.cwd() : absolutifyPath(value);
 };
 
+function getPathToCndiBinary() {
+  const DEFAULT_CNDI_HOME = path.join(homedir(), ".cndi");
+  const CNDI_HOME = Deno.env.get("CNDI_HOME") || DEFAULT_CNDI_HOME;
+  let suffix = "";
+  if (platform() === "win32") {
+    suffix = ".exe";
+  }
+  return path.join(CNDI_HOME, "bin", `cndi${suffix}`);
+}
+
 export {
   checkForRequiredMissingCreateRepoValues,
   checkInitialized,
@@ -574,6 +584,7 @@ export {
   getCDKTFAppConfig,
   getCndiInstallPath,
   getFileSuffixForPlatform,
+  getPathToCndiBinary,
   getPathToCndiConfig,
   getPathToKubesealBinary,
   getPathToTerraformBinary,


### PR DESCRIPTION
# Description

After CNDI is upgraded and the binary is in place, we call `cndi --help` to pre-heat the binary so it is fast and ready to go immediately after being installed.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
