### PR TITLE
remove LaunchTemplate-based EKS tag metadata support

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -731,7 +731,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
       const instanceType = nodeGroup?.instance_type ||
         DEFAULT_INSTANCE_TYPES.aws;
 
-      const volumeSize = nodeGroup?.volume_size ||
+      const diskSize = nodeGroup?.volume_size ||
         nodeGroup?.disk_size ||
         nodeGroup?.disk_size_gb ||
         DEFAULT_NODE_DISK_SIZE_MANAGED;
@@ -748,36 +748,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
       if (minCount) {
         scalingConfig.minSize = minCount;
       }
-      const nodegroupLaunchTemplate = new CDKTFProviderAWS.launchTemplate
-        .LaunchTemplate(
-        this,
-        `cndi_aws_launch_template_${nodeGroupIndex}`,
-        {
-          name: `cndi-${nodeGroupName}-${nodeGroupIndex}`,
-          blockDeviceMappings: [
-            {
-              deviceName: "/dev/sdf",
-              ebs: {
-                volumeSize,
-              },
-            },
-          ],
-          tagSpecifications: [
-            {
-              resourceType: "instance",
-              tags: {
-                Name: nodeGroupName,
-                CNDIProject: project_name,
-              },
-            },
-          ],
-          dependsOn: [
-            workerNodePolicyAttachment,
-            cniPolicyAttachment,
-            containerRegistryAttachment,
-          ],
-        },
-      );
+
       const ng = new CDKTFProviderAWS.eksNodeGroup.EksNodeGroup(
         this,
         `cndi_aws_eks_node_group_${nodeGroupIndex}`,
@@ -790,16 +761,12 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           scalingConfig,
           capacityType: "ON_DEMAND",
           subnetIds: [subnetPrivateA.id],
-          launchTemplate: {
-            id: nodegroupLaunchTemplate.id,
-            version: `${nodegroupLaunchTemplate.latestVersion}`,
-          },
+          diskSize,
           updateConfig: { maxUnavailable: 1 },
           dependsOn: [
             workerNodePolicyAttachment,
             cniPolicyAttachment,
             containerRegistryAttachment,
-            nodegroupLaunchTemplate,
           ],
         },
       );


### PR DESCRIPTION
# Description

This PR removes support for adding metadata tags to EKS nodes based on LaunchTemplates. The bug was caused by LaunchTemplate names not being uniqulely named.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
