### PR TITLE
copy binary dependencies rather than move them

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -36,6 +36,12 @@ jobs:
 
       - name: Build
         run: deno task build
+      
+      - name: Install cndi dependency binaries
+        run: mkdir -p /home/runner/.cndi/bin && cp ./dist/linux/in/* /home/runner/.cndi/bin
+      
+      - name: Test
+        run: deno task test
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/main-latest.yaml
+++ b/.github/workflows/main-latest.yaml
@@ -18,7 +18,8 @@ jobs:
       - run: deno lint
 
       - name: Install cndi dependency binaries
-        run: mkdir -p /home/runner/.cndi/bin && mv ./dist/linux/in/* /home/runner/.cndi/bin
+        run: mkdir -p /home/runner/.cndi/bin && cp ./dist/linux/in/* /home/runner/.cndi/bin
+
       - run: deno task test
 
   main-build: # cndi

--- a/.github/workflows/main-pull.yml
+++ b/.github/workflows/main-pull.yml
@@ -21,7 +21,7 @@ jobs:
         run: deno lint
 
       - name: Install cndi dependency binaries
-        run: mkdir -p /home/runner/.cndi/bin && mv ./dist/linux/in/* /home/runner/.cndi/bin
+        run: mkdir -p /home/runner/.cndi/bin && cp ./dist/linux/in/* /home/runner/.cndi/bin
 
       - name: Test
         run: deno task test


### PR DESCRIPTION
# Description

- [x] copy binary dependencies into `$CNDI_HOME/bin` rather than moving them in GitHub Workflows; this enables running tests before packaging a release

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
