### PR TITLE
[Enhancement]: Install `nginx` through ArgoCD

### DIFF
--- a/src/outputs/core-applications/private-nginx.application.yaml.ts
+++ b/src/outputs/core-applications/private-nginx.application.yaml.ts
@@ -97,7 +97,9 @@ export default function getNginxApplicationManifest(
       name: releaseName,
       finalizers: DEFAULT_FINALIZERS,
       labels: { name: releaseName },
-      "argocd.argoproj.io/sync-wave": "-1",
+      annotations: {
+        "argocd.argoproj.io/sync-wave": "-1",
+      },
     },
     spec: {
       project: DEFAULT_PROJECT,

--- a/src/outputs/core-applications/public-nginx.application.yaml.ts
+++ b/src/outputs/core-applications/public-nginx.application.yaml.ts
@@ -87,7 +87,9 @@ export default function getNginxApplicationManifest(
       name: releaseName,
       finalizers: DEFAULT_FINALIZERS,
       labels: { name: releaseName },
-      "argocd.argoproj.io/sync-wave": "-1",
+      annotations: {
+        "argocd.argoproj.io/sync-wave": "-1",
+      },
     },
     spec: {
       project: DEFAULT_PROJECT,


### PR DESCRIPTION
Issue [#674](https://github.com/polyseam/cndi/issues/674)
### Please provide a summary of the enhancement you are proposing:

`nginx` should be enabled using GitOps and the Application CRD, rather than installed imperatively at runtime with terraform

### Please provide the motivation or use case for this enhancement:

It would be better to put this application in ArgoCD's domain so it can be enabled and disabled, and configured by cluster owners

### How can we best workaround this issue so far?

_No response_

### How would you approach solving this problem within CNDI?

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct
