### PR TITLE
[Bug]: fix non-string prompt responses being wrapped in quotes

### DIFF
--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -687,10 +687,24 @@ function literalizeGetPromptResponseCalls(input: string): string {
   let output = removeWhitespaceBetweenBraces(input);
   for (const responseKey in responses) {
     const val = responses[responseKey];
-    output = output.replaceAll(
-      `{{$cndi.get_prompt_response(${responseKey})}}`,
-      `${val}`,
-    );
+
+    if (typeof val == "string") {
+      output = output.replaceAll(
+        `{{$cndi.get_prompt_response(${responseKey})}}`,
+        `${val}`,
+      );
+    } else {
+      // replace the macro and remove surrrounding single quotes when it represents the entire value
+      output = output.replaceAll(
+        `'{{$cndi.get_prompt_response(${responseKey})}}'`,
+        `${val}`,
+      );
+      // replace the macro when it is embedded in a string
+      output = output.replaceAll(
+        `{{$cndi.get_prompt_response(${responseKey})}}`,
+        `${val}`,
+      );
+    }
   }
   return output;
 }


### PR DESCRIPTION
# Related issue

Issue #934

# Description

CNDI's Template parser was rendering quotes surrounding non-string prompt responses. This change results in the `''` being stripped from the template input when the contents are not a string.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
