### PR TITLE
[Fix]: Allow Deploying multiple GKE clusters to the same GCP Project

### DIFF
--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -27,6 +27,13 @@ import {
 
 import GCPCoreTerraformStack from "./GCPCoreStack.ts";
 
+function truncateString(str: string, num = 63) {
+  if (str.length <= num) {
+    return str;
+  }
+  return str.slice(0, num);
+}
+
 // TODO: ensure that splicing project_name into tags.Name is safe
 export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
   constructor(scope: Construct, name: string, cndi_config: CNDIConfig) {
@@ -105,8 +112,8 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       this,
       "cndi_google_compute_network",
       {
+        name: truncateString(`cndi-compute-network-${project_name}`),
         autoCreateSubnetworks: false,
-        name: "cndi-compute-network",
         dependsOn: [projectServicesReady],
       },
     );
@@ -115,7 +122,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       this,
       "cndi_google_compute_subnetwork",
       {
-        name: "cndi-compute-subnetwork",
+        name: truncateString(`cndi-compute-subnetwork-${project_name}`),
         ipCidrRange: "10.0.0.0/16",
         network: network.selfLink,
         privateIpGoogleAccess: true,
@@ -128,7 +135,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       this,
       "cndi_google_compute_firewall",
       {
-        name: "cndi-compute-firewall-allow-internal",
+        name: truncateString(`cndi-compute-firewall-allow-internal-${project_name}`),
         description: "Allow internal traffic inside cluster",
         network: network.selfLink,
         direction: "INGRESS",
@@ -257,7 +264,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       this,
       "cndi_google_compute_address",
       {
-        name: "cndi-compute-address-lb",
+        name: truncateString(`cndi-compute-address-lb-${project_name}`),
         networkTier: "PREMIUM",
         addressType: "EXTERNAL",
         dependsOn: [projectServicesReady],

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -135,7 +135,9 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
       this,
       "cndi_google_compute_firewall",
       {
-        name: truncateString(`cndi-compute-firewall-allow-internal-${project_name}`),
+        name: truncateString(
+          `cndi-compute-firewall-allow-internal-${project_name}`,
+        ),
         description: "Allow internal traffic inside cluster",
         network: network.selfLink,
         direction: "INGRESS",

--- a/src/use-template/util/validation.ts
+++ b/src/use-template/util/validation.ts
@@ -1,5 +1,6 @@
 import { validator } from "deps";
 import { CNDITemplatePromptResponsePrimitive, PromptType } from "../types.ts";
+import { isSlug } from "src/utils.ts";
 
 type CNDIValidatorInput = {
   value: CNDITemplatePromptResponsePrimitive;
@@ -16,6 +17,16 @@ function redact(s: string): string {
 }
 
 export const BuiltInValidators: Record<string, CNDIValidator> = {
+  is_slug: ({ value, type }: CNDIValidatorInput) => {
+    if (isSlug(value as string)) {
+      return null;
+    }
+    let val = value;
+    if (type === "Secret") {
+      val = redact(value as string);
+    }
+    return `'${val}' is not a valid slug, must be lowercase and contain only letters, numbers, and hyphens`;
+  },
   email: ({ value, type }: CNDIValidatorInput) => {
     if (validator.isEmail(value as string)) {
       return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -576,6 +576,11 @@ function getPathToCndiBinary() {
   return path.join(CNDI_HOME, "bin", `cndi${suffix}`);
 }
 
+function isSlug(input: string): boolean {
+  const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+  return slugPattern.test(input);
+}
+
 export {
   checkForRequiredMissingCreateRepoValues,
   checkInitialized,
@@ -597,6 +602,7 @@ export {
   getTFResource,
   getUserDataTemplateFileString,
   getYAMLString,
+  isSlug,
   loadCndiConfig,
   loadJSONC,
   loadYAML,

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -1,5 +1,6 @@
 import { ccolors } from "deps";
 import { CNDIConfig } from "src/types.ts";
+import { isSlug } from "src/utils.ts";
 
 const cndiConfigLabel = ccolors.faded("\nsrc/validate/cndiConfig.ts:");
 
@@ -47,6 +48,23 @@ export default function validateConfig(
       ].join(" "),
       { cause: 900 },
     );
+  } else if (config?.project_name) {
+    if (!isSlug(config?.project_name)) {
+      throw new Error(
+        [
+          cndiConfigLabel,
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("but the"),
+          ccolors.key_name('"project_name"'),
+          ccolors.error("is not a valid slug"),
+          ccolors.error(
+            "it must only contain lowercase letters, numbers, and hyphens",
+          ),
+        ].join(" "),
+        { cause: 903 },
+      );
+    }
   }
 
   if (!config?.infrastructure) {


### PR DESCRIPTION
# Description

- [x] add suffix to named GCP resources using the `cndi_config.yaml[project_name]`
- [x] ensure every  `cndi_config.yaml[project_name]` is a valid kabob-case slug with lowercase letters
- [x] add `is_slug` as a validator for use-template 

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
