### PR TITLE
 [Enhancement]: add `{{ $cndi.get_random_string(32) }}` Template Invocation Macro

### DIFF
--- a/src/use-template/README.md
+++ b/src/use-template/README.md
@@ -60,3 +60,83 @@ prompts:
         - ==
         - true
 ```
+
+## macros
+
+CNDI Templates are YAML files, and they are invoked during `cndi init` or
+`cndi create`.
+
+Template invocation can happen interactively, or uninteractively.
+
+In interactive mode, the user is prompted for values for each prompt in the
+`prompts` array of the Template YAML.
+
+In non-interactive mode, the user can pass values for each prompt as flags to
+the `cndi init` or `cndi create` like `--set my_prompt_response="my value"`, and
+all other responses will fall back to the default specified in each prompt array
+entry.
+
+After a successful Template invocation, there should be no pairs of `{{}}` left
+in the output files. The code within these braces is called a invocation-time
+macro, and there are only a few.
+
+### `{{ $cndi.get_prompt_response(<prompt_name>) }}`
+
+This macro is used to reference the response to a prompt. This can be used to
+conditionally display prompts, or otherwise templated into the output files.
+
+### `{{ $cndi.get_block(<identifier>) }}`
+
+This macro is used to insert a YAML fragment into the space where it is called.
+This is useful for inserting a block of YAML into a Kubernetes manifest, or
+Terraform resource, especially where you may want to conditionally include or
+exclude a block of YAML.
+
+This call is also used slightly different depending on where it is being
+invoked. If the `{{ $cndi.get_block(<identifier>) }}` is called in your
+`cndi_config` output file, it will expect to recieve a YAML fragment, and that
+fragment replaces the call. If the `{{ $cndi.get_block(<identifier>) }}` is set
+to run conditionally and no blocks pass the condition, CNDI will delete the node
+that the macro is called in.
+
+If the `{{ $cndi.get_block(<identifier>) }}` is called in the `env` block, it
+will expect to recieve a flat YAML fragment of key-value pairs, and those
+key-value pairs will be added to the `env` block of the resource.
+
+If the `{{ $cndi.get_block(<identifier>) }}` is called in the `readme` block it
+will throw an error, you should instead use
+`{{ $cndi.get_string(<identifier>) }}`;
+
+### `{{ $cndi.get_string(<identifier>) }}`
+
+This macro is used to insert a string into the space where it is called. This is
+only available in the `readme` block of your Template.
+
+### `{{ $cndi.get_comment(<identifier>) }}`
+
+This macro is used to insert a comment into the space where it is called. When
+you want to add a comment for the maintainers of a Template, you can simply
+create a YAML comment using `#`. However if you want to insert a comment into
+the product of a template you can use this macro as the key, then the value will
+be the comment you want to insert.
+
+```yaml
+outputs:
+  env:
+    # this comment is for template maintainers
+    $cndi.comment(title): 'This line will show up in the .env file for template consumers'
+    NOTEWORTHY: '{{ $cndi.get_prompt_response(title) }}'
+```
+
+### `{{ $cndi.get_random_string(<length>) }}`
+
+This macro is used to generate a random string of a given length. This is useful
+for generating default passwords or other secrets.
+
+```yaml
+prompts:
+  - name: db_password
+    message: "What password should be used for the database?"
+    default: '{{ $cndi.get_random_string(16) }}'
+    type: "Password"
+```

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -1000,8 +1000,8 @@ async function processCNDIEnvOutput(envSpecRaw: Record<string, unknown>) {
   }
 
   for (const key in envSpec) {
-    const val = literalizeGetPromptResponseCalls(`${envSpec[key]}`);
-
+    let val = literalizeGetPromptResponseCalls(`${envSpec[key]}`);
+    val = literalizeGetRandomStringCalls(val);
     if (key.startsWith("$cndi.comment")) {
       envLines.push(`\n# ${val}`);
     } else if (key.startsWith("$cndi.get_block")) {

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -34,6 +34,22 @@ const templatesLabel = ccolors.faded("\n@cndi/use-template:");
 
 type CNDIMode = "cli" | "webui";
 
+function base10intToHex(decimal: number): string {
+  // if the int8 in hex is less than 2 characters, prepend 0
+  const hex = decimal.toString(16).padStart(2, "0");
+  return hex;
+}
+
+function getRandomString(len = 32) {
+  if (len % 2) {
+    throw new Error("password length must be even");
+  }
+
+  const values = new Uint8Array(len / 2);
+  crypto.getRandomValues(values);
+  return Array.from(values, base10intToHex).join("");
+}
+
 /**
  * Options for `useTemplate`.
  * - `overrides` is a record of prompt names and their values.
@@ -435,6 +451,19 @@ function resolveCNDIPromptCondition(
   }
 }
 
+function literalizeGetRandomStringCalls(input: string): string {
+  let output = removeWhitespaceBetweenBraces(input);
+  const get_random_string_regexp =
+    /\{\{\s*\$cndi\.get_random_string\((\d*)\)\s*\}\}/g;
+
+  output = output.replace(get_random_string_regexp, (_match, len) => {
+    const length = parseInt(len) || 32;
+    return getRandomString(length);
+  });
+
+  return output;
+}
+
 async function presentCliffyPrompt(
   promptDefinition: CNDITemplateStaticPromptEntry,
 ) {
@@ -449,6 +478,17 @@ async function presentCliffyPrompt(
 
   if (!shouldShowPrompt) {
     return;
+  }
+
+  if (promptDefinition.default) {
+    if (typeof promptDefinition.default === "string") {
+      promptDefinition.default = literalizeGetPromptResponseCalls(
+        promptDefinition.default,
+      );
+      promptDefinition.default = literalizeGetRandomStringCalls(
+        promptDefinition.default,
+      );
+    }
   }
 
   await cprompt([
@@ -701,6 +741,9 @@ async function processCNDIConfigOutput(
 
   // get_prompt_response evals
   output = literalizeGetPromptResponseCalls(output);
+
+  // get_random_string evals
+  output = literalizeGetRandomStringCalls(output);
 
   // get_block evals
   const getBlockBeginToken = "$cndi.get_block(";


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #882 

# Description

- [x] adds the `{{ $cndi.get_random_string() }}` macro to the Template parser


<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
