### PR TITLE
[Bug]: `cndi create` should validate repo slug before acting

### DIFF
--- a/docs/error-code-reference.json
+++ b/docs/error-code-reference.json
@@ -111,7 +111,7 @@
   },
   {
     "code": 500,
-    "message": "cndi_config.yaml not found during 'cndi overwrite'",
+    "message": "cndi_config.yaml not found",
     "discussion_link": "https://github.com/orgs/polyseam/discussions/508"
   },
   {
@@ -492,6 +492,11 @@
     "code": 1506,
     "message": "failed to run `cndi create` because the user has not provided the necessary 'git_username' and 'git_repo' responses",
     "discussion_link": "https://github.com/orgs/polyseam/discussions/902"
+  },
+  {
+    "code": 1507,
+    "message": "failed to run `cndi create` because it was called with an invalid repo slug argument",
+    "discussion_link": "https://github.com/orgs/polyseam/discussions/896"
   },
   {
     "code": 1600,

--- a/src/setTF_VARs.ts
+++ b/src/setTF_VARs.ts
@@ -9,14 +9,7 @@ export default async function setTF_VARs(projectDir: string) {
     const { config } = await loadCndiConfig(projectDir);
     isClusterless = config.distribution === "clusterless";
   } catch (e) {
-    console.error(e);
-    throw new Error(
-      [
-        setTF_VARsLabel,
-        ccolors.error("Failed to load cndi config"),
-      ].join(" "),
-      { cause: 90000 },
-    );
+    throw e;
   }
 
   const envPath = path.join(projectDir, ".env");

--- a/src/tests/commands/create.test.ts
+++ b/src/tests/commands/create.test.ts
@@ -1,0 +1,73 @@
+import { assert } from "test-deps";
+
+import { runCndi } from "src/tests/helpers/run-cndi.ts";
+
+Deno.env.set("CNDI_TELEMETRY", "debug");
+
+const ogDir = Deno.cwd();
+
+const cleanup = () => {
+  Deno.chdir(ogDir);
+};
+
+Deno.test(
+  "'cndi create' should throw an error if the repo-slug argument contains invalid characters",
+  async (t) => {
+    let dir = "";
+
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+    });
+
+    await t.step("test", async () => {
+      const result = await runCndi(
+        "create",
+        "owner.foo/repo",
+        "-l",
+        "aws/eks",
+        "-t",
+        "basic",
+      );
+
+      assert(result.status.success === false);
+      assert(result.stderrOutput.includes("slug"));
+    });
+
+    await t.step("cleanup", cleanup);
+  },
+);
+
+// Deno.test(
+//   "'cndi create' should create a repo if the repo-slug is valid",
+//   async (t) => {
+//     let dir = "";
+
+//     await t.step("setup", async () => {
+//       dir = await Deno.makeTempDir();
+//       Deno.chdir(dir);
+//     });
+
+//     await t.step("test", async () => {
+//       const owner = 'polyseam';
+//       const repo = 'test-repo-do-not-touch';
+
+//       const result = await runCndi(
+//         "create",
+//         `${owner}/${repo}`,
+//         "-l",
+//         "aws/eks",
+//         "-t",
+//         "basic",
+//       );
+
+//       assert(result.status.success === false);
+//       assert(result.stderrOutput.includes("slug"));
+//     });
+
+//     await t.step("cleanup", () => {
+
+//       cleanup()
+//     });
+//   },
+// );

--- a/src/tests/commands/create.test.ts
+++ b/src/tests/commands/create.test.ts
@@ -37,37 +37,3 @@ Deno.test(
     await t.step("cleanup", cleanup);
   },
 );
-
-// Deno.test(
-//   "'cndi create' should create a repo if the repo-slug is valid",
-//   async (t) => {
-//     let dir = "";
-
-//     await t.step("setup", async () => {
-//       dir = await Deno.makeTempDir();
-//       Deno.chdir(dir);
-//     });
-
-//     await t.step("test", async () => {
-//       const owner = 'polyseam';
-//       const repo = 'test-repo-do-not-touch';
-
-//       const result = await runCndi(
-//         "create",
-//         `${owner}/${repo}`,
-//         "-l",
-//         "aws/eks",
-//         "-t",
-//         "basic",
-//       );
-
-//       assert(result.status.success === false);
-//       assert(result.stderrOutput.includes("slug"));
-//     });
-
-//     await t.step("cleanup", () => {
-
-//       cleanup()
-//     });
-//   },
-// );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,6 +125,19 @@ const loadCndiConfig = async (
     pathToConfig = path.join(projectDirectory, "cndi_config.yml");
   }
 
+  if (!await exists(pathToConfig)) {
+    throw new Error(
+      [
+        utilsLabel,
+        ccolors.error("failed to find a"),
+        ccolors.key_name(`cndi_config.yaml`),
+        ccolors.error("file at"),
+        ccolors.user_input(path.join(projectDirectory, "cndi_config.yaml")),
+      ].join(" "),
+      { cause: 500 },
+    );
+  }
+
   try {
     const config = await loadYAML(pathToConfig) as CNDIConfig;
     return { config, pathToConfig };


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #991 

# Description

- [x] `cndi create owner/foo.repo` did not validate the slug up front, resulting in broken projects rather than an early exit

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
