### PR TITLE
[Bug]: add `dependsOn` on many resources to fix `cndi destroy` for `eks`

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -53,19 +53,25 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
       this,
       "cndi_aws_internet_gateway",
       {
-        vpcId: vpc.id,
         tags: {
           Name: `cndi-igw_${project_name}`,
         },
       },
     );
 
+    const gwAttachment = new CDKTFProviderAWS.internetGatewayAttachment
+      .InternetGatewayAttachment(this, "cndi_aws_internet_gateway_attachment", {
+      internetGatewayId: igw.id,
+      vpcId: vpc.id,
+      dependsOn: [igw, vpc],
+    });
+
     const eip = new CDKTFProviderAWS.eip.Eip(this, "cndi_aws_eip", {
-      vpc: true,
+      domain: "vpc",
       tags: {
         Name: `cndi-elastic-ip_${project_name}`,
       },
-      dependsOn: [igw],
+      dependsOn: [gwAttachment],
     });
 
     new CDKTFProviderAWS.dataAwsCallerIdentity.DataAwsCallerIdentity(
@@ -151,6 +157,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           "kubernetes.io/role/internal-elb": "1",
         },
         vpcId: vpc.id,
+        dependsOn: [gwAttachment],
       },
     );
 
@@ -167,6 +174,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           "kubernetes.io/role/internal-elb": "1",
         },
         vpcId: vpc.id,
+        dependsOn: [gwAttachment],
       },
     );
 
@@ -183,6 +191,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           "kubernetes.io/role/elb": "1",
         },
         vpcId: vpc.id,
+        dependsOn: [gwAttachment],
       },
     );
 
@@ -800,6 +809,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
             cniPolicyAttachment,
             containerRegistryAttachment,
             nodegroupLaunchTemplate,
+            gwAttachment,
           ],
         },
       );


### PR DESCRIPTION
# Related issue

Issue #756 

# Description

- Fixed issue where failure to delete InternetGateway prevents `cndi destroy`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
