### PR TITLE
[Bug]: `cndi destroy` can hang due to argo-apps failing to destroy

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -1106,7 +1106,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           name: "root-application",
           namespace: "argocd",
           project: "default",
-          finalizers: ["resources-finalizer.argocd.argoproj.io"],
+          finalizers: ["resources-finalizer.argocd.argoproj.io/background"],
           source: {
             repoURL: this.variables.git_repo.value,
             path: "cndi/cluster_manifests",

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -448,7 +448,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
           name: "root-application",
           namespace: "argocd",
           project: "default",
-          finalizers: ["resources-finalizer.argocd.argoproj.io"],
+          finalizers: ["resources-finalizer.argocd.argoproj.io/background"],
           source: {
             repoURL: this.variables.git_repo.value,
             path: "cndi/cluster_manifests",

--- a/src/outputs/terraform/gcp/GCPGKEStack.ts
+++ b/src/outputs/terraform/gcp/GCPGKEStack.ts
@@ -422,7 +422,7 @@ export default class GCPGKETerraformStack extends GCPCoreTerraformStack {
           name: "root-application",
           namespace: "argocd",
           project: "default",
-          finalizers: ["resources-finalizer.argocd.argoproj.io"],
+          finalizers: ["resources-finalizer.argocd.argoproj.io/background"],
           source: {
             repoURL: this.variables.git_repo.value,
             path: "cndi/cluster_manifests",


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #756

# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

- [x] change the ArgoCD app-of-apps helm release resource finalizer to "background" so that Terraform does not require it to destroy completely before moving on

This change was made in every cloud even though the error was not _found_ in non-EKS environments

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
