### PR TITLE
[Enhancement]: remove `TERRAFORM_STATE_PASSPHRASE` prompt - clusterless

### DIFF
--- a/blocks/common/clusterless/core-prompts.yaml
+++ b/blocks/common/clusterless/core-prompts.yaml
@@ -82,9 +82,3 @@
   message: "Please enter your Git Repo URL:"
   type: Input
   default: ""
-
-- name: terraform_state_passphrase
-  message: >-
-    Enter an override for the default Terraform State Passphrase?
-  type: Input
-  default: '{{ $cndi.get_random_string(32) }}'

--- a/blocks/common/clusterless/env.yaml
+++ b/blocks/common/clusterless/env.yaml
@@ -1,2 +1,2 @@
 $cndi.comment(cluster_env): CNDI Clusterless Variables
-TERRAFORM_STATE_PASSPHRASE: "{{ $cndi.get_prompt_response(terraform_state_passphrase) }}"
+TERRAFORM_STATE_PASSPHRASE: "{{ $cndi.get_random_string(32) }}"


### PR DESCRIPTION
# Description

The option to override the `TERRAFORM_STATE_PASSPHRASE` has been removed to simplify clusterless Template setup

- [x] remove `TERRAFORM_STATE_PASSPHRASE` prompt
<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
