### PR TITLE
[Fix]: Flaky Test: MacOS bin-build

### DIFF
--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -31,7 +31,7 @@ jobs:
         run: deno task build-mac
       - name: mac cndi --help
         run: ./dist/mac/in/cndi --help
-        timeout-minutes: 1
+        timeout-minutes: 5
   bin-build-test-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - 'main'
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 jobs:
   bin-build-test-ubuntu:
     runs-on: ubuntu-latest
@@ -31,7 +33,7 @@ jobs:
         run: deno task build-mac
       - name: mac cndi --help
         run: ./dist/mac/in/cndi --help
-        timeout-minutes: 5
+        timeout-minutes: 1
   bin-build-test-windows:
     runs-on: windows-latest
     steps:

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -12,7 +12,6 @@ const upgradeCommand = new GithubReleasesUpgradeCommand({
   provider: new GithubReleasesProvider({
     repository: "polyseam/cndi",
     destinationDir,
-    skipAuth: true,
     osAssetMap: {
       windows: "cndi-win.tar.gz",
       linux: "cndi-linux.tar.gz",

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -12,6 +12,7 @@ const upgradeCommand = new GithubReleasesUpgradeCommand({
   provider: new GithubReleasesProvider({
     repository: "polyseam/cndi",
     destinationDir,
+    skipAuth: true,
     osAssetMap: {
       windows: "cndi-win.tar.gz",
       linux: "cndi-linux.tar.gz",


### PR DESCRIPTION
# Description

This issue seems to be the result of a GitHub Actions runner exceeding the rate limit for it's own IP address.

The reason this happens more often on MacOS is likely related to how these runners are allocated and how much of the quota each one has used.

For this reason, even though the end user should be able to call `cndi --help` without an API token in scope, adding one to this job works around the per-ip-address quota specifically caused by the GitHub Runner environment.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
