### PR TITLE
feat: extdns: do not clobber localhost devmode loopback record

### DIFF
--- a/src/outputs/core-applications/external-dns.application.yaml.ts
+++ b/src/outputs/core-applications/external-dns.application.yaml.ts
@@ -8,6 +8,7 @@ const DEFAULT_ARGOCD_API_VERSION = "argoproj.io/v1alpha1";
 const DEFAULT_HELM_VERSION = "v3";
 const DEFAULT_PROJECT = "default";
 const DEFAULT_FINALIZERS = ["resources-finalizer.argocd.argoproj.io"];
+const EXCLUDED_FROM_EXTERNAL_DNS = ["devmode.cndi.link"];
 
 const getDefaultExternalDNSProviderForCNDIProvider = (
   cndiProvider: CNDIProvider,
@@ -53,6 +54,7 @@ export default function getExternalDNSApplicationManifest(
     ...cndi_config?.infrastructure?.cndi?.external_dns?.values || {},
     provider: externalDNSProvider,
     domainFilters: domain_filters,
+    excludeDomains: EXCLUDED_FROM_EXTERNAL_DNS,
   };
 
   if (externalDNSCannotUseEnvVars.includes(externalDNSProvider)) {


### PR DESCRIPTION
# Description

We have a helper domain which points to localhost for use in `dev/*` clusters. We don't want to attempt to clobber these DNS records in Route53, so we should explicitly omit them from ExternalDNS using it's core-app values.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
