### PR TITLE
skip `project_name` prompt if provided in `cndi_responses.yaml`

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -313,10 +313,14 @@ const createCommand = new Command()
     let project_name = repo;
 
     if (interactive) {
-      project_name = await PromptTypes.Input.prompt({
-        message: ccolors.prompt("Please enter a name for your CNDI project:"),
-        default: project_name,
-      });
+      if (overrides?.project_name) {
+        project_name = `${overrides.project_name}`;
+      } else {
+        project_name = await PromptTypes.Input.prompt({
+          message: ccolors.prompt("Please enter a name for your CNDI project:"),
+          default: project_name,
+        });
+      }
     }
 
     const directoryContainsCNDIFiles = await checkInitialized(

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -312,15 +312,13 @@ const createCommand = new Command()
 
     let project_name = repo;
 
-    if (interactive) {
-      if (overrides?.project_name) {
-        project_name = `${overrides.project_name}`;
-      } else {
-        project_name = await PromptTypes.Input.prompt({
-          message: ccolors.prompt("Please enter a name for your CNDI project:"),
-          default: project_name,
-        });
-      }
+    if (overrides?.project_name) {
+      project_name = `${overrides.project_name}`;
+    } else if (interactive) {
+      project_name = await PromptTypes.Input.prompt({
+        message: ccolors.prompt("Please enter a name for your CNDI project:"),
+        default: project_name,
+      });
     }
 
     const directoryContainsCNDIFiles = await checkInitialized(


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #943 

# Description

- [x] `cndi create` will now skip asking the user for a project_name if it is supplied in `cndi_responses.yaml`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
