### PR TITLE
Add PrunePropagationPolicy=background Annotation to Prevent PDBs from Blocking Cluster Destruction

### DIFF
--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -429,6 +429,7 @@ outputs:
           name: "{{ $cndi.get_prompt_response(postgresql_cluster_name) }}"
           namespace: "{{ $cndi.get_prompt_response(postgresql_namespace) }}"
           annotations:
+            $cndi.comment(why_propagation_policy): PrunePropagationPolicy=background should prevent PDBs from blocking cluster destruction
             argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         spec:
           imageName: 'ghcr.io/cloudnative-pg/postgresql:16'

--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -430,7 +430,7 @@ outputs:
           namespace: "{{ $cndi.get_prompt_response(postgresql_namespace) }}"
           annotations:
             $cndi.comment(why_propagation_policy): PrunePropagationPolicy=background should prevent PDBs from blocking cluster destruction
-            argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+            argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,PrunePropagationPolicy=background
         spec:
           imageName: 'ghcr.io/cloudnative-pg/postgresql:16'
           instances: 3


### PR DESCRIPTION
### Summary
This pull request adds the `PrunePropagationPolicy=background` annotation to the cnpg cluster. This change prevents Pod Disruption Budgets (PDBs) from blocking cluster destruction.

### Changes
- Added `PrunePropagationPolicy=background` annotation to the cnpg cluster in `cnpg-cluster.yaml`.
https://github.com/polyseam/cndi/commit/0d78581ecf42af0e39a1b534328979f65e596d96
https://github.com/polyseam/cndi/pull/956/commits/4882aadd2c5be75c3c8679b43a5270943b93dac8
### Rationale
The `PrunePropagationPolicy=background` ensures that resources are pruned in the background, which prevents PDBs from blocking the deletion process. This is important for ensuring smooth cluster teardown and resource cleanup.

### Testing
- Verified that the annotation is correctly applied.
- Tested cluster destruction to ensure PDBs do not block the process.
