### PR TITLE
[Enhancement]: add `--quiet` to `cndi show-outputs`

### DIFF
--- a/src/commands/show-outputs.ts
+++ b/src/commands/show-outputs.ts
@@ -19,8 +19,8 @@ const showOutputsCommand = new Command()
   .option("-p, --path <path:string>", "path to your cndi git repository", {
     default: Deno.cwd(),
   })
-  .option("--json", "output as JSON")
-  .option("-q, --quiet", "eliminate unnecessary output")
+  .option("--json", "Output as JSON.")
+  .option("-q, --quiet", "Eliminate unnecessary output.")
   .env(
     "GIT_REPO=<value:string>",
     "URL of your git repository where your cndi project is hosted.",

--- a/src/commands/show-outputs.ts
+++ b/src/commands/show-outputs.ts
@@ -20,6 +20,7 @@ const showOutputsCommand = new Command()
     default: Deno.cwd(),
   })
   .option("--json", "output as JSON")
+  .option("-q, --quiet", "eliminate unnecessary output")
   .env(
     "GIT_REPO=<value:string>",
     "URL of your git repository where your cndi project is hosted.",
@@ -62,8 +63,9 @@ const showOutputsCommand = new Command()
   )
   .action(async (options) => {
     const cmd = "cndi show-outputs";
-    console.log(`${cmd}\n`);
-
+    if (!options?.quiet) {
+      console.log(`${cmd}\n`);
+    }
     const pathToTerraformResources = path.join(
       options.path,
       "cndi",
@@ -89,8 +91,9 @@ const showOutputsCommand = new Command()
     }
 
     try {
-      console.log(ccolors.faded("\n-- terraform init --\n"));
-
+      if (!options?.quiet) {
+        console.log(ccolors.faded("\n-- terraform init --\n"));
+      }
       const terraformInitCommand = new Deno.Command(pathToTerraformBinary, {
         args: [`-chdir=${pathToTerraformResources}`, "init"],
         stderr: "piped",
@@ -99,7 +102,9 @@ const showOutputsCommand = new Command()
 
       const terraformInitCommandOutput = await terraformInitCommand.output();
 
-      await Deno.stdout.write(terraformInitCommandOutput.stdout);
+      if (!options?.quiet) {
+        await Deno.stdout.write(terraformInitCommandOutput.stdout);
+      }
       await Deno.stderr.write(terraformInitCommandOutput.stderr);
 
       if (terraformInitCommandOutput.code !== 0) {
@@ -121,8 +126,9 @@ const showOutputsCommand = new Command()
     }
 
     try {
-      console.log(ccolors.faded("\n-- terraform output --\n"));
-
+      if (!options?.quiet) {
+        console.log(ccolors.faded("\n-- terraform output --\n"));
+      }
       const outputArgs = [
         `-chdir=${pathToTerraformResources}`,
         "output",


### PR DESCRIPTION
# Description

`cndi show-outputs --quiet` will post only actual outputs to stdout and no feedback logging

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
