### PR TITLE
[Bug]: `$cndi.get_block(foo)` clobbers existing peer properties

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,10 +5,10 @@
       "jsr:@cliffy/ansi@1.0.0-rc.4": "jsr:@cliffy/ansi@1.0.0-rc.4",
       "jsr:@cliffy/ansi@1.0.0-rc.5": "jsr:@cliffy/ansi@1.0.0-rc.5",
       "jsr:@cliffy/ansi@^1.0.0-rc.4": "jsr:@cliffy/ansi@1.0.0-rc.5",
-      "jsr:@cliffy/ansi@^1.0.0-rc.5": "jsr:@cliffy/ansi@1.0.0-rc.5",
+      "jsr:@cliffy/ansi@^1.0.0-rc.5": "jsr:@cliffy/ansi@1.0.0-rc.7",
       "jsr:@cliffy/ansi@^1.0.0-rc.7": "jsr:@cliffy/ansi@1.0.0-rc.7",
       "jsr:@cliffy/command@^1.0.0-rc.4": "jsr:@cliffy/command@1.0.0-rc.5",
-      "jsr:@cliffy/command@^1.0.0-rc.5": "jsr:@cliffy/command@1.0.0-rc.5",
+      "jsr:@cliffy/command@^1.0.0-rc.5": "jsr:@cliffy/command@1.0.0-rc.7",
       "jsr:@cliffy/command@^1.0.0-rc.7": "jsr:@cliffy/command@1.0.0-rc.7",
       "jsr:@cliffy/flags@1.0.0-rc.4": "jsr:@cliffy/flags@1.0.0-rc.4",
       "jsr:@cliffy/flags@1.0.0-rc.5": "jsr:@cliffy/flags@1.0.0-rc.5",
@@ -49,6 +49,7 @@
       "jsr:@std/io@0.221": "jsr:@std/io@0.221.0",
       "jsr:@std/io@^0.214.0": "jsr:@std/io@0.214.0",
       "jsr:@std/io@^0.221.0": "jsr:@std/io@0.221.0",
+      "jsr:@std/io@~0.224.2": "jsr:@std/io@0.224.9",
       "jsr:@std/json@^0.221.0": "jsr:@std/json@0.221.0",
       "jsr:@std/jsonc@^0.221.0": "jsr:@std/jsonc@0.221.0",
       "jsr:@std/path@0.214.0": "jsr:@std/path@0.214.0",
@@ -101,7 +102,8 @@
         "dependencies": [
           "jsr:@cliffy/internal@1.0.0-rc.5",
           "jsr:@std/encoding@1.0.0-rc.2",
-          "jsr:@std/fmt@~0.225.4"
+          "jsr:@std/fmt@~0.225.4",
+          "jsr:@std/io@~0.224.2"
         ]
       },
       "@cliffy/ansi@1.0.0-rc.7": {
@@ -174,6 +176,7 @@
           "jsr:@cliffy/keycode@1.0.0-rc.5",
           "jsr:@std/assert@1.0.0-rc.2",
           "jsr:@std/fmt@~0.225.4",
+          "jsr:@std/io@~0.224.2",
           "jsr:@std/path@1.0.0-rc.2",
           "jsr:@std/text@1.0.0-rc.1"
         ]
@@ -214,6 +217,7 @@
           "jsr:@std/cli@^0.221.0",
           "jsr:@std/fs@^0.221.0",
           "jsr:@std/semver@^1.0.3",
+          "npm:@octokit/types@^13.4.1",
           "npm:octokit@^3.1.2"
         ]
       },
@@ -327,6 +331,9 @@
           "jsr:@std/assert@^0.221.0",
           "jsr:@std/bytes@^0.221.0"
         ]
