### PR TITLE
[Bug]: `$cndi.get_block(identifier)` failed if stringification did not wrap it with quotes

### DIFF
--- a/cndi_config.yaml
+++ b/cndi_config.yaml
@@ -4,7 +4,6 @@ provider: aws # or 'gcp', 'azure'
 distribution: eks # or 'clusterless'
 infrastructure:
   cndi:
-
     cert_manager:
       email: matt.johnston@polyseam.io
     nodes:
@@ -12,11 +11,5 @@ infrastructure:
         instance_type: t3.medium # or 'n1-standard-2', 'Standard_D2_v2'
         disk_size: 100
 
-cluster_manifests:
-  some:
-    metadata:
-      name: fns-env-secret
-      namespace: fns
-    stringData: {}
-
+cluster_manifests: {}
 applications: {}

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -774,7 +774,6 @@ async function processCNDIConfigOutput(
     let body = getValueFromKeyPath(cndiConfigObj, pathToKey) as GetBlockBody;
 
     if (!body) {
-
       // $cndi.get_block(blockname) with no {{ values }} can result in no singlequoted key
       // so we search for an endToken which does not contain a single quote
       const plainBlockEndToken = "):\n";

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -774,8 +774,11 @@ async function processCNDIConfigOutput(
     let body = getValueFromKeyPath(cndiConfigObj, pathToKey) as GetBlockBody;
 
     if (!body) {
-      // $cndi.get_block(blockname) with no {{ values }} results in no singlequoted key
+
+      // $cndi.get_block(blockname) with no {{ values }} can result in no singlequoted key
+      // so we search for an endToken which does not contain a single quote
       const plainBlockEndToken = "):\n";
+
       indexClose = output.indexOf(plainBlockEndToken, indexOpen);
       key = output.slice(indexOpen, indexClose + 1);
       pathToKey = findPathToKey(key, cndiConfigObj);

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -763,7 +763,7 @@ async function processCNDIConfigOutput(
   let indexOpen = output.indexOf(getBlockBeginToken);
   let indexClose = output.indexOf(getBlockEndToken, indexOpen);
 
-  // first loop
+  // possible that noQuote signature is in first loop: set constent for while condition
   const noQuoteIndexClose = output.indexOf(getBlockEndTokenNoQuote, indexOpen);
 
   let ax = 0;
@@ -793,7 +793,6 @@ async function processCNDIConfigOutput(
     let shouldOutput = true;
 
     if (body?.condition) {
-      console.log("condition", body.condition);
       if (!resolveCNDIPromptCondition(body.condition)) {
         shouldOutput = false;
       }

--- a/src/use-template/tests/mock/templates/get_block-mock.yaml
+++ b/src/use-template/tests/mock/templates/get_block-mock.yaml
@@ -1,0 +1,49 @@
+
+blocks:
+  - name: functions
+    content:
+      hostname: "{{ $cndi.get_prompt_response(fns_hostname) }}"
+
+prompts:
+  - name: enable_fns_ingress
+    default: true
+    message: >-
+      Do you want to expose Cloud Functions with an Ingress?
+    type: Confirm
+ 
+  - name: fns_hostname
+    default: fns.example.com
+    message: >-
+      What hostname should Cloud Functions be accessible at?
+    type: Input
+    validators:
+      - hostname
+    condition:
+      - "{{ $cndi.get_prompt_response(enable_fns_ingress) }}"
+      - ==
+      - true
+
+  - name: cert_manager_email
+    default: true
+    message: >-
+      What email?
+    type: Input
+
+outputs:
+  env:
+    FOO: bar
+  readme:
+    foo: '# header'
+  cndi_config:
+    cndi_version: v2
+    project_name: "{{ $cndi.get_prompt_response(project_name) }}"
+    provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
+    distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
+    infrastructure:
+      cndi:
+        functions:
+          $cndi.get_block(functions):
+            condition:
+              - "{{ $cndi.get_prompt_response(enable_fns_ingress) }}"
+              - ==
+              - true

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -1,6 +1,7 @@
 import { YAML } from "deps";
 import { useTemplate } from "../mod.ts";
 import { assert, parseDotEnv } from "test-deps";
+import { CNDIConfig } from "src/types.ts";
 
 const mySanity = { sanitizeResources: false, sanitizeOps: false };
 
@@ -220,6 +221,7 @@ Deno.test(
   "template execution: a template should be able to insert a block using $cndi.get_block(block_name)",
   mySanity,
   async () => {
+    const fns_hostname = "fns.example.com";
     const mockYamlFileUri = "file://" + Deno.cwd() +
       "/src/use-template/tests/mock/templates/get_block-mock.yaml";
     const template = await useTemplate(mockYamlFileUri, {
@@ -227,12 +229,13 @@ Deno.test(
       overrides: {
         project_name: "test",
         enable_fns_ingress: true,
-        fns_hostname: "fns.example.com",
+        fns_hostname,
         deployment_target_provider: "aws",
         deployment_target_distribution: "eks",
         cert_manager_email: "matt.johnston@polyseam.io",
       },
     });
-    console.log(template.files["cndi_config.yaml"]);
+    const config = YAML.parse(template.files["cndi_config.yaml"]) as CNDIConfig;
+    assert(config?.infrastructure?.cndi?.functions?.hostname === fns_hostname);
   },
 );

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -215,3 +215,24 @@ Deno.test(
     assert(JSON.stringify(parsed.infrastructure?.cndi?.external_dns) !== "{}");
   },
 );
+
+Deno.test(
+  "template execution: a template should be able to insert a block using $cndi.get_block(block_name)",
+  mySanity,
+  async () => {
+    const mockYamlFileUri = "file://" + Deno.cwd() +
+      "/src/use-template/tests/mock/templates/get_block-mock.yaml";
+    const template = await useTemplate(mockYamlFileUri, {
+      interactive: false,
+      overrides: {
+        project_name: "test",
+        enable_fns_ingress: true,
+        fns_hostname: "fns.example.com",
+        deployment_target_provider: "aws",
+        deployment_target_distribution: "eks",
+        cert_manager_email: "matt.johnston@polyseam.io",
+      },
+    });
+    console.log(template.files["cndi_config.yaml"]);
+  },
+);

--- a/templates/fns.yaml
+++ b/templates/fns.yaml
@@ -1,11 +1,8 @@
 # Note: This fns Template just simplifies Cloud Functions setup
 # but any Template can be extended to include Cloud Functions
 
-blocks: # TODO: determine why I can't just have a single block called conditionally by name
-  - name: fns_hostname_false
-    content: {}
-    
-  - name: fns_hostname_true
+blocks:
+  - name: functions
     content:
       hostname: "{{ $cndi.get_prompt_response(fns_hostname) }}"
 
@@ -61,8 +58,12 @@ outputs:
     # this is a Template comment
     infrastructure:
       cndi:
-        functions: 
-          $cndi.get_block(fns_hostname_{{ $cndi.get_prompt_response(enable_fns_ingress) }}): {}
+        functions:
+          $cndi.get_block(functions):
+            condition:
+              - "{{ $cndi.get_prompt_response(enable_fns_ingress) }}"
+              - ==
+              - true
         
         cert_manager:
           email: "{{ $cndi.get_prompt_response(cert_manager_email) }}"


### PR DESCRIPTION
# Description

The process of inserting a block of content into a `cndi_config.yaml` file relies on finding `$cndi.get_block(identifier)` tokens and reliably replacing them with the corresponding block.

This process leveraged the fact that a `$cndi.get_block` call was typically wrapped in single quotes:

```yaml
example:
  # worked before this PR
  '$cndi.get_block(foo-{{ $cndi.get_prompt_response(example_prompt)}})':
    condition:
      - "{{ $cndi.get_prompt_response(example_prompt) }}"
      - ==
      - true
```

however if the `$cndi.get_block` call was stringified without the wrapping quotes, it could not be replaced with the content:

```yaml
example:
  # works after this PR
  $cndi.get_block(foobar):
    condition:
      - "{{ $cndi.get_prompt_response(example_prompt) }}"
      - ==
      - true
```

The solution should be harmless because we only search for the 2nd signature if the first kind can't be found.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
