### PR TITLE
Add PostgreSQL Namespace and Configure Nginx Load Balancer

### DIFF
--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -420,7 +420,11 @@ outputs:
             - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
             - ==
             - true
-
+      cnpg-namespace:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: "{{ $cndi.get_prompt_response(postgresql_namespace) }}"
       $cndi.comment(postgres-cluster): Configure your CNPG Cluster here
       cnpg-cluster:
         apiVersion: postgresql.cnpg.io/v1

--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -347,8 +347,8 @@ prompts:
     default: true
     message: >-
       Do you want to install jupyterhub, a web-based data analytics tool?
-
     type: Confirm
+
   - name: jupyter_notebook_login_password
     default: '{{ $cndi.get_random_string(12) }}'
     message: >-
@@ -401,12 +401,7 @@ outputs:
               enabled: true
               values:
                 tcp: 
-                  5432: "{{ $cndi.get_prompt_response(postgresql_namespace) }}/{{ $cndi.get_prompt_response(postgresql_cluster_name) }}-rw:5432"                       
-            private: 
-              enabled: true 
-              values:
-                tcp: 
-                  5432: "{{ $cndi.get_prompt_response(postgresql_namespace) }}/{{ $cndi.get_prompt_response(postgresql_cluster_name) }}-rw:5432"                       
+                  5432: "{{ $cndi.get_prompt_response(postgresql_namespace) }}/{{ $cndi.get_prompt_response(postgresql_cluster_name) }}-rw:5432"                                            
         cert_manager:
           email: "{{ $cndi.get_prompt_response(cert_manager_email) }}"
         nodes:


### PR DESCRIPTION
#Add PostgreSQL Namespace and Configure Nginx Load Balancer
# Description
Addition of PostgreSQL Namespace:

A dedicated namespace for PostgreSQL has been added to enhance organization and isolation of database resources within Kubernetes. 
Commit Reference: [Add postgresql namespace](https://github.com/polyseam/cndi/commit/a7d3a35c6741f9bb07c71ca0ac2eb128dcceebee)
Configuration of Nginx as a Load Balancer:

This update configures that private load balancer setting is disabled to optimize cost and resource utilization in development environments.
Commit Reference: [Disable private lb by default](https://github.com/polyseam/cndi/commit/dc5dd6beebe290707f0f94ff5122fa67da698580)

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [ ] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
