### PR TITLE
[Build]: copy linux binaries for terraform and kubeseal before running tests

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -34,6 +34,9 @@ jobs:
         run: |
           echo "CNDI Version: ${{ steps.get_deno_json.outputs.version }} does not match Tag version: ${{ steps.get_version_from_ref.outputs.VERSION }}" && exit 1
 
+      - name: Install cndi dependency binaries
+        run: deno task cp-linux-bin-deps
+
       - name: Test
         run: deno task test
 

--- a/.github/workflows/main-latest.yaml
+++ b/.github/workflows/main-latest.yaml
@@ -18,7 +18,7 @@ jobs:
       - run: deno lint
 
       - name: Install cndi dependency binaries
-        run: mkdir -p /home/runner/.cndi/bin && mv ./dist/linux/in/* /home/runner/.cndi/bin
+        run: deno task cp-linux-bin-deps
 
       - run: deno task test
 

--- a/.github/workflows/main-pull.yml
+++ b/.github/workflows/main-pull.yml
@@ -21,7 +21,7 @@ jobs:
         run: deno lint
 
       - name: Install cndi dependency binaries
-        run: mkdir -p /home/runner/.cndi/bin && mv ./dist/linux/in/* /home/runner/.cndi/bin
+        run: deno task cp-linux-bin-deps
 
       - name: Test
         run: deno task test

--- a/deno.json
+++ b/deno.json
@@ -20,7 +20,8 @@
     "build-win": "deno lint && deno fmt && deno task clean-dist && deno task compile-win",
     "test": "deno test --allow-all --v8-flags=--max-old-space-size=8000",
     "test-fast": "deno test --allow-all --v8-flags=--max-old-space-size=8000 --fail-fast",
-    "test-watch": "deno test --allow-all --v8-flags=--max-old-space-size=8000 --watch"
+    "test-watch": "deno test --allow-all --v8-flags=--max-old-space-size=8000 --watch",
+    "cp-linux-bin-deps": "mkdir -p /home/runner/.cndi/bin && mv ./dist/linux/in/* /home/runner/.cndi/bin"
   },
   "imports": {
     "@cdktf/provider-aws": "npm:@cdktf/provider-aws@^19.25.0",


### PR DESCRIPTION
# Description

- [x] fix failing tests by ensuring `kubeseal-cndi` and `terraform-cndi` are copied into $CNDI_HOME before tests run

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
