### PR TITLE
[Bug]: redis-password unlinked to cluster

### DIFF
--- a/templates/redis.yaml
+++ b/templates/redis.yaml
@@ -140,6 +140,9 @@ outputs:
           kubernetesConfig:
             image: quay.io/opstree/redis:v7.0.12
             imagePullPolicy: IfNotPresent
+            redisSecret:
+              name: redis-secret
+              key: password
             resources:
               $cndi.comment(sizing): consumption stable for default node type 
               requests:


### PR DESCRIPTION
# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

- [x] ensure redis-password is present and correct upon connection

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
