### PR TITLE
[Enhancement]: replace "ERROR" with "IMPORTANT" when missing env vars

### DIFF
--- a/src/outputs/sealed-secret-manifest.ts
+++ b/src/outputs/sealed-secret-manifest.ts
@@ -46,7 +46,7 @@ const parseCndiSecret = (
             ccolors.warn(
               `\n\n${
                 ccolors.error(
-                  "ERROR",
+                  "IMPORTANT",
                 )
               }: ${
                 ccolors.key_name(`"${secretEnvName}"`)
@@ -113,7 +113,7 @@ const parseCndiSecret = (
           console.error(
             sealedSecretManifestLabel,
             ccolors.error(
-              "ERROR",
+              "IMPORTANT",
             ),
             ccolors.key_name(`"${secretEnvName}"`),
             ccolors.warn("not found in environment"),


### PR DESCRIPTION
# Description

CNDI Alerts users when it has missing values that are meant to be sealed with Sealed Secrets. This message use to begin with "Error" but in some cases (like mixed-environment ExternalDNS setups) would be unavoidable and not the user's fault.

This PR simply changes the word ERROR to IMPORTANT in recognition that the user did nothing wrong.

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
