### PR TITLE
deepmerge syncPolicy; no default namespace for App CRD

### DIFF
--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -119,7 +119,8 @@ const getApplicationManifest = (
     console.log(
       ccolors.warn("using"),
       releaseNameForPrint,
-      ccolors.warn("for destinationNamespace"),
+      ccolors.warn("for"),
+      ccolors.key_name("destinationNamespace"),
     );
   }
 

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -71,7 +71,6 @@ const DEFAULT_SYNC_POLICY = {
 
 const DEFAULT_DESTINATION_SERVER = "https://kubernetes.default.svc";
 const DEFAULT_ARGOCD_API_VERSION = "argoproj.io/v1alpha1";
-const DEFAULT_NAMESPACE = "default";
 const DEFAULT_HELM_VERSION = "v3";
 const DEFAULT_PROJECT = "default";
 
@@ -86,9 +85,11 @@ const getApplicationManifest = (
   const valuesObject = applicationSpec?.values || {};
   const specSourcePath = applicationSpec.path;
   const specSourceChart = applicationSpec.chart;
+  const destinationNamespace = applicationSpec?.destinationNamespace;
+
+  const releaseNameForPrint = ccolors.user_input(`"${releaseName}"`);
 
   if (!specSourcePath && !specSourceChart) {
-    const releaseNameForPrint = ccolors.user_input(`"${releaseName}"`);
     console.error(
       applicationManifestLabel,
       ccolors.error(
@@ -100,6 +101,25 @@ const getApplicationManifest = (
         `or applications[${releaseNameForPrint}]${ccolors.key_name(".chart")}`,
       ),
       ccolors.error(`must be defined`),
+    );
+  }
+
+  if (!destinationNamespace) {
+    console.log(
+      applicationManifestLabel,
+      ccolors.error(
+        `applications[${releaseNameForPrint}]${
+          ccolors.key_name(
+            ".destinationNamespace",
+          )
+        }`,
+      ),
+      ccolors.error(`must be defined`),
+    );
+    console.log(
+      ccolors.warn("using"),
+      releaseNameForPrint,
+      ccolors.warn("for destinationNamespace"),
     );
   }
 
@@ -141,7 +161,7 @@ const getApplicationManifest = (
     },
     destination: {
       server: DEFAULT_DESTINATION_SERVER,
-      namespace: applicationSpec.destinationNamespace,
+      namespace: destinationNamespace,
     },
     syncPolicy,
     info,

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -115,7 +115,6 @@ const getApplicationManifest = (
 
   const metadata: Meta = {
     name,
-    namespace: DEFAULT_NAMESPACE,
     labels,
     finalizers: applicationSpec?.finalizers,
     ...userMeta,
@@ -125,7 +124,7 @@ const getApplicationManifest = (
     DEFAULT_SYNC_POLICY,
     applicationSpec?.syncPolicy || {},
   );
-  
+
   const { repoURL, path, chart, targetRevision, info } = applicationSpec;
 
   const spec = {

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -1,4 +1,4 @@
-import { ccolors } from "deps";
+import { ccolors, deepMerge } from "deps";
 import { getYAMLString } from "src/utils.ts";
 
 type ArgoAppInfo = Array<{ name: string; value: string }>;
@@ -121,7 +121,11 @@ const getApplicationManifest = (
     ...userMeta,
   };
 
-  const syncPolicy = { ...DEFAULT_SYNC_POLICY, ...applicationSpec?.syncPolicy };
+  const syncPolicy = deepMerge(
+    DEFAULT_SYNC_POLICY,
+    applicationSpec?.syncPolicy || {},
+  );
+  
   const { repoURL, path, chart, targetRevision, info } = applicationSpec;
 
   const spec = {


### PR DESCRIPTION
# Description

- [x] application manifests should not have source CRD `namespace` by default
- [x] if a `destinationNamespace` is missing, call the users attention to it but use the `releaseName` 

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
