### PR TITLE
use `LaunchTemplate.namePrefix` instead of `.name`

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -753,7 +753,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         this,
         `cndi_aws_launch_template_${nodeGroupIndex}`,
         {
-          name: `cndi-${nodeGroupName}-${nodeGroupIndex}`,
+          namePrefix: `cndi-${nodeGroupName}-${nodeGroupIndex}`,
           blockDeviceMappings: [
             {
               deviceName: "/dev/sdf",

--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -753,7 +753,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
         this,
         `cndi_aws_launch_template_${nodeGroupIndex}`,
         {
-          namePrefix: `cndi-${nodeGroupName}-${nodeGroupIndex}`,
+          namePrefix: `cndi-${nodeGroupName}-${nodeGroupIndex}-`,
           blockDeviceMappings: [
             {
               deviceName: "/dev/sdf",


### PR DESCRIPTION
# Description

LaunchTemplate names must be unique, therefore we swapped out the `name` argument for `namePrefix`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [ ] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
