### PR TITLE
[Bug]: Disabling ExternalDNS crashes Template

### DIFF
--- a/blocks/common/cluster/core-prompts.yaml
+++ b/blocks/common/cluster/core-prompts.yaml
@@ -105,10 +105,11 @@
     - google
     - cloudflare
   default: aws
-  condition:
-    - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
-    - ==
-    - true
+  # always enable_external_dns:
+  # condition:
+  #   - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
+  #   - ==
+  #   - true
 
 - name: external_dns_gcp_project
   message: >-


### PR DESCRIPTION
# Description

- [x] make `dns_provider` response unconditional to fix failure to launch when missing

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
