### PR TITLE
[Bug]: fix build step when using custom `--workflow-source-ref` 

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -117,7 +117,7 @@ const createCommand = new Command()
     "Label in the form of <provider>/<distribution> slug to specifying a deployment target",
   )
   .option(
-    "--workflow-source-ref, -w <workflow_source_ref:string>",
+    "-w, --workflow-source-ref <workflow_source_ref:string>",
     "A git ref pointing to the version of the cndi codebase to use in the 'cndi run' workflow",
     { hidden: true },
   )

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -97,7 +97,7 @@ const initCommand = new Command()
     },
   )
   .option(
-    "-w, --workflow-ref <ref:string>",
+    "-w, --workflow-source-ref <workflow_source_ref:string>",
     "Specify a ref to build a cndi workflow with",
     {
       hidden: true,
@@ -392,7 +392,7 @@ const initCommand = new Command()
     if (deployment_target_provider !== "dev") {
       await stageFile(
         path.join(".github", "workflows", "cndi-run.yaml"),
-        getCndiRunGitHubWorkflowYamlContents(options?.workflowRef),
+        getCndiRunGitHubWorkflowYamlContents(options?.workflowSourceRef),
       );
     }
 

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -118,11 +118,7 @@ function getSteps(sourceRef?: string) {
     run: "deno task build-linux",
   }, {
     name: "persist cndi",
-    run:
-      "mkdir -p $HOME/.cndi/bin && mv ./dist/cndi-linux $HOME/.cndi/bin/cndi",
-  }, {
-    name: "cndi install",
-    run: "$HOME/.cndi/bin/cndi install", // even though we install automatically in run.ts, we expect this has more performant caching
+    run: "mkdir -p $HOME/.cndi/bin && mv ./dist/linux/in/* $HOME/.cndi/bin/",
   }, {
     name: "checkout repo",
     uses: "actions/checkout@v3",


### PR DESCRIPTION
# Description

Deploying a custom ref for a CNDI workflow will now properly compile a new linux binary using the provided git ref, this hidden flag needed to be updated since changes were made to the build pipeline

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
