### PR TITLE
feat: disable `cndi run` github workflow for `dev` provider

### DIFF
--- a/src/actions/overwrite.worker.ts
+++ b/src/actions/overwrite.worker.ts
@@ -189,18 +189,23 @@ self.onmessage = async (message: OverwriteWorkerMessage) => {
         "cndi-run.yaml",
       );
 
-      await stageFile(
-        runWorkflowPath,
-        getCndiRunGitHubWorkflowYamlContents(
-          config,
-          options?.workflowSourceRef,
-        ),
-      );
-
-      console.log(
-        ccolors.success("staged 'cndi-run' GitHub workflow:"),
-        ccolors.key_name(runWorkflowPath),
-      );
+      if (config?.provider !== "dev") {
+        await stageFile(
+          runWorkflowPath,
+          getCndiRunGitHubWorkflowYamlContents(
+            config,
+            options?.workflowSourceRef,
+          ),
+        );
+        console.log(
+          ccolors.success("staged 'cndi-run' GitHub workflow:"),
+          ccolors.key_name(runWorkflowPath),
+        );
+      } else {
+        console.log(
+          "Skipping 'cndi-run' workflow for 'dev' provider.",
+        );
+      }
 
       if (options?.enablePrChecks) {
         const onPullWorkflowPath = path.join(

--- a/src/tests/commands/ow.test.ts
+++ b/src/tests/commands/ow.test.ts
@@ -3,6 +3,7 @@ import { assert } from "test-deps";
 import { runCndi } from "src/tests/helpers/run-cndi.ts";
 
 import {
+  listAllFilePaths,
   listChangedFilePaths,
   setsAreEquivalent,
 } from "src/tests/helpers/util.ts";
@@ -34,6 +35,30 @@ Deno.test(
         assert(status.success);
       });
       assert(changedFilePaths.length === 0);
+    });
+
+    await t.step("cleanup", cleanup);
+  },
+);
+
+Deno.test(
+  "'cndi ow' should not create cndi-run GitHub workflow for 'dev' provider",
+  async (t) => {
+    let dir = "";
+    await t.step("setup", async () => {
+      dir = await Deno.makeTempDir();
+      Deno.chdir(dir);
+      await runCndi("init", "-t", "basic", "-l", "dev/microk8s");
+    });
+
+    await t.step("test", async () => {
+      const filepaths = await listAllFilePaths(dir);
+      const pathToCndiRunWorkflow = path.join(
+        ".github",
+        "workflows",
+        "cndi-run.yaml",
+      );
+      assert(!filepaths.includes(pathToCndiRunWorkflow));
     });
 
     await t.step("cleanup", cleanup);

--- a/src/tests/helpers/util.ts
+++ b/src/tests/helpers/util.ts
@@ -38,7 +38,7 @@ const hasSameFilesAfter = async (
 };
 
 // Function to list all file paths in the current directory including subfolders
-async function listAllFilePaths(directory: string): Promise<string[]> {
+export async function listAllFilePaths(directory: string): Promise<string[]> {
   const filePaths: string[] = [];
 
   for await (const entry of walk(directory)) {


### PR DESCRIPTION
# Description

- [x] disable GitHub Action Workflow for `cndi run` in all `dev/*` deployment targets

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
