### PR TITLE
[Enhancement]: add `--skip-push` option when using `cndi create`

### DIFF
--- a/src/actions/createRepo.ts
+++ b/src/actions/createRepo.ts
@@ -5,6 +5,7 @@ const createRepoLabel = ccolors.faded("\nsrc/actions/createRepo.ts:");
 
 type CreateRepoOptions = {
   output: string;
+  skipPush?: boolean;
 };
 
 export default async function createRepo(options: CreateRepoOptions) {
@@ -149,20 +150,21 @@ export default async function createRepo(options: CreateRepoOptions) {
     }
   }
 
-  try {
-    await git.push("origin", "main", ["--set-upstream"]);
-  } catch (e) {
-    console.error(e);
+  if (!options?.skipPush) {
+    try {
+      await git.push("origin", "main", ["--set-upstream"]);
+    } catch (e) {
+      console.error(e);
+      console.log(
+        ccolors.warn("git push origin main"),
+        ccolors.error("failed"),
+      );
+    }
     console.log(
-      ccolors.warn("git push origin main"),
-      ccolors.error("failed"),
+      ccolors.success(
+        `created cndi cluster repo at`,
+      ),
+      ccolors.key_name(`${repoUrlString}`),
     );
   }
-
-  console.log(
-    ccolors.success(
-      `created cndi cluster repo at`,
-    ),
-    ccolors.key_name(`${repoUrlString}`),
-  );
 }

--- a/src/actions/overwrite.worker.ts
+++ b/src/actions/overwrite.worker.ts
@@ -517,8 +517,10 @@ self.onmessage = async (message: OverwriteWorkerMessage) => {
     }
 
     const completionMessage = options?.initializing
-      ? "initialized your cndi project in the ./cndi directory!"
-      : "overwrote your cndi project in the ./cndi directory!";
+      ? `initialized your cndi project at ${ccolors.key_name(options.output)}!`
+      : `overwrote your cndi project files in ${
+        ccolors.key_name(path.join(options.output, "cndi"))
+      }!`;
 
     console.log("\n" + completionMessage);
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -48,6 +48,7 @@ type EchoCreateOptions = {
   output?: string;
   deploymentTargetLabel?: string;
   responsesFile: string;
+  skipPush?: boolean;
 };
 
 const echoCreate = (options: EchoCreateOptions, slug?: string) => {
@@ -64,8 +65,9 @@ const echoCreate = (options: EchoCreateOptions, slug?: string) => {
   const cndiCreateDeploymentTargetLabel = options.deploymentTargetLabel
     ? ` --deployment-target-label ${options.deploymentTargetLabel}`
     : "";
+  const cndiCreateSkipPush = options.skipPush ? " --skip-push" : "";
   console.log(
-    `${cndiCreate}${cndiCreateSlug}${cndiCreateInteractive}${cndiCreateTemplate}${cndiCreateOutput}${cndiCreateDeploymentTargetLabel}${cndiCreateSet}\n`,
+    `${cndiCreate}${cndiCreateSlug}${cndiCreateInteractive}${cndiCreateTemplate}${cndiCreateOutput}${cndiCreateDeploymentTargetLabel}${cndiCreateSet}${cndiCreateSkipPush}\n`,
   );
 };
 
@@ -91,6 +93,7 @@ const createCommand = new Command()
       default: path.join(Deno.cwd(), "cndi_responses.yaml"),
     },
   )
+  .option("--skip-push", "Skip pushing to remote repository")
   .option(
     `-s, --set <set>`,
     `Override a response, usage: --set responseName=responseValue`,
@@ -120,6 +123,7 @@ const createCommand = new Command()
   )
   .action(async (options, slug) => {
     echoCreate(options, slug);
+    const skipPush = options.skipPush;
     const interactive = !options.nonInteractive;
     let template: string | undefined = options?.template;
     let overrides: Record<string, CNDITemplatePromptResponsePrimitive> = {};
@@ -460,6 +464,7 @@ const createCommand = new Command()
       output: destinationDirectory,
       initializing: true,
       create: true,
+      skipPush,
     });
   });
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -41,11 +41,13 @@ type EchoInitOptions = {
   deploymentTargetLabel?: string;
   keep?: boolean;
   create?: boolean;
+  skipPush?: boolean;
 };
 
 const echoInit = (options: EchoInitOptions) => {
   const cndiInit = "cndi init";
   const cndiInitCreate = options.create ? " --create" : "";
+  const cndiInitSkipPush = options.skipPush ? " --skip-push" : "";
   const cndiInitInteractive = options.interactive ? " --interactive" : "";
   const cndiInitTemplate = options.template
     ? ` --template ${options.template}`
@@ -59,7 +61,7 @@ const echoInit = (options: EchoInitOptions) => {
     ? ` --deployment-target-label ${options.deploymentTargetLabel}`
     : "";
   console.log(
-    `${cndiInit}${cndiInitCreate}${cndiInitInteractive}${cndiInitTemplate}${deploymentTargetLabel}${cndiInitOutput}\n`,
+    `${cndiInit}${cndiInitCreate}${cndiInitInteractive}${cndiInitTemplate}${deploymentTargetLabel}${cndiInitOutput}${cndiInitSkipPush}\n`,
   );
 };
 
@@ -110,6 +112,9 @@ const initCommand = new Command()
     "-c, --create",
     "Create a new cndi cluster repo",
   )
+  .option("--skip-push", "Skip pushing to the remote repository", {
+    depends: ["create"],
+  })
   .action(async (options) => {
     // default to the current working directory if -o, --output is ommitted
     const destinationDirectory = options.output ?? Deno.cwd();


### PR DESCRIPTION
# Description

Sometimes it is useful to be able to make some changes after `cndi create` does all of it's work, but before the first deployment is triggered. If you'd like to get in front of a deployment and add some commits before it is triggered you can now use `--skip-push`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
