### PR TITLE
[Enhancement]: Use `identity: SystemAssigned` instead of user principal keys

### DIFF
--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -220,9 +220,8 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
           diskDriverEnabled: true,
           blobDriverEnabled: false,
         },
-        servicePrincipal: {
-          clientId: this.variables.arm_client_id.value,
-          clientSecret: this.variables.arm_client_secret.value,
+        identity: {
+          type: "SystemAssigned",
         },
         nodeResourceGroup: `rg-${project_name}-cluster-resources`,
         dependsOn: [this.rg],


### PR DESCRIPTION
# Description

The following was done to ensure that Azure secrets are not required to deploy a cluster:

- [x] convert AKS Cluster permissions from user supplied principal to a system assigned identity

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
