### PR TITLE
[Enhancement]: Make `t3.large` the default AWS instance type

### DIFF
--- a/blocks/aws/basic-node-pool.yaml
+++ b/blocks/aws/basic-node-pool.yaml
@@ -1,4 +1,4 @@
 - name: x-node-group
-  instance_type: t3.medium
+  instance_type: t3.large
   disk_size: 100
   count: 3


### PR DESCRIPTION
# Description

- [x] update aws default instance type to align with azure and gcp

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
