### PR TITLE
 Ignore Differences for Certain Fields in Cert Manager to Stop AKS Sync Loop in ArgoCD

### DIFF
--- a/src/outputs/core-applications/cert-manager.application.yaml.ts
+++ b/src/outputs/core-applications/cert-manager.application.yaml.ts
@@ -33,6 +33,17 @@ export default function getCertManagerApplicationManifest(): string {
         server: DEFAULT_DESTINATION_SERVER,
         namespace: "cert-manager",
       },
+      ignoreDifferences: [
+        {
+          group: "admissionregistration.k8s.io",
+          kind: "ValidatingWebhookConfiguration",
+          name: "cert-manager-webhook",
+          jqPathExpressions: [
+            '.webhooks[].namespaceSelector.matchExpressions[] | select(.key == "control-plane")',
+            '.webhooks[].namespaceSelector.matchExpressions[] | select(.key == "kubernetes.azure.com/managedby")',
+          ],
+        },
+      ],
       syncPolicy: {
         automated: {
           prune: true,


### PR DESCRIPTION
Description:
This pull request addresses an issue where ArgoCD was continuously syncing changes on an AKS cluster due to differences detected in certain fields managed by Cert Manager.

Problem:
ArgoCD was entering a sync loop due to changes detected in specific fields of Cert Manager resources, particularly in the status and webhook fields of ValidatingWebhookConfiguration objects. These fields are often updated automatically by aks, causing unnecessary sync operations.

Solution:
To prevent this sync loop, the following changes have been implemented:

Added ignoreDifferences configuration in the ArgoCD Application manifest to ignore changes in the  webhook fields of ValidatingWebhookConfiguration deployed by the Cert Manager app.
Used jqPathExpressions to specify the paths that should be ignored by ArgoCD during the comparison.

Impact:
This change will stop ArgoCD from unnecessarily syncing changes when these specific fields are updated, reducing sync noise and preventing potential issues in the AKS environment.

Testing:
Verified the ArgoCD sync behavior with the updated ignoreDifferences configuration.
Ensured that no unintended differences are ignored, keeping the sync process accurate and effective.
By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)
https://github.com/cert-manager/cert-manager/issues/4114#issuecomment-1008162907
https://github.com/Azure/AKS/issues/4002
<!-- Additional notes that add context or help reviewers -->
