### PR TITLE
Remove redundant ssl-passthrough=true annotation when ssl enable is not enabled in the controller

### DIFF
--- a/blocks/common/cluster/default-ingress.yaml
+++ b/blocks/common/cluster/default-ingress.yaml
@@ -6,11 +6,8 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: cluster-issuer
     kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     external-dns.alpha.kubernetes.io/hostname: "{{ $cndi.get_arg(hostname) }}"
-    $cndi.comment(unmanaged_target_description): "if you are using an unmanaged Kubernetes distribution, you can uncomment the following line and replace the value with your load balancer hostname"
-    $cndi.comment(unmanaged_target): "external-dns.alpha.kubernetes.io/target: my-loadbalancer.us-east-1.elb.amazonaws.com"
 spec:
   ingressClassName: "{{ $cndi.get_arg(ingress_class_name) }}"
   tls:

--- a/templates/airflow.yaml
+++ b/templates/airflow.yaml
@@ -56,7 +56,6 @@ blocks:
         annotations:
           cert-manager.io/cluster-issuer: cluster-issuer
           kubernetes.io/tls-acme: 'true'
-          nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
           external-dns.alpha.kubernetes.io/hostname: "{{ $cndi.get_prompt_response(airflow_hostname) }}"
       spec:
         ingressClassName: public

--- a/templates/cnpg.yaml
+++ b/templates/cnpg.yaml
@@ -33,7 +33,6 @@ blocks:
       annotations:
         cert-manager.io/cluster-issuer: cluster-issuer
         kubernetes.io/tls-acme: 'true'
-        nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
         external-dns.alpha.kubernetes.io/hostname: "{{ $cndi.get_prompt_response(jupyter_notebook_hostname) }}"
     spec:
       ingressClassName: public
@@ -189,7 +188,6 @@ blocks:
       annotations:
         cert-manager.io/cluster-issuer: cluster-issuer
         kubernetes.io/tls-acme: 'true'
-        nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
         external-dns.alpha.kubernetes.io/hostname: "{{ $cndi.get_prompt_response(pgadmin_hostname) }}"
         # if you are using an unmanaged Kubernetes distribution, you can uncomment the following line and replace the value with your load balancer hostname
         # external-dns.alpha.kubernetes.io/target: my-loadbalancer.us-east-1.elb.amazonaws.com

--- a/templates/coder.yaml
+++ b/templates/coder.yaml
@@ -34,7 +34,6 @@ blocks:
       annotations:
         cert-manager.io/cluster-issuer: cluster-issuer
         kubernetes.io/tls-acme: 'true'
-        nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
         external-dns.alpha.kubernetes.io/hostname: "{{ $cndi.get_prompt_response(pgadmin_hostname) }}"
     spec:
       ingressClassName: public
@@ -64,7 +63,6 @@ blocks:
       annotations:
         cert-manager.io/cluster-issuer: cluster-issuer
         kubernetes.io/tls-acme: 'true'
-        nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
         external-dns.alpha.kubernetes.io/hostname: "{{ $cndi.get_prompt_response(coder_hostname) }}"
     spec:
       ingressClassName: public

--- a/templates/mongodb.yaml
+++ b/templates/mongodb.yaml
@@ -9,7 +9,6 @@ blocks:
           annotations:
             cert-manager.io/cluster-issuer: cluster-issuer
             kubernetes.io/tls-acme: 'true'
-            nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
         spec:
           ingressClassName: public

--- a/templates/mysql.yaml
+++ b/templates/mysql.yaml
@@ -9,7 +9,6 @@ blocks:
           annotations:
             cert-manager.io/cluster-issuer: cluster-issuer
             kubernetes.io/tls-acme: 'true'
-            nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
         spec:
           ingressClassName: public

--- a/templates/proxy.yaml
+++ b/templates/proxy.yaml
@@ -117,7 +117,6 @@ outputs:
             cert-manager.io/cluster-issuer: cluster-issuer
             kubernetes.io/tls-acme: "true"
             $cndi.comment(nginx_annotation_link): "to learn more about available nginx annotations checkout https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations"
-            nginx.ingress.kubernetes.io/ssl-passthrough: "true"
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
             nginx.ingress.kubernetes.io/limit-rpm: "{{ $cndi.get_prompt_response(rate_limit_rpm) }}" # rate limit in requests per minute
             nginx.ingress.kubernetes.io/limit-burst-multiplier: "{{ $cndi.get_prompt_response(rate_limit_burst) }}" # burst multiplier

--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -9,7 +9,6 @@ blocks:
           annotations:
             cert-manager.io/cluster-issuer: cluster-issuer
             kubernetes.io/tls-acme: 'true'
-            nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
             nginx.ingress.kubernetes.io/backend-protocol: HTTPS
         spec:
           ingressClassName: public


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #
I had thought enabling ssl-passthough through the ingress resource as an annotation was the only thing needed to have ssl passthrough  turns out it requires 2 steps:

1. Configure SSL passthrough on the ingress controller.
2. Annotate your ingress with ssl-passthrough.

# Description
[Ingress-nginx User Guide](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#:~:text=302%20(Moved%20Temporarily)-,SSL%20Passthrough,-%C2%B6)

[Kafka KRaft Strimzi behind Nginx ingress controller TLS/SSL](https://qdnqn.com/kafka-strimzi-behind-nginx-ingress-controller/#:~:text=To%20deploy%20nginx%2Dingress%2Dcontroller%20in%20the%20ssl%2Dpassthrough%20mode%20it%20needs%20explicit%20configuration%20for%20that.%20By%20default%20ssl%2Dpassthroug%20is%20disabled.)

In this code I removed the nginx.ingress.kubernetes.io/ssl-passthrough=true annotation from all the ingresses as the first step of configuring SSL passthrough on the ingress controller [--enable-ssl-passthrough](https://kubernetes.github.io/ingress-nginx/user-guide/cli-arguments/) so the annotation isnt enabled and actually working. Its only in the case of the kafka template where step 1 - the enable-ssl-passthrough as true is set on the nginx controller and step 2 -  the nginx.ingress.kubernetes.io/ssl-passthrough=true annotation is set on the ingress. is ssl passthrough  actually working and that is what is causing argo ingress to not work anymore.
![image](https://github.com/user-attachments/assets/8536af4e-d726-41c4-bb16-1c4cced0be40)
 Once i remove   nginx.ingress.kubernetes.io/ssl-passthrough: 'true' off the argocd ingress
 it now works

![image](https://github.com/user-attachments/assets/c0dbd65a-2625-4c0f-aed1-c6d425a85689)



# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
