### PR TITLE
Configure Airflow fernet key and webserver secret key

### DIFF
--- a/templates/airflow.yaml
+++ b/templates/airflow.yaml
@@ -194,6 +194,26 @@ outputs:
         stringData:
           connection: $cndi_on_ow.seal_secret_from_env_var(POSTGRESQL_CONNECTION_STRING)
 
+      airflow-fernet-key-secret:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: airflow-fernet-key
+          namespace: airflow
+        type: Opaque
+        stringData:
+          fernet-key: $cndi_on_ow.seal_secret_from_env_var(AIRFLOW_FERNET_KEY)
+      
+      airflow-webserver-key-secret:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: airflow-webserver-key
+          namespace: airflow
+        type: Opaque
+        stringData:
+          webserver-key: $cndi_on_ow.seal_secret_from_env_var(AIRFLOW_WEBSERVER_KEY)
+              
       cnpg-cluster:
         apiVersion: postgresql.cnpg.io/v1
         kind: Cluster
@@ -286,6 +306,11 @@ outputs:
               wait: 40
               $cndi.comment(subPath): Folder path in DAG repo to sync
               subPath: dags
+          enableBuiltInSecretEnvVars:
+            AIRFLOW__CORE__FERNET_KEY: false
+            AIRFLOW__WEBSERVER__SECRET_KEY: false
+          fernetKeySecretName: airflow-fernet-key
+          webserverSecretKeySecretName: airflow-webserver-key
           config:
             $cndi.get_block(airflow_public_config):
               args:
@@ -325,8 +350,11 @@ outputs:
       {}
     $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/common/cluster/env.yaml):
       {}
-
-    $cndi.comment(neo4j-heading): PostgreSQL Connection Parameters
+     
+    $cndi.comment(airflow-heading): Airflow Key Parameters 
+    AIRFLOW_FERNET_KEY: '{{ $cndi.get_random_string(32) }}' 
+    AIRFLOW_WEBSERVER_KEY: '{{ $cndi.get_random_string(16) }}'    
+    $cndi.comment(postgres-heading): PostgreSQL Connection Parameters
     POSTGRESQL_DB: airflow-db
     POSTGRESQL_USER: airflow
     POSTGRESQL_PASSWORD: "{{ $cndi.get_prompt_response(postgresql_password) }}"


### PR DESCRIPTION
Issue #

# Description

This pull request introduces security enhancements to our Apache Airflow deployment. Specifically, it configures the fernetKey for encrypting sensitive data in the metadata database and sets the webserverSecretKeySecretName to manage webserver session secrets securely.
## Changes Made
### Fernet Key Configuration:

Added a new base64-encoded Fernet key to the Helm values file (values.yaml).
This key is essential for encrypting and decrypting sensitive data such as connection passwords and variables stored in Airflow's metadata database.

### Webserver Secret Key Name:

Specified the Kubernetes Secret name (webserverSecretKeySecretName) in the Helm values file.
This secret name is used by the Airflow webserver to reference the Kubernetes Secret that stores the actual session secret key, ensuring secure session management.
Impact

Enhanced Security: These changes strengthen the security of our Airflow deployment by ensuring that sensitive data and user sessions are encrypted and managed securely.
Compliance and Best Practices: Aligns our deployment with security best practices and potential compliance requirements for handling sensitive information.

# Test Instructions

Ensure that the Airflow webserver can successfully retrieve and utilize the session secret key from the specified Kubernetes Secret.
Verify that Airflow can encrypt and decrypt metadata database entries using the new Fernet key without errors.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
