### PR TITLE
Remove ArgoCD Sync-Wave Annotation

### DIFF
--- a/src/outputs/core-applications/private-nginx.application.yaml.ts
+++ b/src/outputs/core-applications/private-nginx.application.yaml.ts
@@ -100,9 +100,6 @@ export default function getNginxApplicationManifest(
       name: releaseName,
       finalizers: DEFAULT_FINALIZERS,
       labels: { name: releaseName },
-      annotations: {
-        "argocd.argoproj.io/sync-wave": "-1",
-      },
     },
     spec: {
       project: DEFAULT_PROJECT,

--- a/src/outputs/core-applications/public-nginx.application.yaml.ts
+++ b/src/outputs/core-applications/public-nginx.application.yaml.ts
@@ -89,9 +89,6 @@ export default function getNginxApplicationManifest(
       name: releaseName,
       finalizers: DEFAULT_FINALIZERS,
       labels: { name: releaseName },
-      annotations: {
-        "argocd.argoproj.io/sync-wave": "-1",
-      },
     },
     spec: {
       project: DEFAULT_PROJECT,


### PR DESCRIPTION
⚠️ if this causes problems in the future, re-instating the sync-waves should be save!

# Related issue
[#756](https://github.com/polyseam/cndi/issues/756)

Issue #

This pull request removes the ArgoCD sync-wave annotation from the Kubernetes configuration to ensure resources are synchronized without any specified order. This change is intended to simplify deployments by removing the explicit wave dependency.

The sync-wave was initially added to minic the previous order of resource deployment. However, after reassessing our deployment strategy, we found that the explicit ordering is no longer necessary, and removing it may prevent potential sync issues and simplify the process.

# Test Instructions
Ensure that the application still deploys correctly without the sync-wave.
Verify that all resources are synchronized correctly in the absence of a wave specification.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

