### PR TITLE
`kubeseal` validation before shellout; `cndi ow` will destory any files that aren't regenerated; add tests;

### DIFF
--- a/src/actions/overwrite.worker.ts
+++ b/src/actions/overwrite.worker.ts
@@ -199,14 +199,6 @@ self.onmessage = async (message: OverwriteWorkerMessage) => {
       ".ts",
     );
 
-    // try {
-    //   await Deno.remove(pathToFunctionsOutput, {
-    //     recursive: true,
-    //   });
-    // } catch {
-    //   // folder did not exist
-    // }
-
     if (shouldBuildFunctions) {
       const fnsWorkflowPath = path.join(
         ".github",

--- a/src/outputs/application-manifest.ts
+++ b/src/outputs/application-manifest.ts
@@ -173,6 +173,18 @@ const getApplicationManifest = (
     applicationSpec?.syncPolicy || {},
   );
 
+  const finalSyncOptions: Record<string, string> = {};
+
+  for (const syncOption of syncPolicy.syncOptions) {
+    const [name, status] = syncOption.split("=");
+    finalSyncOptions[name] = status;
+  }
+
+  // syncOptions are deduped and the user-supplied values are preferred
+  syncPolicy.syncOptions = Object.entries(finalSyncOptions).map(([k, v]) =>
+    `${k}=${v}`
+  );
+
   const {
     repoURL,
     path,

--- a/src/tests/helpers/util.ts
+++ b/src/tests/helpers/util.ts
@@ -50,6 +50,21 @@ export async function listAllFilePaths(directory: string): Promise<string[]> {
   return filePaths;
 }
 
+type FilePathsBeforeAndAfter = {
+  before: string[];
+  after: string[];
+};
+
+export async function listFilepathsBeforeAndAfter(
+  operationFn: () => Promise<void>,
+  dir = ".",
+): Promise<FilePathsBeforeAndAfter> {
+  const before = await listAllFilePaths(dir);
+  await operationFn();
+  const after = await listAllFilePaths(dir);
+  return { before, after };
+}
+
 export async function listChangedFilePaths(
   operationFn: () => Promise<void>,
   dir = ".",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -454,10 +454,27 @@ async function getCDKTFAppConfig(): Promise<PxResult<CDKTFAppConfig>> {
   return [undefined, { outdir }];
 }
 
+type PersistStagedFilesOptions = {
+  purge: string[]; // a list of subpaths to purge from the target directory
+};
+
 async function persistStagedFiles(
   targetDirectory: string,
+  opt?: PersistStagedFilesOptions,
 ): Promise<ErrOut | void> {
+  const purge = opt?.purge || [];
+
   const [err, stagingDirectory] = getStagingDirectory();
+
+  for (const relPath of purge) {
+    try {
+      await Deno.remove(path.join(targetDirectory, relPath), {
+        recursive: true,
+      });
+    } catch {
+      // directory doesn't exist
+    }
+  }
 
   if (err) return err;
 

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -671,7 +671,10 @@ function validateClusterManifestsSpec(
     const manifest = entry[1] as Manifest;
 
     if (manifest.kind === "Secret") {
-      const d = manifest.stringData || manifest.data;
+      const d = (manifest?.stringData || manifest?.data) as Record<
+        string,
+        unknown
+      >;
       if (!d) {
         console.log(
           "Secret manifest should have either",
@@ -681,7 +684,8 @@ function validateClusterManifestsSpec(
         );
       } else {
         for (const key in d) {
-          const sealedData = parseCNDISecretDataForSealing(d[key]);
+          const val = `${d[key]}`;
+          const sealedData = parseCNDISecretDataForSealing(val);
           if (!sealedData) {
             return new ErrOut(
               [

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -1,5 +1,11 @@
 import { ccolors } from "deps";
-import { CNDIConfig, CNDIProvider } from "src/types.ts";
+import {
+  CNDIConfig,
+  CNDIDistribution,
+  CNDIInfrastructure,
+  CNDINodeSpec,
+  CNDIProvider,
+} from "src/types.ts";
 import { isSlug } from "src/utils.ts";
 import {
   EFFECT_VALUES,
@@ -10,37 +16,66 @@ import {
 
 import { ErrOut } from "errout";
 
+type CNDIMeta = {
+  distribution: CNDIDistribution;
+  provider: CNDIProvider;
+  project_name: string;
+  cndi_version: string;
+  pathToConfig: string;
+};
+
 const label = ccolors.faded("\nsrc/validate/cndiConfig.ts:");
 
 const PROVIDERS_SUPPORTING_KEYLESS: Array<CNDIProvider> = [];
 
+interface Manifest {
+  kind: string;
+  apiVersion: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    annotations?: Record<string, string>;
+    labels?: Record<string, string>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+// if the user's cndi_config.yaml can be statically analyzed to be critically invalid
+// we must catch it now before consuming resources and writing to the filesystem
+// "critically invalid" means that the current command has no hope of synthesizing the user's desired state
 export default function validateConfig(
   config: CNDIConfig,
   pathToConfig: string,
 ): ErrOut | void {
-  if (config?.cndi_version && config?.cndi_version !== "v2") {
-    console.log();
-
-    // config?.infrastructure?.cndi?.keyless
-    return new ErrOut(
-      [
-        ccolors.error("cndi_config file found was at "),
-        ccolors.user_input(`"${pathToConfig}"`),
-        ccolors.error("but it has an unsupported"),
-        ccolors.key_name('"cndi_version"'),
-        ccolors.error("value. Only"),
-        ccolors.key_name("v2"),
-        ccolors.error("is supported."),
-      ],
-      {
-        code: 914,
-        id: "validate/cndi_config/cndi_version!=v2",
-        metadata: { config },
-        label,
-      },
-    );
+  let cndi_version = config?.cndi_version;
+  // CNDI Version must be undefined or "v2"
+  if (cndi_version) {
+    if (config.cndi_version !== "v2") {
+      console.log();
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("but it has an unsupported"),
+          ccolors.key_name('"cndi_version"'),
+          ccolors.error("value. Only"),
+          ccolors.key_name("v2"),
+          ccolors.error("is supported."),
+        ],
+        {
+          code: 914,
+          id: "validate/cndi_config/cndi_version!=v2",
+          metadata: { config },
+          label,
+        },
+      );
+    }
+  } else {
+    cndi_version = "v2";
   }
 
+  // cndi_config must have a project_name
   if (!config?.project_name) {
     console.log();
     return new ErrOut(
@@ -58,202 +93,28 @@ export default function validateConfig(
         label,
       },
     );
-  } else if (config?.project_name) {
-    if (!isSlug(config?.project_name)) {
-      console.log();
-      return new ErrOut(
-        [
-          ccolors.error("cndi_config file found was at "),
-          ccolors.user_input(`"${pathToConfig}"`),
-          ccolors.error("but the"),
-          ccolors.key_name('"project_name"'),
-          ccolors.error("is not a valid slug"),
-          ccolors.error(
-            "it must only contain lowercase letters, numbers, and hyphens",
-          ),
-        ],
-        {
-          code: 903,
-          id: "validate/cndi_config/!isSlug(project_name)",
-          metadata: { config },
-          label,
-        },
-      );
-    }
-  }
-
-  if (!config?.infrastructure) {
+  } else if (!isSlug(config?.project_name)) {
+    // project_name must be a valid slug
+    // because it is used downstream when provisioning infrastructure
     console.log();
     return new ErrOut(
       [
         ccolors.error("cndi_config file found was at "),
         ccolors.user_input(`"${pathToConfig}"`),
-        ccolors.error("but it does not have the required"),
-        ccolors.key_name('"infrastructure"'),
-        ccolors.error("key"),
+        ccolors.error("but the"),
+        ccolors.key_name('"project_name"'),
+        ccolors.error("is not a valid slug"),
+        ccolors.error(
+          "it must only contain lowercase letters, numbers, and hyphens",
+        ),
       ],
       {
-        code: 901,
-        id: "validate/cndi_config/!infrastructure",
+        code: 903,
+        id: "validate/cndi_config/!isSlug(project_name)",
         metadata: { config },
         label,
       },
     );
-  }
-
-  if (config?.infrastructure?.cndi?.keyless === true) {
-    if (!PROVIDERS_SUPPORTING_KEYLESS.includes(config?.provider)) {
-      return new ErrOut(
-        [
-          ccolors.error("cndi_config file found was at "),
-          ccolors.user_input(`"${pathToConfig}"`),
-          ccolors.error("but it has"),
-          ccolors.key_name('"infrastructure.cndi.keyless"'),
-          ccolors.error("set to"),
-          ccolors.user_input('"true"'),
-          ccolors.error("while"),
-          ccolors.key_name("keyless"),
-          ccolors.error("deployments are not supported in"),
-          ccolors.user_input(config?.provider),
-        ],
-        {
-          code: 921,
-          id: "validate/cndi_config/keyless/!keylessSupported(provider)",
-          metadata: { config },
-          label,
-        },
-      );
-    }
-  }
-
-  const open_ports = config?.infrastructure?.cndi?.open_ports;
-
-  if (open_ports) {
-    if (Array.isArray(open_ports)) {
-      let index = 0;
-      for (const port of open_ports) {
-        if (!port.number) {
-          return new ErrOut(
-            [
-              ccolors.error("cndi_config file found was at "),
-              ccolors.user_input(`"${pathToConfig}"`),
-              ccolors.error(
-                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
-              ),
-              ccolors.key_name('"number"'),
-              ccolors.error("key"),
-            ],
-            {
-              code: 912,
-              id: "validate/cndi_config/!open_ports[n][number]",
-              metadata: { config },
-              label,
-            },
-          );
-        }
-        if (!port.name) {
-          return new ErrOut(
-            [
-              ccolors.error("cndi_config file found was at "),
-              ccolors.user_input(`"${pathToConfig}"`),
-              ccolors.error(
-                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
-              ),
-              ccolors.key_name('"name"'),
-              ccolors.error("key"),
-            ],
-            {
-              code: 913,
-              id: "validate/cndi_config/!open_ports[n][name]",
-              metadata: { config },
-              label,
-            },
-          );
-        }
-        if (!port.service && !!port?.namespace) {
-          return new ErrOut(
-            [
-              ccolors.error("cndi_config file found was at "),
-              ccolors.user_input(`"${pathToConfig}"`),
-              ccolors.error(
-                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
-              ),
-              ccolors.key_name('"service"'),
-              ccolors.error("key"),
-            ],
-            {
-              code: 910,
-              id: "validate/cndi_config/!open_ports[n][service]",
-              metadata: { config },
-              label,
-            },
-          );
-        } else if (!port.namespace && !!port?.service) {
-          return new ErrOut(
-            [
-              ccolors.error("cndi_config file found was at "),
-              ccolors.user_input(`"${pathToConfig}"`),
-              ccolors.error(
-                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
-              ),
-              ccolors.key_name('"namespace"'),
-              ccolors.error("key"),
-            ].join(" "),
-            {
-              code: 909,
-              id: "validate/cndi_config/!open_ports[n][namespace]",
-              metadata: { config },
-              label,
-            },
-          );
-        }
-        index++;
-      }
-    } else {
-      return new ErrOut(
-        [
-          ccolors.error("cndi_config file found was at "),
-          ccolors.user_input(`"${pathToConfig}"`),
-          ccolors.error("but"),
-          ccolors.key_name('"infrastructure.cndi.open_ports"'),
-          ccolors.error("must be an array of objects if set"),
-        ],
-        {
-          code: 908,
-          id: "validate/cndi_config/!isArray(open_ports)",
-          metadata: { config },
-          label,
-        },
-      );
-    }
-  }
-
-  if (config?.infrastructure?.cndi?.cert_manager) {
-    if (config?.infrastructure?.cndi?.cert_manager?.enabled === false) {
-      // cert_manager is disabled explicitly
-    } else if (
-      !config?.infrastructure?.cndi?.cert_manager?.self_signed &&
-      !config?.infrastructure?.cndi?.cert_manager?.email
-    ) {
-      return new ErrOut(
-        [
-          ccolors.error("cndi_config file found was at"),
-          ccolors.user_input(`"${pathToConfig}"`),
-          ccolors.error("\nwith"),
-          ccolors.key_name("infrastructure.cndi.cert_manager"),
-          ccolors.error("present but missing one of the required keys:"),
-          ccolors.key_name("\ninfrastructure.cndi.cert_manager.self_signed"),
-          ccolors.error("or"),
-          ccolors.key_name("infrastructure.cndi.cert_manager.email"),
-        ],
-        {
-          code: 915,
-          id: "validate/cndi_config/cert_manager![email|self_signed]",
-          metadata: { config },
-          label,
-        },
-      );
-    }
   }
 
   if (!config?.provider) {
@@ -274,9 +135,7 @@ export default function validateConfig(
     );
   }
 
-  const isClusterless = config?.distribution === "clusterless";
-
-  if (isClusterless) {
+  if (config?.distribution === "clusterless") {
     if (config?.provider === "dev") {
       return new ErrOut(
         [
@@ -300,6 +159,8 @@ export default function validateConfig(
         },
       );
     }
+
+    // assumes all objects under infrastructure.cndi are not applicable in clusterless mode
     if (config?.infrastructure?.cndi) {
       return new ErrOut(
         [
@@ -318,191 +179,112 @@ export default function validateConfig(
         },
       );
     }
-    // TODO: throw if cluster things are present in clusterless mode
-  } else {
-    if (!config?.distribution) {
+  }
+
+  if (!config?.distribution) {
+    return new ErrOut(
+      [
+        ccolors.error("cndi_config file found was at "),
+        ccolors.user_input(`"${pathToConfig}"`),
+        ccolors.error("but it does not have the required"),
+        ccolors.key_name('"distribution"'),
+        ccolors.error("key"),
+      ],
+      {
+        code: 917,
+        id: "validate/cndi_config/!distribution",
+        metadata: { config },
+        label,
+      },
+    );
+  }
+
+  const distribution = config.distribution as CNDIDistribution;
+  const provider = config.provider as CNDIProvider;
+  const project_name = config.project_name;
+
+  const meta = {
+    distribution,
+    provider,
+    project_name,
+    cndi_version,
+    pathToConfig,
+  };
+
+  const infrastructureE = validateInfrastructureSpec(
+    config.infrastructure,
+    meta,
+  );
+
+  if (infrastructureE) return infrastructureE;
+
+  const cluster_manifestsE = validateClusterManifestsSpec(
+    config.cluster_manifests as Record<string, Manifest>,
+    meta,
+  );
+
+  if (cluster_manifestsE) return cluster_manifestsE;
+}
+
+function validateInfrastructureComponentCndiNodes(
+  nodes: CNDINodeSpec[],
+  meta: CNDIMeta,
+): ErrOut | void {
+  const { pathToConfig, distribution, provider } = meta;
+
+  const nodeNameSet = new Set();
+
+  for (const node of nodes) {
+    if (!node.name) {
       return new ErrOut(
         [
           ccolors.error("cndi_config file found was at "),
           ccolors.user_input(`"${pathToConfig}"`),
-          ccolors.error("but it does not have the required"),
-          ccolors.key_name('"distribution"'),
-          ccolors.error("key"),
+          ccolors.error("but it has at least one"),
+          ccolors.key_name('"infrastructure.cndi.nodes"'),
+          ccolors.error("entry that is missing a"),
+          ccolors.key_name('"name"'),
+          ccolors.error("value. Node names must be specified."),
         ],
         {
-          code: 917,
-          id: "validate/cndi_config/!distribution",
-          metadata: { config },
+          code: 905,
+          id: "validate/cndi_config/infrastructure.cndi.nodes[*]!name",
           label,
         },
       );
     }
 
-    const firstNode = config?.infrastructure?.cndi?.nodes?.[0];
+    nodeNameSet.add(node.name);
 
-    if (!firstNode) {
-      return new ErrOut(
-        [
-          ccolors.error("cndi_config file found was at "),
-          ccolors.user_input(`"${pathToConfig}"`),
-          ccolors.error("but it does not have any"),
-          ccolors.key_name('"infrastructure.cndi.nodes"'),
-          ccolors.error("entries"),
-        ].join(" "),
-        {
-          code: 902,
-          id: "validate/cndi_config/dev/!infrastructure.cndi.nodes.length>1",
-          metadata: { config },
-          label,
-        },
-      );
-    } else if (firstNode.taints?.length) {
-      // throw on AKS
-      if (config?.distribution === "aks") {
+    for (const taint of node.taints || []) {
+      if (!taint?.effect) {
         return new ErrOut(
           [
             ccolors.error("cndi_config file found was at "),
             ccolors.user_input(`"${pathToConfig}"`),
-            ccolors.error(
-              "but taints are not allowed on the first node in aks",
-            ),
+            ccolors.error("\nbut the"),
             ccolors.key_name('"infrastructure.cndi.nodes"'),
-            ccolors.error("entry"),
+            ccolors.error("entry named"),
+            ccolors.user_input(`"${node.name}"`),
+            ccolors.error("has a taint without an"),
+            ccolors.key_name('"effect"'),
+            ccolors.error("value."),
+            ccolors.error("\n\nTaint effects must be:"),
+            ccolors.error(
+              `${ccolors.key_name(NO_SCHEDULE)}, ${
+                ccolors.key_name(PREFER_NO_SCHEDULE)
+              }, or ${ccolors.key_name(NO_EXECUTE)}`,
+            ),
           ],
           {
-            code: 918,
+            code: 920,
             id:
-              "validate/cndi_config/aks/infrastructure.cndi.nodes[0].taints.length",
-            metadata: { config },
+              "validate/cndi_config/infrastructure.cndi.nodes[*].taints[*]!effect",
             label,
           },
         );
-      }
-      // warn on other distributions
-      console.log(
-        label,
-        ccolors.warn(
-          "Warning:",
-        ),
-        ccolors.key_name("taints"),
-        ccolors.warn(
-          "are only supported in the first node group when using",
-        ),
-        ccolors.key_name("distribution"),
-        ccolors.user_input(`gke`),
-        ccolors.warn("or"),
-        ccolors.user_input(`eks`),
-        ccolors.warn("!\n"),
-      );
-    }
-
-    if (
-      config?.provider === "dev"
-    ) {
-      const devNode = firstNode;
-
-      if (devNode?.count && devNode.count !== 1) {
-        return new ErrOut(
-          [
-            ccolors.error("cndi_config file found was at "),
-            ccolors.user_input(`"${pathToConfig}"`),
-            ccolors.error("but it has a dev node with a"),
-            ccolors.key_name("count"),
-            ccolors.error("defined and not equal to"),
-            ccolors.key_name("1"),
-            ccolors.error(
-              "Only one node can be deployed when doing dev deployments.",
-            ),
-          ],
-          {
-            code: 911,
-            id: "validate/cndi_config/dev/count!=1",
-            metadata: { config },
-            label,
-          },
-        );
-      }
-
-      if (devNode?.min_count && devNode.min_count !== 1) {
-        return new ErrOut(
-          [
-            ccolors.error("cndi_config file found was at "),
-            ccolors.user_input(`"${pathToConfig}"`),
-            ccolors.error("but it has a dev node with a"),
-            ccolors.key_name("min_count"),
-            ccolors.error("defined and not equal to"),
-            ccolors.key_name("1"),
-            ccolors.error(
-              "Only one node can be deployed when doing dev deployments.",
-            ),
-          ],
-          {
-            code: 911,
-            id: "validate/cndi_config/dev/min_count!=1",
-            metadata: { config },
-            label,
-          },
-        );
-      }
-
-      if (devNode?.max_count && devNode.max_count !== 1) {
-        return new ErrOut(
-          [
-            ccolors.error("cndi_config file found was at "),
-            ccolors.user_input(`"${pathToConfig}"`),
-            ccolors.error("but it has a dev node with a"),
-            ccolors.key_name("max_count"),
-            ccolors.error("defined and not equal to"),
-            ccolors.key_name("1"),
-            ccolors.error(
-              "Only one node can be deployed when doing dev deployments.",
-            ),
-          ],
-          {
-            code: 911,
-            id: "validate/cndi_config/dev/max_count!=1",
-            metadata: { config },
-            label,
-          },
-        );
-      }
-    }
-
-    if (!config?.cndi_version) {
-      console.log(
-        label,
-        ccolors.warn(`You haven't specified a`),
-        ccolors.key_name(`"cndi_version"`),
-        ccolors.warn(`in your config file, defaulting to "v2"`),
-      );
-    }
-
-    const nodeNameSet = new Set();
-
-    for (const node of config?.infrastructure?.cndi?.nodes) {
-      if (!node.name) {
-        return new ErrOut(
-          [
-            ccolors.error("cndi_config file found was at "),
-            ccolors.user_input(`"${pathToConfig}"`),
-            ccolors.error("but it has at least one"),
-            ccolors.key_name('"infrastructure.cndi.nodes"'),
-            ccolors.error("entry that is missing a"),
-            ccolors.key_name('"name"'),
-            ccolors.error("value. Node names must be specified."),
-          ],
-          {
-            code: 905,
-            id: "validate/cndi_config/infrastructure.cndi.nodes[*]!name",
-            metadata: { config },
-            label,
-          },
-        );
-      }
-      nodeNameSet.add(node.name);
-
-      for (const taint of node.taints || []) {
-        if (!taint?.effect) {
+      } else {
+        if (!EFFECT_VALUES.includes(taint.effect)) {
           return new ErrOut(
             [
               ccolors.error("cndi_config file found was at "),
@@ -510,9 +292,9 @@ export default function validateConfig(
               ccolors.error("\nbut the"),
               ccolors.key_name('"infrastructure.cndi.nodes"'),
               ccolors.error("entry named"),
-              ccolors.user_input(`"${node.name}"`),
-              ccolors.error("has a taint without an"),
-              ccolors.key_name('"effect"'),
+              ccolors.user_input(`${node.name}`),
+              ccolors.error("has a taint with an invalid"),
+              ccolors.key_name("effect"),
               ccolors.error("value."),
               ccolors.error("\n\nTaint effects must be:"),
               ccolors.error(
@@ -520,71 +302,412 @@ export default function validateConfig(
                   ccolors.key_name(PREFER_NO_SCHEDULE)
                 }, or ${ccolors.key_name(NO_EXECUTE)}`,
               ),
+              ccolors.error("\nYou supplied:"),
+              ccolors.user_input(`"${taint.effect}"`),
             ],
             {
               code: 920,
-              id:
-                "validate/cndi_config/infrastructure.cndi.nodes[*].taints[*]!effect",
-              metadata: { config },
+              id: "validate/cndi_config/!EFFECT_VALUES",
               label,
             },
           );
-        } else {
-          if (!EFFECT_VALUES.includes(taint.effect)) {
+        }
+      }
+    }
+  }
+
+  const nodeNamesAreUnique = nodeNameSet.size === nodes?.length;
+
+  if (!nodeNamesAreUnique) {
+    return new ErrOut(
+      [
+        ccolors.error("cndi_config file found was at "),
+        ccolors.user_input(`"${pathToConfig}"`),
+        ccolors.error("but it has multiple "),
+        ccolors.key_name('"infrastructure.cndi.nodes"'),
+        ccolors.error("entries with the same"),
+        ccolors.key_name('"name"'),
+        ccolors.error("values. Node names must be unique."),
+      ],
+      {
+        code: 906,
+        id:
+          "validate/cndi_config/infrastructure.cndi.nodes.every(unique(name))",
+        label,
+      },
+    );
+  }
+
+  const firstNode = nodes?.[0];
+
+  if (!firstNode) {
+    return new ErrOut(
+      [
+        ccolors.error("cndi_config file found was at "),
+        ccolors.user_input(`"${pathToConfig}"`),
+        ccolors.error("but it does not have any"),
+        ccolors.key_name('"infrastructure.cndi.nodes"'),
+        ccolors.error("entries"),
+      ].join(" "),
+      {
+        code: 902,
+        id: "validate/cndi_config/dev/!infrastructure.cndi.nodes.length>1",
+        label,
+      },
+    );
+  } else if (firstNode.taints?.length) {
+    // throw on AKS
+    if (distribution === "aks") {
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error(
+            "but taints are not allowed on the first node in aks",
+          ),
+          ccolors.key_name('"infrastructure.cndi.nodes"'),
+          ccolors.error("entry"),
+        ],
+        {
+          code: 918,
+          id:
+            "validate/cndi_config/aks/infrastructure.cndi.nodes[0].taints.length",
+          label,
+        },
+      );
+    }
+    // warn on other distributions
+    console.log(
+      label,
+      ccolors.warn(
+        "Warning:",
+      ),
+      ccolors.key_name("taints"),
+      ccolors.warn(
+        "are only supported in the first node group when using",
+      ),
+      ccolors.key_name("distribution"),
+      ccolors.user_input(`gke`),
+      ccolors.warn("or"),
+      ccolors.user_input(`eks`),
+      ccolors.warn("!\n"),
+    );
+  }
+
+  if (
+    provider === "dev"
+  ) {
+    const devNode = firstNode;
+
+    if (devNode?.count && devNode.count !== 1) {
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("but it has a dev node with a"),
+          ccolors.key_name("count"),
+          ccolors.error("defined and not equal to"),
+          ccolors.key_name("1"),
+          ccolors.error(
+            "Only one node can be deployed when doing dev deployments.",
+          ),
+        ],
+        {
+          code: 911,
+          id: "validate/cndi_config/dev/count!=1",
+          label,
+        },
+      );
+    }
+
+    if (devNode?.min_count && devNode.min_count !== 1) {
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("but it has a dev node with a"),
+          ccolors.key_name("min_count"),
+          ccolors.error("defined and not equal to"),
+          ccolors.key_name("1"),
+          ccolors.error(
+            "Only one node can be deployed when doing dev deployments.",
+          ),
+        ],
+        {
+          code: 911,
+          id: "validate/cndi_config/dev/min_count!=1",
+          label,
+        },
+      );
+    }
+
+    if (devNode?.max_count && devNode.max_count !== 1) {
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("but it has a dev node with a"),
+          ccolors.key_name("max_count"),
+          ccolors.error("defined and not equal to"),
+          ccolors.key_name("1"),
+          ccolors.error(
+            "Only one node can be deployed when doing dev deployments.",
+          ),
+        ],
+        {
+          code: 911,
+          id: "validate/cndi_config/dev/max_count!=1",
+          label,
+        },
+      );
+    }
+  }
+}
+
+function validateInfrastructureSpec(
+  infrastructure: CNDIInfrastructure,
+  meta: CNDIMeta,
+): ErrOut | void {
+  const { pathToConfig, provider } = meta;
+
+  if (!infrastructure) {
+    console.log();
+    return new ErrOut(
+      [
+        ccolors.error("cndi_config file found was at "),
+        ccolors.user_input(`"${pathToConfig}"`),
+        ccolors.error("but it does not have the required"),
+        ccolors.key_name('"infrastructure"'),
+        ccolors.error("key"),
+      ],
+      {
+        code: 901,
+        id: "validate/cndi_config/!infrastructure",
+        label,
+      },
+    );
+  }
+
+  if (infrastructure?.cndi?.keyless === true) {
+    if (!PROVIDERS_SUPPORTING_KEYLESS.includes(provider)) {
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("but it has"),
+          ccolors.key_name('"infrastructure.cndi.keyless"'),
+          ccolors.error("set to"),
+          ccolors.user_input('"true"'),
+          ccolors.error("while"),
+          ccolors.key_name("keyless"),
+          ccolors.error("deployments are not supported in"),
+          ccolors.user_input(provider),
+        ],
+        {
+          code: 921,
+          id: "validate/cndi_config/keyless/!keylessSupported(provider)",
+          label,
+        },
+      );
+    }
+  }
+
+  const open_ports = infrastructure?.cndi?.open_ports;
+
+  if (open_ports) {
+    if (Array.isArray(open_ports)) {
+      let index = 0;
+      for (const port of open_ports) {
+        if (!port.number) {
+          return new ErrOut(
+            [
+              ccolors.error("cndi_config file found was at "),
+              ccolors.user_input(`"${pathToConfig}"`),
+              ccolors.error(
+                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
+              ),
+              ccolors.key_name('"number"'),
+              ccolors.error("key"),
+            ],
+            {
+              code: 912,
+              id: "validate/cndi_config/!open_ports[n][number]",
+              label,
+            },
+          );
+        }
+
+        if (!port.name) {
+          return new ErrOut(
+            [
+              ccolors.error("cndi_config file found was at "),
+              ccolors.user_input(`"${pathToConfig}"`),
+              ccolors.error(
+                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
+              ),
+              ccolors.key_name('"name"'),
+              ccolors.error("key"),
+            ],
+            {
+              code: 913,
+              id: "validate/cndi_config/!open_ports[n][name]",
+              label,
+            },
+          );
+        }
+        if (!port.service && !!port?.namespace) {
+          return new ErrOut(
+            [
+              ccolors.error("cndi_config file found was at "),
+              ccolors.user_input(`"${pathToConfig}"`),
+              ccolors.error(
+                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
+              ),
+              ccolors.key_name('"service"'),
+              ccolors.error("key"),
+            ],
+            {
+              code: 910,
+              id: "validate/cndi_config/!open_ports[n][service]",
+              label,
+            },
+          );
+        } else if (!port.namespace && !!port?.service) {
+          return new ErrOut(
+            [
+              ccolors.error("cndi_config file found was at "),
+              ccolors.user_input(`"${pathToConfig}"`),
+              ccolors.error(
+                `but 'cndi_config.infrastructure.cndi.open_ports[${index}]' is missing the`,
+              ),
+              ccolors.key_name('"namespace"'),
+              ccolors.error("key"),
+            ].join(" "),
+            {
+              code: 909,
+              id: "validate/cndi_config/!open_ports[n][namespace]",
+              label,
+            },
+          );
+        }
+        index++;
+      }
+    } else {
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at "),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("but"),
+          ccolors.key_name('"infrastructure.cndi.open_ports"'),
+          ccolors.error("must be an array of objects if set"),
+        ],
+        {
+          code: 908,
+          id: "validate/cndi_config/!isArray(open_ports)",
+          label,
+        },
+      );
+    }
+  }
+
+  if (infrastructure?.cndi?.cert_manager) {
+    if (infrastructure?.cndi?.cert_manager?.enabled === false) {
+      // cert_manager is disabled explicitly
+    } else if (
+      !infrastructure?.cndi?.cert_manager?.self_signed &&
+      !infrastructure?.cndi?.cert_manager?.email
+    ) {
+      return new ErrOut(
+        [
+          ccolors.error("cndi_config file found was at"),
+          ccolors.user_input(`"${pathToConfig}"`),
+          ccolors.error("\nwith"),
+          ccolors.key_name("infrastructure.cndi.cert_manager"),
+          ccolors.error("present but missing one of the required keys:"),
+          ccolors.key_name("\ninfrastructure.cndi.cert_manager.self_signed"),
+          ccolors.error("or"),
+          ccolors.key_name("infrastructure.cndi.cert_manager.email"),
+        ],
+        {
+          code: 915,
+          id: "validate/cndi_config/cert_manager![email|self_signed]",
+          label,
+        },
+      );
+    }
+  }
+  const errout = validateInfrastructureComponentCndiNodes(
+    infrastructure.cndi.nodes,
+    meta,
+  );
+  if (errout) return errout;
+}
+
+const CNDI_SECRET_MANIFEST_DATA_PREFIX =
+  "$cndi_on_ow.seal_secret_from_env_var(";
+const CNDI_SECRET_MANIFEST_DATA_SUFFIX = ")";
+
+function parseCNDISecretDataForSealing(key: string): string | null {
+  if (
+    key.startsWith(CNDI_SECRET_MANIFEST_DATA_PREFIX) &&
+    key.endsWith(CNDI_SECRET_MANIFEST_DATA_SUFFIX)
+  ) {
+    return key.slice(
+      CNDI_SECRET_MANIFEST_DATA_PREFIX.length,
+      key.length - CNDI_SECRET_MANIFEST_DATA_SUFFIX.length,
+    );
+  }
+  return null;
+}
+
+function validateClusterManifestsSpec(
+  cluster_manifests: Record<string, Manifest>,
+  meta: CNDIMeta,
+): ErrOut | void {
+  const { pathToConfig } = meta;
+
+  for (const entry of Object.entries(cluster_manifests)) {
+    const filename = entry[0];
+    const manifest = entry[1] as Manifest;
+
+    if (manifest.kind === "Secret") {
+      const d = manifest.stringData || manifest.data;
+      if (!d) {
+        console.log(
+          "Secret manifest should have either",
+          ccolors.key_name("stringData"),
+          "or",
+          ccolors.key_name("data"),
+        );
+      } else {
+        for (const key in d) {
+          const sealedData = parseCNDISecretDataForSealing(d[key]);
+          if (!sealedData) {
             return new ErrOut(
               [
-                ccolors.error("cndi_config file found was at "),
-                ccolors.user_input(`"${pathToConfig}"`),
-                ccolors.error("\nbut the"),
-                ccolors.key_name('"infrastructure.cndi.nodes"'),
-                ccolors.error("entry named"),
-                ccolors.user_input(`${node.name}`),
-                ccolors.error("has a taint with an invalid"),
-                ccolors.key_name("effect"),
-                ccolors.error("value."),
-                ccolors.error("\n\nTaint effects must be:"),
-                ccolors.error(
-                  `${ccolors.key_name(NO_SCHEDULE)}, ${
-                    ccolors.key_name(PREFER_NO_SCHEDULE)
-                  }, or ${ccolors.key_name(NO_EXECUTE)}`,
+                ccolors.error("cndi_config file found was at"),
+                ccolors.user_input(`"${pathToConfig}"\n`),
+                ccolors.error("with a"),
+                ccolors.key_name(`Secret`),
+                ccolors.error("at"),
+                ccolors.key_name(`cluster_manifests.${filename}\n`),
+                ccolors.error("which specifies a string literal value for"),
+                ccolors.key_name(`"${key}"\n\n`),
+                ccolors.warn("You should use the"),
+                ccolors.user_input(
+                  "$cndi_on_ow.seal_secret_from_env_var(MY_ENV_VAR)",
                 ),
-                ccolors.error("\nYou supplied:"),
-                ccolors.user_input(`"${taint.effect}"`),
+                ccolors.warn("macro instead"),
               ],
               {
-                code: 920,
-                id: "validate/cndi_config/!EFFECT_VALUES",
-                metadata: { config },
+                code: 700,
+                id: "validate/cndi_config/cert_manager![email|self_signed]",
                 label,
               },
             );
           }
         }
       }
-    }
-
-    const nodeNamesAreUnique =
-      nodeNameSet.size === config?.infrastructure?.cndi?.nodes?.length;
-
-    if (!nodeNamesAreUnique) {
-      return new ErrOut(
-        [
-          ccolors.error("cndi_config file found was at "),
-          ccolors.user_input(`"${pathToConfig}"`),
-          ccolors.error("but it has multiple "),
-          ccolors.key_name('"infrastructure.cndi.nodes"'),
-          ccolors.error("entries with the same"),
-          ccolors.key_name('"name"'),
-          ccolors.error("values. Node names must be unique."),
-        ],
-        {
-          code: 906,
-          id:
-            "validate/cndi_config/infrastructure.cndi.nodes.every(unique(name))",
-          metadata: { config },
-          label,
-        },
-      );
     }
   }
 }


### PR DESCRIPTION
# Description

- [x] fixed issue where old `cndi/` objects are not pruned when absent from input
- [x] added check to `cndi_config` validation to check for Secret literals
- [x] ensured that `AppSpec.syncPolicy.syncOptions` is deduped and prefers user-specified info
- [x] added test for sealing secrets with literals
- [x] added check for sealing secrets with env secret present
- [x] added check for sealing secrets with env secret absent resulting in placeholders  

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
