### PR TITLE
enable much greater flexibilty in configuring CNDI applications

### DIFF
--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -4,10 +4,10 @@ import { getYAMLString } from "src/utils.ts";
 type ArgoAppInfo = Array<{ name: string; value: string }>;
 
 type Meta = {
-  name: string;
-  namespace: string;
-  labels: Record<string, string>;
-  finalizers: string[];
+  name?: string;
+  namespace?: string;
+  labels?: Record<string, string>;
+  finalizers?: string[];
 };
 
 type SyncPolicy = {
@@ -83,7 +83,7 @@ const getApplicationManifest = (
   releaseName: string,
   applicationSpec: CNDIApplicationSpec,
 ): [string, string] => {
-  const values = getYAMLString(applicationSpec?.values || {});
+  const valuesObject = applicationSpec?.values || {};
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
 
@@ -117,7 +117,7 @@ const getApplicationManifest = (
     name,
     namespace: DEFAULT_NAMESPACE,
     labels,
-    finalizers: applicationSpec.finalizers || [],
+    finalizers: applicationSpec?.finalizers,
     ...userMeta,
   };
 
@@ -133,7 +133,7 @@ const getApplicationManifest = (
       targetRevision,
       helm: {
         version: DEFAULT_HELM_VERSION,
-        values,
+        valuesObject,
       },
     },
     destination: {

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -83,7 +83,7 @@ const getApplicationManifest = (
   releaseName: string,
   applicationSpec: CNDIApplicationSpec,
 ): [string, string] => {
-  const valuesObject = applicationSpec?.values || {};
+  const values = getYAMLString(applicationSpec?.values || {});
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
 
@@ -133,7 +133,7 @@ const getApplicationManifest = (
       targetRevision,
       helm: {
         version: DEFAULT_HELM_VERSION,
-        valuesObject,
+        values,
       },
     },
     destination: {

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -123,7 +123,7 @@ const getApplicationManifest = (
   };
 
   const syncPolicy = { ...DEFAULT_SYNC_POLICY, ...applicationSpec?.syncPolicy };
-  const { repoURL, path, chart, targetRevision } = applicationSpec;
+  const { repoURL, path, chart, targetRevision, info } = applicationSpec;
 
   const spec = {
     project: DEFAULT_PROJECT,
@@ -142,6 +142,7 @@ const getApplicationManifest = (
       namespace: applicationSpec.destinationNamespace,
     },
     syncPolicy,
+    info,
   };
 
   const manifest = {

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -84,7 +84,6 @@ const getApplicationManifest = (
   applicationSpec: CNDIApplicationSpec,
 ): [string, string] => {
   const valuesObject = applicationSpec?.values || {};
-  // const values = getYAMLString(applicationSpec?.values || {});
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
 

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -36,8 +36,8 @@ export interface CNDIApplicationSpec {
   values: {
     [key: string]: unknown;
   };
-  labels: Record<string, string>;
-  finalizers: string[];
+  labels?: Record<string, string>;
+  finalizers?: string[];
   directory?: {
     include?: string;
     exclude?: string;

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -1,6 +1,32 @@
 import { ccolors } from "deps";
 import { getYAMLString } from "src/utils.ts";
 
+type ArgoAppInfo = Array<{ name: string; value: string }>;
+
+type Meta = {
+  name: string;
+  namespace: string;
+  labels: Record<string, string>;
+  finalizers: string[];
+};
+
+type SyncPolicy = {
+  automated: {
+    prune: boolean;
+    selfHeal: boolean;
+    allowEmpty: boolean;
+  };
+  syncOptions: string[];
+  retry: {
+    limit: number;
+    backoff: {
+      duration: string;
+      factor: number;
+      maxDuration: string;
+    };
+  };
+};
+
 export interface CNDIApplicationSpec {
   targetRevision: string;
   repoURL: string;
@@ -10,6 +36,15 @@ export interface CNDIApplicationSpec {
   values: {
     [key: string]: unknown;
   };
+  labels: Record<string, string>;
+  finalizers: string[];
+  directory?: {
+    include?: string;
+    exclude?: string;
+  };
+  info?: ArgoAppInfo;
+  syncPolicy?: SyncPolicy;
+  metadata?: Meta;
 }
 
 const DEFAULT_SYNC_POLICY = {
@@ -44,32 +79,12 @@ const applicationManifestLabel = ccolors.faded(
   "\nsrc/outputs/application-manifest.ts:",
 );
 
-const manifestFramework = {
-  apiVersion: DEFAULT_ARGOCD_API_VERSION,
-  kind: "Application",
-  metadata: {
-    namespace: DEFAULT_NAMESPACE,
-    labels: {},
-  },
-  spec: {
-    project: DEFAULT_PROJECT,
-    source: {
-      helm: {
-        version: DEFAULT_HELM_VERSION,
-      },
-    },
-    destination: {
-      server: DEFAULT_DESTINATION_SERVER,
-    },
-    syncPolicy: DEFAULT_SYNC_POLICY,
-  },
-};
-
 const getApplicationManifest = (
   releaseName: string,
   applicationSpec: CNDIApplicationSpec,
 ): [string, string] => {
-  const values = getYAMLString(applicationSpec?.values || {});
+  const valuesObject = applicationSpec?.values || {};
+  // const values = getYAMLString(applicationSpec?.values || {});
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
 
@@ -89,32 +104,51 @@ const getApplicationManifest = (
     );
   }
 
+  const labelSpec = applicationSpec.labels || {};
+  const name = releaseName;
+
+  const userMeta: Partial<Meta> = applicationSpec?.metadata || {};
+
+  const labels = {
+    ...labelSpec,
+    name,
+  };
+
+  const metadata: Meta = {
+    name,
+    namespace: DEFAULT_NAMESPACE,
+    labels,
+    finalizers: applicationSpec.finalizers || [],
+    ...userMeta,
+  };
+
+  const syncPolicy = { ...DEFAULT_SYNC_POLICY, ...applicationSpec?.syncPolicy };
+  const { repoURL, path, chart, targetRevision } = applicationSpec;
+
+  const spec = {
+    project: DEFAULT_PROJECT,
+    source: {
+      repoURL,
+      path,
+      chart,
+      targetRevision,
+      helm: {
+        version: DEFAULT_HELM_VERSION,
+        valuesObject,
+      },
+    },
+    destination: {
+      server: DEFAULT_DESTINATION_SERVER,
+      namespace: applicationSpec.destinationNamespace,
+    },
+    syncPolicy,
+  };
+
   const manifest = {
-    ...manifestFramework,
-    metadata: {
-      name: releaseName,
-      labels: {
-        name: releaseName,
-      },
-    },
-    spec: {
-      ...manifestFramework.spec,
-      source: {
-        ...manifestFramework.spec.source,
-        repoURL: applicationSpec.repoURL,
-        path: applicationSpec.path,
-        chart: applicationSpec.chart,
-        targetRevision: applicationSpec.targetRevision,
-        helm: {
-          ...manifestFramework.spec.source.helm,
-          values, // TODO: use valuesObject it's a bit more readable etc.
-        },
-      },
-      destination: {
-        ...manifestFramework.spec.destination,
-        namespace: applicationSpec.destinationNamespace,
-      },
-    },
+    apiVersion: DEFAULT_ARGOCD_API_VERSION,
+    kind: "Application",
+    metadata,
+    spec,
   };
 
   return [getYAMLString(manifest), `${releaseName}.application.yaml`];


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #190 

# Description

- [x] rewrote `src/outputs/application-manifest.yaml` for greater user control and flexibility
- [x] use argo's `valuesObject` option instead of `values` for more legible Application Manifests 

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
