### PR TITLE
[Bug]: Argo Apps Finalizers Preventing `cndi destroy`

### DIFF
--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -39,7 +39,6 @@ const DEFAULT_ARGOCD_API_VERSION = "argoproj.io/v1alpha1";
 const DEFAULT_NAMESPACE = "default";
 const DEFAULT_HELM_VERSION = "v3";
 const DEFAULT_PROJECT = "default";
-const DEFAULT_FINALIZERS = ["resources-finalizer.argocd.argoproj.io"];
 
 const applicationManifestLabel = ccolors.faded(
   "\nsrc/outputs/application-manifest.ts:",
@@ -50,7 +49,6 @@ const manifestFramework = {
   kind: "Application",
   metadata: {
     namespace: DEFAULT_NAMESPACE,
-    finalizers: DEFAULT_FINALIZERS,
     labels: {},
   },
   spec: {
@@ -98,7 +96,6 @@ const getApplicationManifest = (
       labels: {
         name: releaseName,
       },
-      finalizers: DEFAULT_FINALIZERS,
     },
     spec: {
       ...manifestFramework.spec,


### PR DESCRIPTION
### Pull Request: Remove Finalizers from Non-Core Argo Child Apps

#### Description

This pull request aims to remove finalizers from non-core Argo child applications. Removing these finalizers ensures smoother deletion and cleanup of resources, improving the overall manageability and performance of the Argo environment.

#### Summary of Changes

1. **Remove Finalizers from Non-Core Argo Child Apps**
   - This change removes the finalizers from non-core Argo child applications. By doing so, it allows for the immediate deletion of these resources without waiting for additional cleanup processes, streamlining the deletion workflow.
   - Commit: [remove finalizers from non-core apps](https://github.com/polyseam/cndi/commit/4212798e8229452b9464a4e8f9e68faea1f01043)

#### Testing and Validation

- Verified that the removal of finalizers does not impact the core functionality of the Argo applications.
- Ensured that non-core Argo child applications can be deleted without any issues and that no residual resources remain.
- Conducted tests to confirm that the overall performance and manageability of the Argo environment are improved post-change.

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
[remove finalizers from non-core apps](https://github.com/polyseam/cndi/commit/4212798e8229452b9464a4e8f9e68faea1f01043)

@[IamTamika](https://github.com/polyseam/cndi/commits?author=IamTamika)
IamTamika committed 27 minutes ago