### PR TITLE
[Enhancement]: add `external` network topology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ cndi
 benchee.json
 
 src/tests/cwd
+
+*scratch.txt

--- a/cndi_config.yaml
+++ b/cndi_config.yaml
@@ -1,9 +1,14 @@
 cndi_version: v2
 project_name: basic-ec2
-provider: aws
+provider: gcp
 distribution: microk8s
 infrastructure:
   cndi:
+    network:
+      mode: external
+      network_name: cndi-compute-network
+      public_subnets:
+        - cndi-compute-subnetwork
     cert_manager:
       email: matt.johnston@polyseam.io
     nodes:

--- a/cndi_config.yaml
+++ b/cndi_config.yaml
@@ -4,11 +4,6 @@ provider: gcp
 distribution: microk8s
 infrastructure:
   cndi:
-    network:
-      mode: external
-      network_name: cndi-compute-network
-      public_subnets:
-        - cndi-compute-subnetwork
     cert_manager:
       email: matt.johnston@polyseam.io
     nodes:

--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -112,12 +112,12 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         ),
       ];
     } else if (netconfig.mode === "external") {
+      netconfig = netconfig as CNDINetworkConfigExternalAWS;
       vpc = new CDKTFProviderAWS.dataAwsVpc.DataAwsVpc(
         this,
         "cndi_aws_vpc",
         {},
       );
-      netconfig = netconfig as CNDINetworkConfigExternalAWS;
       primary_subnet = new CDKTFProviderAWS.dataAwsSubnet.DataAwsSubnet(
         this,
         "cndi_aws_subnet_primary",

--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -405,7 +405,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           endpointPrivateAccess: true,
           endpointPublicAccess: true,
           securityGroupIds: [securityGroup.id],
-          subnetIds: [subnetPrivateA.id, subnetPrivateB.id, subnetPublicA.id],
+          subnetIds: [/** all subnets? */],
         },
         enabledClusterLogTypes: [
           "api",
@@ -761,7 +761,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           nodeRoleArn: computeRole.arn,
           scalingConfig,
           capacityType: "ON_DEMAND",
-          subnetIds: [subnetPrivateA.id],
+          subnetIds: [/** all private subnets (if exist else public) */],
           updateConfig: { maxUnavailable: 1 },
           dependsOn: [
             workerNodePolicyAttachment,

--- a/src/outputs/terraform/aws/AWSMicrok8sStack.ts
+++ b/src/outputs/terraform/aws/AWSMicrok8sStack.ts
@@ -84,7 +84,9 @@ export class AWSMicrok8sStack extends AWSCoreTerraformStack {
       vpc = new CDKTFProviderAWS.dataAwsVpc.DataAwsVpc(
         this,
         "cndi_aws_vpc",
-        {},
+        {
+          id: netconfig.aws.vpc_id,
+        },
       );
       primary_subnet = new CDKTFProviderAWS.dataAwsSubnet.DataAwsSubnet(
         this,

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -57,12 +57,12 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
   constructor(scope: Construct, name: string, cndi_config: CNDIConfig) {
     super(scope, name, cndi_config);
 
-    const network = cndi_config?.infrastructure?.cndi?.network || {
+    const netconfig = cndi_config?.infrastructure?.cndi?.network || {
       mode: "encapsulated",
     };
 
-    if (!network.mode) {
-      network.mode = "encapsulated";
+    if (!netconfig.mode) {
+      netconfig.mode = "encapsulated";
     }
 
     new CDKTFProviderTime.provider.TimeProvider(this, "cndi_time_provider", {});
@@ -109,7 +109,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
 
     let vnetSubnetId: string;
 
-    if (network.mode === "encapsulated") {
+    if (netconfig.mode === "encapsulated") {
       // Create a virtual network (VNet) in Azure with a dynamic address space.
       // The address space is partially determined by the random integer generated above.
       const vnet = new CDKTFProviderAzure.virtualNetwork.VirtualNetwork(
@@ -141,16 +141,16 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
 
       // Subnet ID is used to associate the AKS node_pools with the subnet.
       vnetSubnetId = subnet.id;
-    } else if (network.mode === "external") {
+    } else if (netconfig.mode === "external") {
       // If the network mode is 'external', the subnet_identifier must be provided in the CNDI config.
-      if (!network?.subnet_identifier) {
+      if (!netconfig?.subnet_identifier) {
         throw new Error('no "subnet_identifier" provided in "external" mode');
         // TODO: with a provided vnet_id we could create a subnet here
       } else {
-        vnetSubnetId = network.subnet_identifier;
+        vnetSubnetId = netconfig.subnet_identifier;
       }
     } else {
-      throw new Error(`unsupported network mode: ${network.mode}`);
+      throw new Error(`unsupported network mode: ${netconfig.mode}`);
     }
 
     const nodePools: Array<AnonymousClusterNodePoolConfig> = cndi_config

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -104,8 +104,6 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
 
     let vnetSubnetId: string;
 
-    let subnet: CDKTFProviderAzure.subnet.Subnet;
-
     if (network.mode === "encapsulated") {
       // Create a virtual network (VNet) in Azure with a dynamic address space.
       // The address space is partially determined by the random integer generated above.
@@ -123,7 +121,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
 
       // Create a subnet within the above VNet.
       // The subnet address prefix is dynamically calculated using the address space multiplier.
-      subnet = new CDKTFProviderAzure.subnet.Subnet(
+      const subnet = new CDKTFProviderAzure.subnet.Subnet(
         this,
         "cndi_azure_subnet",
         {
@@ -136,13 +134,13 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
         },
       );
 
+      // Subnet ID is used to associate the AKS node_pools with the subnet.
       vnetSubnetId = subnet.id;
     } else if (network.mode === "external") {
-      // If the network mode is external, the subnet and VNet IDs are provided in the CNDI config.
-
+      // If the network mode is 'external', the subnet_identifier must be provided in the CNDI config.
       if (!network?.subnet_identifier) {
         throw new Error('no "subnet_identifier" provided in "external" mode');
-        // TODO: we should be able to create a subnet in the VNet provided
+        // TODO: with a provided vnet_id we could create a subnet here
       } else {
         vnetSubnetId = network.subnet_identifier;
       }

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -57,8 +57,13 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
   constructor(scope: Construct, name: string, cndi_config: CNDIConfig) {
     super(scope, name, cndi_config);
 
-    const network = cndi_config.infrastructure.cndi.network ??
-      { mode: "encapsulated" };
+    const network = cndi_config?.infrastructure?.cndi?.network || {
+      mode: "encapsulated",
+    };
+
+    if (!network.mode) {
+      network.mode = "encapsulated";
+    }
 
     new CDKTFProviderTime.provider.TimeProvider(this, "cndi_time_provider", {});
     new CDKTFProviderTls.provider.TlsProvider(this, "cndi_tls_provider", {});

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -144,6 +144,8 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
       } else {
         vnetSubnetId = network.subnet_identifier;
       }
+    } else {
+      throw new Error(`unsupported network mode: ${network.mode}`);
     }
 
     const nodePools: Array<AnonymousClusterNodePoolConfig> = cndi_config

--- a/src/outputs/terraform/azure/AzureMicrok8sStack.ts
+++ b/src/outputs/terraform/azure/AzureMicrok8sStack.ts
@@ -25,9 +25,13 @@ export class AzureMicrok8sStack extends AzureCoreTerraformStack {
   constructor(scope: Construct, name: string, cndi_config: CNDIConfig) {
     super(scope, name, cndi_config);
 
-    const network = cndi_config.infrastructure.cndi.network ?? {
+    const network = cndi_config?.infrastructure?.cndi?.network || {
       mode: "encapsulated",
     };
+
+    if (!network.mode) {
+      network.mode = "encapsulated";
+    }
 
     const open_ports = resolveCNDIPorts(cndi_config);
     const _nodeIdList: string[] = [];

--- a/src/outputs/terraform/azure/AzureMicrok8sStack.ts
+++ b/src/outputs/terraform/azure/AzureMicrok8sStack.ts
@@ -25,12 +25,12 @@ export class AzureMicrok8sStack extends AzureCoreTerraformStack {
   constructor(scope: Construct, name: string, cndi_config: CNDIConfig) {
     super(scope, name, cndi_config);
 
-    const network = cndi_config?.infrastructure?.cndi?.network || {
+    const netconfig = cndi_config?.infrastructure?.cndi?.network || {
       mode: "encapsulated",
     };
 
-    if (!network.mode) {
-      network.mode = "encapsulated";
+    if (!netconfig.mode) {
+      netconfig.mode = "encapsulated";
     }
 
     const open_ports = resolveCNDIPorts(cndi_config);
@@ -57,7 +57,7 @@ export class AzureMicrok8sStack extends AzureCoreTerraformStack {
     );
 
     let subnetId: string;
-    if (network.mode === "encapsulated") {
+    if (netconfig.mode === "encapsulated") {
       const vnet = new CDKTFProviderAzure.virtualNetwork.VirtualNetwork(
         this,
         "cndi_azure_vnet",
@@ -81,13 +81,13 @@ export class AzureMicrok8sStack extends AzureCoreTerraformStack {
         },
       );
       subnetId = subnet.id;
-    } else if (network.mode === "external") {
-      if (!network.subnet_identifier) {
+    } else if (netconfig.mode === "external") {
+      if (!netconfig.subnet_identifier) {
         throw new Error('no "subnet_identifier" provided in "external" mode');
       }
-      subnetId = network.subnet_identifier;
+      subnetId = netconfig.subnet_identifier;
     } else {
-      throw new Error(`unsupported network mode: ${network.mode}`);
+      throw new Error(`unsupported network mode: ${netconfig.mode}`);
     }
 
     const lb = new CDKTFProviderAzure.lb.Lb(this, "cndi_azure_load_balancer", {

--- a/src/outputs/terraform/azure/utils.ts
+++ b/src/outputs/terraform/azure/utils.ts
@@ -1,0 +1,19 @@
+export function parseNetworkResourceId(networkResourceId: string) {
+  // /subscriptions/12345678/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet
+  const [
+    _subscriptions, // 'subscriptions'
+    _subscription, // '123456'
+    _resourceGroups, // 'resourceGroups'
+    resourceGroupName, // 'my-rg'
+    _providers, // 'providers'
+    _provider, // 'Microsoft.Network'
+    _virtualNetworks, // 'virtualNetworks'
+    virtualNetworkName, // 'my-vnet'
+  ] = networkResourceId.split("/");
+
+  if (!resourceGroupName || !virtualNetworkName) {
+    throw new Error(`Invalid network resource id: ${networkResourceId}`);
+  }
+
+  return { resourceGroupName, virtualNetworkName };
+}

--- a/src/outputs/terraform/azure/utils.ts
+++ b/src/outputs/terraform/azure/utils.ts
@@ -1,6 +1,7 @@
 export function parseNetworkResourceId(networkResourceId: string) {
   // /subscriptions/12345678/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet
   const [
+    _leadingSlash,
     _subscriptions, // 'subscriptions'
     _subscription, // '123456'
     _resourceGroups, // 'resourceGroups'

--- a/src/outputs/terraform/netconfig.ts
+++ b/src/outputs/terraform/netconfig.ts
@@ -12,7 +12,6 @@ export default function getNetConfig(
   provider: CNDIProvider,
 ) {
   let netconfig = cndi_config?.infrastructure?.cndi?.network;
-
   if (netconfig?.mode === "external") {
     if (provider === "azure") {
       netconfig = netconfig as CNDINetworkConfigExternalAzure;
@@ -40,13 +39,14 @@ export default function getNetConfig(
       netconfig = netconfig as CNDINetworkConfigExternalAWS;
       const vpc_id = netconfig?.aws?.vpc_id;
       const primary_subnet = netconfig?.aws?.primary_subnet;
-      const private_subnets = netconfig?.aws?.private_subnets;
+      const private_subnets = netconfig?.aws?.private_subnets ?? [];
 
       if (!vpc_id) {
         throw new Error('no "network" provided in aws "external" mode');
-      }
-      if (!private_subnets) {
-        throw new Error('no "subnets" provided in aws "external" mode');
+      } else {
+        if (!primary_subnet) {
+          throw new Error('no "primary_subnet" provided in "external" mode');
+        }
       }
 
       return {

--- a/src/outputs/terraform/netconfig.ts
+++ b/src/outputs/terraform/netconfig.ts
@@ -1,9 +1,9 @@
 import {
   CNDIConfig,
-  CNDINetworkConfigAWS,
-  CNDINetworkConfigAzure,
   CNDINetworkConfigEncapsulated,
-  CNDINetworkConfigGCP,
+  CNDINetworkConfigExternalAWS,
+  CNDINetworkConfigExternalAzure,
+  CNDINetworkConfigExternalGCP,
   CNDIProvider,
 } from "src/types.ts";
 
@@ -15,32 +15,37 @@ export default function getNetConfig(
 
   if (netconfig?.mode === "external") {
     if (provider === "azure") {
-      netconfig = netconfig as CNDINetworkConfigAzure;
-      const subnets = netconfig?.azure?.subnets;
+      netconfig = netconfig as CNDINetworkConfigExternalAzure;
+      const primary_subnet = netconfig?.azure?.primary_subnet;
+      const private_subnets = netconfig?.azure?.private_subnets;
       const network_resource_id = netconfig?.azure?.network_resource_id;
+
       if (!network_resource_id) {
         throw new Error(
           'no "network_resource_id" provided in azure "external" mode',
         );
       }
+
       return {
         mode: "external",
         azure: {
           network_resource_id,
-          subnets,
+          primary_subnet,
+          private_subnets,
         },
-      } as CNDINetworkConfigAzure;
+      } as CNDINetworkConfigExternalAzure;
     }
 
     if (provider === "aws") {
-      netconfig = netconfig as CNDINetworkConfigAWS;
+      netconfig = netconfig as CNDINetworkConfigExternalAWS;
       const vpc_id = netconfig?.aws?.vpc_id;
-      const subnets = netconfig?.aws?.subnets;
+      const primary_subnet = netconfig?.aws?.primary_subnet;
+      const private_subnets = netconfig?.aws?.private_subnets;
 
       if (!vpc_id) {
         throw new Error('no "network" provided in aws "external" mode');
       }
-      if (!subnets) {
+      if (!private_subnets) {
         throw new Error('no "subnets" provided in aws "external" mode');
       }
 
@@ -48,33 +53,36 @@ export default function getNetConfig(
         mode: "external",
         aws: {
           vpc_id,
-          subnets,
+          primary_subnet,
+          private_subnets,
         },
-      } as CNDINetworkConfigAWS;
+      } as CNDINetworkConfigExternalAWS;
     }
 
     if (provider === "gcp") {
-      netconfig = netconfig as CNDINetworkConfigGCP;
+      netconfig = netconfig as CNDINetworkConfigExternalGCP;
       const network_name = netconfig?.gcp?.network_name;
-      const subnets = netconfig?.gcp?.subnets;
+      const private_subnets = netconfig?.gcp?.private_subnets;
+      const primary_subnet = netconfig?.gcp?.primary_subnet;
       const project = netconfig?.gcp?.project;
 
       if (!network_name) {
         throw new Error('no "network" provided in "external" mode');
       }
 
-      if (!subnets) {
-        throw new Error('no "public_subnet" provided in "external" mode');
+      if (!primary_subnet) {
+        throw new Error('no "primary_subnet" provided in "external" mode');
       }
 
       return {
         mode: "external",
         gcp: {
-          project,
           network_name,
-          subnets,
+          primary_subnet,
+          private_subnets,
+          project,
         },
-      } as CNDINetworkConfigGCP;
+      } as CNDINetworkConfigExternalGCP;
     }
   }
 

--- a/src/outputs/terraform/netconfig.ts
+++ b/src/outputs/terraform/netconfig.ts
@@ -1,0 +1,88 @@
+import {
+  CNDIConfig,
+  CNDINetworkConfigAWS,
+  CNDINetworkConfigAzure,
+  CNDINetworkConfigEncapsulated,
+  CNDINetworkConfigGCP,
+  CNDIProvider,
+} from "src/types.ts";
+
+export default function getNetConfig(
+  cndi_config: CNDIConfig,
+  provider: CNDIProvider,
+) {
+  let netconfig = cndi_config?.infrastructure?.cndi?.network;
+
+  if (netconfig?.mode === "external") {
+    if (provider === "azure") {
+      netconfig = netconfig as CNDINetworkConfigAzure;
+      const subnets = netconfig?.azure?.subnets;
+      const network_resource_id = netconfig?.azure?.network_resource_id;
+      if (!network_resource_id) {
+        throw new Error(
+          'no "network_resource_id" provided in azure "external" mode',
+        );
+      }
+      return {
+        mode: "external",
+        azure: {
+          network_resource_id,
+          subnets,
+        },
+      } as CNDINetworkConfigAzure;
+    }
+
+    if (provider === "aws") {
+      netconfig = netconfig as CNDINetworkConfigAWS;
+      const vpc_id = netconfig?.aws?.vpc_id;
+      const subnets = netconfig?.aws?.subnets;
+
+      if (!vpc_id) {
+        throw new Error('no "network" provided in aws "external" mode');
+      }
+      if (!subnets) {
+        throw new Error('no "subnets" provided in aws "external" mode');
+      }
+
+      return {
+        mode: "external",
+        aws: {
+          vpc_id,
+          subnets,
+        },
+      } as CNDINetworkConfigAWS;
+    }
+
+    if (provider === "gcp") {
+      netconfig = netconfig as CNDINetworkConfigGCP;
+      const network_name = netconfig?.gcp?.network_name;
+      const subnets = netconfig?.gcp?.subnets;
+      const project = netconfig?.gcp?.project;
+
+      if (!network_name) {
+        throw new Error('no "network" provided in "external" mode');
+      }
+
+      if (!subnets) {
+        throw new Error('no "public_subnet" provided in "external" mode');
+      }
+
+      return {
+        mode: "external",
+        gcp: {
+          project,
+          network_name,
+          subnets,
+        },
+      } as CNDINetworkConfigGCP;
+    }
+  }
+
+  if (netconfig?.mode && netconfig.mode !== "encapsulated") {
+    throw new Error(`invalid network mode: '${netconfig.mode}'`);
+  }
+
+  return {
+    mode: "encapsulated",
+  } as CNDINetworkConfigEncapsulated;
+}

--- a/src/schemas/cndi_config.schema.json
+++ b/src/schemas/cndi_config.schema.json
@@ -124,6 +124,78 @@
               },
               "additionalProperties": false
             },
+            "network": {
+              "type": "object",
+              "description": "An optional object which enables the configuration of various available network topologies.",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "description": "The network mode to deploy the cluster in.",
+                  "enum": ["encapsulated", "external"],
+                  "default": "encapsulated"
+                },
+                "aws": {
+                  "type": "object",
+                  "properties": {
+                    "vpc": {
+                      "type": "string",
+                      "description": "The VPC to deploy the cluster into."
+                    },
+                    "public_subnet": {
+                      "type": "string",
+                      "description": "The public subnet to deploy the cluster into."
+                    },
+                    "private_subnet": {
+                      "type": "string",
+                      "description": "The private subnet to deploy the cluster into."
+                    }
+                  }
+                },
+                "gcp": {
+                  "type": "object",
+                  "properties": {
+                    "network_name": {
+                      "type": "string",
+                      "description": "The network to deploy the cluster into."
+                    },
+                    "public_subnet_name": {
+                      "type": "string",
+                      "description": "The subnet to deploy the cluster into."
+                    },
+                    "private_subnet_name": {
+                      "type": "string",
+                      "description": "The subnet to deploy the cluster into."
+                    },
+                    "project": {
+                      "type": "string",
+                      "description": "The GCP project id to deploy the cluster into."
+                    }
+                  }
+                },
+                "azure": {
+                  "type": "object",
+                  "properties": {
+                    "resource_group": {
+                      "type": "string",
+                      "description": "The resource group to deploy the cluster into."
+                    },
+                    "vnet": {
+                      "type": "string",
+                      "description": "The VNet to deploy the cluster into."
+                    },
+                    "public_subnet_id": {
+                      "type": "string",
+                      "description": "The subnet to deploy the cluster into."
+                    },
+                    "private_subnet_id": {
+                      "type": "string",
+                      "description": "The subnet to deploy the cluster into."
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
             "cert_manager": {
               "properties": {
                 "enabled": {

--- a/src/schemas/cndi_config.schema.json
+++ b/src/schemas/cndi_config.schema.json
@@ -141,7 +141,7 @@
                       "type": "string",
                       "description": "The VPC to deploy the cluster into."
                     },
-                    "public_subnet": {
+                    "primary_subnet": {
                       "type": "string",
                       "description": "The public subnet to deploy the cluster into."
                     },
@@ -158,7 +158,7 @@
                       "type": "string",
                       "description": "The network to deploy the cluster into."
                     },
-                    "public_subnet_name": {
+                    "primary_subnet_name": {
                       "type": "string",
                       "description": "The subnet to deploy the cluster into."
                     },
@@ -183,7 +183,7 @@
                       "type": "string",
                       "description": "The VNet to deploy the cluster into."
                     },
-                    "public_subnet_id": {
+                    "primary_subnet_id": {
                       "type": "string",
                       "description": "The subnet to deploy the cluster into."
                     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,7 +235,6 @@ export type CNDINetworkMode = "encapsulated" | "external";
 export interface CNDINetworkConfig {
   mode?: CNDINetworkMode;
   subnet_identifier?: string;
-  vnet_identifier?: string;
 }
 
 export interface CNDINetworkConfigEncapsulated extends CNDINetworkConfig {
@@ -245,7 +244,6 @@ export interface CNDINetworkConfigEncapsulated extends CNDINetworkConfig {
 export interface CNDINetworkConfigExternal extends CNDINetworkConfig {
   mode: "external";
   subnet_identifier: string;
-  vnet_identifier: string;
 }
 
 // incomplete type, config will have more options

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,24 @@ export type ExternalDNSProvider =
 
 export type CNDIProvider = "aws" | "azure" | "gcp" | "dev";
 
+export type CNDINetworkMode = "encapsulated" | "external";
+
+export interface CNDINetworkConfig {
+  mode?: CNDINetworkMode;
+  subnet_identifier?: string;
+  vnet_identifier?: string;
+}
+
+export interface CNDINetworkConfigEncapsulated extends CNDINetworkConfig {
+  mode?: "encapsulated";
+}
+
+export interface CNDINetworkConfigExternal extends CNDINetworkConfig {
+  mode: "external";
+  subnet_identifier: string;
+  vnet_identifier: string;
+}
+
 // incomplete type, config will have more options
 interface CNDIConfig {
   project_name?: string;
@@ -238,6 +256,7 @@ interface CNDIConfig {
   provider: CNDIProvider;
   infrastructure: {
     cndi: {
+      network?: CNDINetworkConfig;
       deployment_target_configuration?: DeploymentTargetConfiguration;
       external_dns: {
         enabled?: boolean; // default: true

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,7 @@ export type CNDINetworkMode = "encapsulated" | "external";
 export interface CNDINetworkConfig {
   mode?: CNDINetworkMode;
   subnet_identifier?: string;
+  network_identifier?: string;
 }
 
 export interface CNDINetworkConfigEncapsulated extends CNDINetworkConfig {
@@ -244,6 +245,7 @@ export interface CNDINetworkConfigEncapsulated extends CNDINetworkConfig {
 export interface CNDINetworkConfigExternal extends CNDINetworkConfig {
   mode: "external";
   subnet_identifier: string;
+  network_identifier?: string;
 }
 
 // incomplete type, config will have more options

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,27 +232,54 @@ export type CNDIProvider = "aws" | "azure" | "gcp" | "dev";
 
 export type CNDINetworkMode = "encapsulated" | "external";
 
-export interface CNDINetworkConfig {
+export interface CNDINetworkConfigBase {
   mode?: CNDINetworkMode;
-  subnet_identifier?: string;
-  network_identifier?: string;
 }
 
-export interface CNDINetworkConfigEncapsulated extends CNDINetworkConfig {
-  mode?: "encapsulated";
+export interface CNDINetworkConfigEncapsulated extends CNDINetworkConfigBase {
+  mode: "encapsulated";
 }
 
-export interface CNDINetworkConfigExternal extends CNDINetworkConfig {
+export interface CNDINetworkConfigExternal extends CNDINetworkConfigBase {
   mode: "external";
-  subnet_identifier: string;
-  network_identifier?: string;
 }
+
+export interface CNDINetworkConfigAWS extends CNDINetworkConfigExternal {
+  aws: {
+    vpc_id: string;
+    subnets: Array<string>;
+  };
+}
+
+export interface CNDINetworkConfigAzure extends CNDINetworkConfigExternal {
+  azure: {
+    subnets: Array<string>;
+    network_resource_id: string; // /subscriptions/12345678/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet
+  };
+}
+
+export interface CNDINetworkConfigGCP extends CNDINetworkConfigExternal {
+  gcp: {
+    network_name: string;
+    private_subnets?: Array<string>;
+    public_subnet: string;
+    project?: string;
+  };
+}
+
+export type CNDIDistribution = "microk8s" | "eks" | "gke" | "aks";
+
+export type CNDINetworkConfig =
+  | CNDINetworkConfigEncapsulated
+  | CNDINetworkConfigAWS
+  | CNDINetworkConfigAzure
+  | CNDINetworkConfigGCP;
 
 // incomplete type, config will have more options
 interface CNDIConfig {
   project_name?: string;
   cndi_version?: string;
-  distribution: "microk8s" | "eks" | "gke" | "aks";
+  distribution: CNDIDistribution;
   provider: CNDIProvider;
   infrastructure: {
     cndi: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,25 +244,30 @@ export interface CNDINetworkConfigExternal extends CNDINetworkConfigBase {
   mode: "external";
 }
 
-export interface CNDINetworkConfigAWS extends CNDINetworkConfigExternal {
+export interface CNDINetworkConfigExternalAWS
+  extends CNDINetworkConfigExternal {
   aws: {
     vpc_id: string;
-    subnets: Array<string>;
+    primary_subnet: string;
+    private_subnets: Array<string>;
   };
 }
 
-export interface CNDINetworkConfigAzure extends CNDINetworkConfigExternal {
+export interface CNDINetworkConfigExternalAzure
+  extends CNDINetworkConfigExternal {
   azure: {
-    subnets: Array<string>;
     network_resource_id: string; // /subscriptions/12345678/resourceGroups/my-rg/providers/Microsoft.Network/virtualNetworks/my-vnet
+    primary_subnet: string;
+    private_subnets: Array<string>;
   };
 }
 
-export interface CNDINetworkConfigGCP extends CNDINetworkConfigExternal {
+export interface CNDINetworkConfigExternalGCP
+  extends CNDINetworkConfigExternal {
   gcp: {
     network_name: string;
+    primary_subnet: string;
     private_subnets?: Array<string>;
-    public_subnet: string;
     project?: string;
   };
 }
@@ -271,9 +276,9 @@ export type CNDIDistribution = "microk8s" | "eks" | "gke" | "aks";
 
 export type CNDINetworkConfig =
   | CNDINetworkConfigEncapsulated
-  | CNDINetworkConfigAWS
-  | CNDINetworkConfigAzure
-  | CNDINetworkConfigGCP;
+  | CNDINetworkConfigExternalAWS
+  | CNDINetworkConfigExternalAzure
+  | CNDINetworkConfigExternalGCP;
 
 // incomplete type, config will have more options
 interface CNDIConfig {

--- a/templates/basic.yaml
+++ b/templates/basic.yaml
@@ -1,3 +1,10 @@
+blocks:
+  - name: external_net_config
+    content:
+      mode: external
+      subnet_identifier: "{{ $cndi.get_prompt_response(external_subnet_id) }}"
+      vnet_identifier: "{{ $cndi.get_prompt_response(external_network_name) }}"
+      vnet_rg: "{{ $cndi.get_prompt_response(external_network_rg) }}"
 prompts:
   - $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-prompts.yaml):
       {}
@@ -21,7 +28,44 @@ prompts:
       - "{{ $cndi.get_prompt_response(deploy_argocd_ingress) }}"
       - ==
       - true
-
+  - name: use_external_network
+    message: >-
+      Would you like to use an existing Virtual Network?
+    type: Confirm
+    default: false
+  - name: external_network_name
+    message: >-
+      What is the name of the existing Virtual Network?
+    type: Input
+    condition:
+      - "{{ $cndi.get_prompt_response(use_external_network) }}"
+      - ==
+      - true
+  - name: external_network_rg
+    message: >-
+      What Resource Group holds the existing Virtual Network?
+    type: Input
+    condition:
+      - "{{ $cndi.get_prompt_response(use_external_network) }}"
+      - ==
+      - true
+  - name: create_new_subnet
+    message: >-
+      Would you like to create a new Subnet in your external network?
+    type: Confirm
+    default: true
+    condition:
+      - "{{ $cndi.get_prompt_response(use_external_network) }}"
+      - ==
+      - true
+  - name: external_subnet_id
+    message: >-
+      Please provide a Subnet ID for CNDI to use:
+    type: Input
+    condition:
+      - "{{ $cndi.get_prompt_response(create_new_subnet) }}"
+      - ==
+      - false
 outputs:
   cndi_config:
     # source_control_platform: github ?
@@ -32,6 +76,13 @@ outputs:
     # this is a Template comment
     infrastructure:
       cndi:
+        network:
+          $cndi.get_block(external_net_config):
+            condition:
+              - "{{ $cndi.get_prompt_response(use_external_network) }}"
+              - ==
+              - true
+
         cert_manager:
           email: "{{ $cndi.get_prompt_response(cert_manager_email) }}"
 

--- a/templates/basic.yaml
+++ b/templates/basic.yaml
@@ -3,8 +3,6 @@ blocks:
     content:
       mode: external
       subnet_identifier: "{{ $cndi.get_prompt_response(external_subnet_id) }}"
-      vnet_identifier: "{{ $cndi.get_prompt_response(external_network_name) }}"
-      vnet_rg: "{{ $cndi.get_prompt_response(external_network_rg) }}"
 prompts:
   - $cndi.get_block(https://raw.githubusercontent.com/polyseam/common-blocks/main/common/core-prompts.yaml):
       {}
@@ -28,44 +26,21 @@ prompts:
       - "{{ $cndi.get_prompt_response(deploy_argocd_ingress) }}"
       - ==
       - true
+      
   - name: use_external_network
     message: >-
       Would you like to use an existing Virtual Network?
     type: Confirm
     default: false
-  - name: external_network_name
-    message: >-
-      What is the name of the existing Virtual Network?
-    type: Input
-    condition:
-      - "{{ $cndi.get_prompt_response(use_external_network) }}"
-      - ==
-      - true
-  - name: external_network_rg
-    message: >-
-      What Resource Group holds the existing Virtual Network?
-    type: Input
-    condition:
-      - "{{ $cndi.get_prompt_response(use_external_network) }}"
-      - ==
-      - true
-  - name: create_new_subnet
-    message: >-
-      Would you like to create a new Subnet in your external network?
-    type: Confirm
-    default: true
-    condition:
-      - "{{ $cndi.get_prompt_response(use_external_network) }}"
-      - ==
-      - true
+
   - name: external_subnet_id
     message: >-
       Please provide a Subnet ID for CNDI to use:
     type: Input
     condition:
-      - "{{ $cndi.get_prompt_response(create_new_subnet) }}"
+      - "{{ $cndi.get_prompt_response(use_external_network) }}"
       - ==
-      - false
+      - true
 outputs:
   cndi_config:
     # source_control_platform: github ?

--- a/templates/basic.yaml
+++ b/templates/basic.yaml
@@ -33,6 +33,28 @@ prompts:
     type: Confirm
     default: false
 
+  - name: use_existing_subnets
+    message: >-
+      Would you like to use existing subnets from that Virtual Network?
+    type: Confirm
+    default: false
+    condition:
+      - "{{ $cndi.get_prompt_response(use_external_network) }}"
+      - ==
+      - true
+    
+  - name: subnets
+    message: >-
+      Please list your subnet names:
+    type: List
+    default: false
+    condition:
+      - "{{ $cndi.get_prompt_response(use_external_network) }}"
+      - ==
+      - true
+    
+  
+
   - name: external_subnet_id
     message: >-
       Please provide a Subnet ID for CNDI to use:


### PR DESCRIPTION
# Description

This PR adds the option of using the `external` network mode in cndi_config when using `azure/aks`, which requires a `subnet_identifier`. The provided subnet will ultimately hold the Kubernetes nodes. Kubernetes services will be deployed in a separate subnet, which is `10.0.0.0/16` by default, so it is important that address space is left unclaimed at the time of deployment.

When using the default network mode `encapsulated`, everything behaves as it did before.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
