### PR TITLE
[Enhancement]: Grow charset in random generation

### DIFF
--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -34,20 +34,13 @@ const templatesLabel = ccolors.faded("\n@cndi/use-template:");
 
 type CNDIMode = "cli" | "webui";
 
-function base10intToHex(decimal: number): string {
-  // if the int8 in hex is less than 2 characters, prepend 0
-  const hex = decimal.toString(16).padStart(2, "0");
-  return hex;
-}
+const ALPHANUMERIC_CHARSET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-function getRandomString(len = 32) {
-  if (len % 2) {
-    throw new Error("password length must be even");
-  }
-
-  const values = new Uint8Array(len / 2);
-  crypto.getRandomValues(values);
-  return Array.from(values, base10intToHex).join("");
+function getRandomString(length = 32, charset = ALPHANUMERIC_CHARSET) {
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => charset[byte % charset.length]).join("");
 }
 
 // TODO: 1200 codes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -479,12 +479,6 @@ const getCndiInstallPath = (): string => {
   return path.join(CNDI_HOME, "bin", `cndi${suffix}`);
 };
 
-function base10intToHex(decimal: number): string {
-  // if the int8 in hex is less than 2 characters, prepend 0
-  const hex = decimal.toString(16).padStart(2, "0");
-  return hex;
-}
-
 function getUserDataTemplateFileString(
   role?: NodeRole,
   doBase64Encode?: boolean,
@@ -537,16 +531,6 @@ function replaceRange(
   substitute: string,
 ) {
   return s.substring(0, start) + substitute + s.substring(end);
-}
-
-function getSecretOfLength(len = 32): string {
-  if (len % 2) {
-    throw new Error("password length must be even");
-  }
-
-  const values = new Uint8Array(len / 2);
-  crypto.getRandomValues(values);
-  return Array.from(values, base10intToHex).join("");
 }
 
 function useSshRepoAuth(): boolean {
@@ -619,7 +603,6 @@ export {
   getPathToTerraformBinary,
   getPrettyJSONString,
   getProjectDirectoryFromFlag,
-  getSecretOfLength,
   getStagingDir,
   getTaintEffectForDistribution,
   getTFData,


### PR DESCRIPTION
# Description

Before this PR we generate random strings using only the `0123456789abcdef` character set, now the default charset is `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