+      },
+      "@std/io@0.224.9": {
+        "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3"
       },
       "@std/json@0.221.0": {
         "integrity": "3e63d5fe37c5256b9db345d42c11b57c850aa501bc6464d310e4836b85631b5e"

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -829,22 +829,23 @@ async function processCNDIConfigOutput(
       // the value of the block is parsed
       const parsedVal = YAML.parse(obj.value) as Record<string, unknown>;
 
-      let final: Record<string, unknown> | Array<unknown>;
+      // the ultimate block including the host object, the block object, and the original call removed
+      let resolvedBlock: Record<string, unknown> | Array<unknown>;
 
       if (Array.isArray(parsedVal)) {
-        final = parsedVal; // if the returned block is an array just return it
+        resolvedBlock = parsedVal; // if the returned block is an array just return it
       } else {
         // the returned block is an object
         // merge it with the host object, overwriting any matching keys
         // and preserving the host object's distinct keys
-        final = { ...host, ...parsedVal };
+        resolvedBlock = { ...host, ...parsedVal };
       }
 
-      // then the parsed value is set in the host object
+      // then the resolved block is saved to cndiConfigObj
       setValueForKeyPath(
         cndiConfigObj,
         targetPath, // path to host object
-        final,
+        resolvedBlock,
       );
     } else {
       const numChilden =

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -829,12 +829,16 @@ async function processCNDIConfigOutput(
       // the value of the block is parsed
       const parsedVal = YAML.parse(obj.value) as Record<string, unknown>;
 
-      // then the block is merged with the host object, overwriting any matching keys
-      // preserving the host object's distinct keys
-      const final = {
-        ...host,
-        ...parsedVal,
-      };
+      let final: Record<string, unknown> | Array<unknown>;
+
+      if (Array.isArray(parsedVal)) {
+        final = parsedVal; // if the returned block is an array just return it
+      } else {
+        // the returned block is an object
+        // merge it with the host object, overwriting any matching keys
+        // and preserving the host object's distinct keys
+        final = { ...host, ...parsedVal };
+      }
 
       // then the parsed value is set in the host object
       setValueForKeyPath(

--- a/src/use-template/tests/mock/templates/get_block_with_peer-mock.yaml
+++ b/src/use-template/tests/mock/templates/get_block_with_peer-mock.yaml
@@ -1,0 +1,36 @@
+
+blocks:
+  - name: alpha
+    content:
+      details:
+        example_a: "value_a"
+
+prompts:
+  - name: enable_alpha
+    default: true
+    message: >-
+      Do you want to expose Cloud Functions with an Ingress?
+    type: Confirm
+
+outputs:
+  env:
+    FOO: bar
+  readme:
+    foo: '# header'
+  cndi_config:
+    cndi_version: v2
+    project_name: "{{ $cndi.get_prompt_response(project_name) }}"
+    provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
+    distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
+    applications:
+      myapp:
+        values:
+          some_beta_content:
+            should_exist: true
+          some_charlie_content:
+            should_exist: true
+          $cndi.get_block(alpha):
+            condition:
+              - "{{ $cndi.get_prompt_response(enable_alpha) }}"
+              - ==
+              - true

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -298,7 +298,7 @@ Deno.test(
         enable_alpha: true,
       },
     });
-    console.log("template", JSON.stringify(template));
+
     const config = YAML.parse(template.files["cndi_config.yaml"]) as CNDIConfig;
 
     const values = config?.applications?.myapp?.values as {
@@ -307,7 +307,6 @@ Deno.test(
       "details": { "example_a": string };
     };
 
-    console.log("values", JSON.stringify(values));
     assert(values.some_beta_content?.should_exist);
     assert(values?.some_charlie_content?.should_exist);
     assert(values?.details.example_a === "value_a");

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -283,3 +283,33 @@ Deno.test(
     }
   },
 );
+
+Deno.test(
+  "template execution: $cndi.get_block(identifier) macro should not clobber siblings",
+  mySanity,
+  async () => {
+    const mockYamlFileUri = "file://" + Deno.cwd() +
+      "/src/use-template/tests/mock/templates/get_block_with_peer-mock.yaml";
+    const template = await useTemplate(mockYamlFileUri, {
+      interactive: false,
+      overrides: {
+        project_name: "test",
+        greet_who: "Extra!",
+        enable_alpha: true,
+      },
+    });
+    console.log("template", JSON.stringify(template));
+    const config = YAML.parse(template.files["cndi_config.yaml"]) as CNDIConfig;
+
+    const values = config?.applications?.myapp?.values as {
+      "some_beta_content": { "should_exist": boolean };
+      "some_charlie_content": { "should_exist": boolean };
+      "details": { "example_a": string };
+    };
+
+    console.log("values", JSON.stringify(values));
+    assert(values.some_beta_content?.should_exist);
+    assert(values?.some_charlie_content?.should_exist);
+    assert(values?.details.example_a === "value_a");
+  },
+);


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #1028 

# Description

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

- [x] updated the Template parser to spread existing properties at the time of insertion, with the block taking precedence in the event of a collision

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
