### PR TITLE
Exposing TCP services from NGINX Ingress Controller and rm open ports

### DIFF
--- a/templates/mongodb.yaml
+++ b/templates/mongodb.yaml
@@ -27,7 +27,7 @@ blocks:
                       service:
                         name: mongodb-replica-set-svc
                         port:
-                          name: mongodb
+                          number: 27017
 prompts:
   - $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/common/cluster/core-prompts.yaml):
       {}
@@ -113,15 +113,17 @@ outputs:
               - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
               - ==
               - true
+        ingress:
+          nginx:
+            public: 
+              enabled: true
+              values:
+                tcp: 
+                  27017: "{{ $cndi.get_prompt_response(mongodb_namespace) }}/mongodb-replica-set-svc:27017"        
         nodes:
           $cndi.get_block(https://raw.githubusercontent.com/polyseam//polyseam/cndi/main/blocks/{{ $cndi.get_prompt_response(deployment_target_provider) }}/basic-node-pool.yaml):
             {}
-
-        open_ports:
-          - number: 27017
-            name: mongodb
-            namespace: "{{ $cndi.get_prompt_response(mongodb_namespace) }}"
-            service: mongodb-replica-set-svc
+      
     cluster_manifests:
       argo-ingress:
         $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/common/cluster/default-ingress.yaml):

--- a/templates/mssqlserver.yaml
+++ b/templates/mssqlserver.yaml
@@ -111,13 +111,13 @@ outputs:
               - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
               - ==
               - true
-
-        open_ports:
-          - number: 1433
-            name: mssql
-            namespace: mssql
-            service: mssql-0
-
+        ingress:
+          nginx:
+            public: 
+              enabled: true
+              values:
+                tcp: 
+                  1433: "mssql/mssql-0:1433"
         nodes:
           $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/{{ $cndi.get_prompt_response(deployment_target_provider) }}/basic-node-pool.yaml):
             {}

--- a/templates/mysql.yaml
+++ b/templates/mysql.yaml
@@ -97,16 +97,16 @@ outputs:
               - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
               - ==
               - true
-              
+        ingress:
+          nginx:
+            public: 
+              enabled: true
+              values:
+                tcp: 
+                  3306: "myinnodbcluster/mycluster:3306"                       
         nodes:
           $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/{{ $cndi.get_prompt_response(deployment_target_provider) }}/basic-node-pool.yaml):
             {}
-            
-        open_ports:
-          - number: 3306
-            name: mysql
-            namespace: myinnodbcluster
-            service: mycluster
 
     cluster_manifests:
       argo-ingress:

--- a/templates/neo4j.yaml
+++ b/templates/neo4j.yaml
@@ -65,16 +65,16 @@ outputs:
               - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
               - ==
               - true
-              
+        ingress:
+          nginx:
+            public: 
+              enabled: true
+              values:
+                tcp: 
+                  7687: "neo4j/neo4j:7687"                       
         nodes:
           $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/{{ $cndi.get_prompt_response(deployment_target_provider) }}/basic-node-pool.yaml):
             {}
-            
-        open_ports:
-          - name: tcp-bolt
-            number: 7687
-            service: neo4j
-            namespace: neo4j
             
     cluster_manifests:
       $cndi.comment(neo4j-auth-secret): Neo4j Credentials

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -106,17 +106,17 @@ outputs:
               - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
               - ==
               - true
-              
+        ingress:
+          nginx:
+            public: 
+              enabled: true
+              values:
+                tcp: 
+                  6379: "{{ $cndi.get_prompt_response(default_namespace) }}/redis-replication:6379"                       
         nodes:
           $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/{{ $cndi.get_prompt_response(deployment_target_provider) }}/basic-node-pool.yaml):
             {}
             
-        open_ports:
-          - name: redisrep
-            number: 6379
-            service: redis-replication
-            namespace: "{{ $cndi.get_prompt_response(default_namespace) }}"
-
     cluster_manifests:
       redis-secret:
         apiVersion: v1

--- a/templates/superset.yaml
+++ b/templates/superset.yaml
@@ -109,14 +109,17 @@ outputs:
               - "{{ $cndi.get_prompt_response(enable_external_dns) }}"
               - ==
               - true
-
+        ingress:
+          nginx:
+            public: 
+              enabled: true
+              values:
+                tcp: 
+                  8088: "{{ $cndi.get_prompt_response(superset_namespace) }}/apache-superset:8088"         
         nodes:
           $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/{{ $cndi.get_prompt_response(deployment_target_provider) }}/basic-node-pool.yaml):
             {}
-            
-        open_ports:
-          - name: superset
-            number: 8088
+
     cluster_manifests:
       superset-namespace:
           apiVersion: v1


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #

# Description
By default ingress doesn't support TCP.  In order for our ingress controller to expose and redirect incoming tcp connection to the appropriate service we have to add entries to the empty tcp config map.

In the key-value entry, the key is the port we want to expose on our cluster and the value is the target service using the pattern 

key : namespace/service-name:port

- [x ] removed open ports section
- [x ] add tcp entry section to nginx controller
# Test Instructions
The nginx loadbalancer ports should update with the added tcp entry and the service should be available publicly 

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x ] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
