### PR TITLE
Change node name for azure from gpu-enabled to gpuenabled based on the error:

### DIFF
--- a/templates/gpu-operator.yaml
+++ b/templates/gpu-operator.yaml
@@ -12,7 +12,7 @@ blocks:
   - name: azure-nodes
     content:
       nodes:
-        - name: gpu-enabled
+        - name: gpuenabled
           $cndi.comment(azure_vantage): https://instances.vantage.sh/azure/vm/nc4ast4-v3
           instance_type: nc4ast4-v3
           labels:


### PR DESCRIPTION
 `Your AKS node name "gpu-enabled" is invalid
 AKS Node Pool names must be at most 12 characters long and only contain
lowercase alphanumeric characters`

# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #

# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
