### PR TITLE
Fix template comments

### DIFF
--- a/src/tests/commands/ow.test.ts
+++ b/src/tests/commands/ow.test.ts
@@ -109,7 +109,7 @@ Deno.test(`'cndi ow' should successfully convert secrets if correctly defined`, 
         `${dir}/cndi_config.yaml`,
         YAML.stringify(config),
       );
-      await runCndi("ow", "--loud");
+      await runCndi("ow");
     });
 
     const beforeSet = new Set(before);

--- a/src/tests/mocks/templates/basic.yaml
+++ b/src/tests/mocks/templates/basic.yaml
@@ -24,12 +24,11 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
     project_name: "{{ $cndi.get_prompt_response(project_name) }}"
     provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
-    # this is a Template comment
+
     infrastructure:
       cndi:
         cert_manager:

--- a/src/tests/mocks/templates/prompts_get_block_array.yaml
+++ b/src/tests/mocks/templates/prompts_get_block_array.yaml
@@ -4,8 +4,8 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
-  readme: "# hello world"
+  readme:
+    heading: "# hello world"
   env:
     FOO: bar

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -762,9 +762,7 @@ function processCNDICommentCalls(input: string): string {
 
   // Replace the matched lines with '# ' followed by the captured text after the colon
   const replaced = input.replace(pattern, "# $2");
-
-  console.log("input", input);
-  console.log("replaced", replaced);
+  
   return replaced;
 }
 

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -762,7 +762,7 @@ function processCNDICommentCalls(input: string): string {
 
   // Replace the matched lines with '# ' followed by the captured text after the colon
   const replaced = input.replace(pattern, "# $2");
-  
+
   return replaced;
 }
 

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -763,6 +763,8 @@ function processCNDICommentCalls(input: string): string {
   // Replace the matched lines with '# ' followed by the captured text after the colon
   const replaced = input.replace(pattern, "# $2");
 
+  console.log("input", input);
+  console.log("replaced", replaced);
   return replaced;
 }
 
@@ -961,8 +963,11 @@ async function processCNDIConfigOutput(
 
   // get_prompt_response evals (again)
   output = literalizeGetPromptResponseCalls(output);
-  output = processCNDICommentCalls(output);
+
   output = fixUndefinedDistributionIfRequired(output);
+
+  // comment evals last so they don't get removed in YAML.parse by other steps
+  output = processCNDICommentCalls(output);
 
   return [undefined, output];
 }

--- a/src/use-template/tests/mock/templates/comment-mock.yaml
+++ b/src/use-template/tests/mock/templates/comment-mock.yaml
@@ -1,0 +1,34 @@
+prompts:
+  - name: greet_who
+    default: World
+    message: >-
+      Who do you want to greet?
+    type: Input
+
+outputs:
+  cndi_config:
+    cndi_version: v2
+    project_name: "{{ $cndi.get_prompt_response(project_name) }}"
+    provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
+    distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
+    infrastructure:
+      cndi:
+        nodes:
+          - name: my-node
+
+    cluster_manifests:
+      arbitrary-resource:
+        apiVersion: example.com/v1
+        kind: SomeResource
+        metadata:
+          name: my-thing
+          namespace: my-namespace
+          annotations:
+            $cndi.comment(why_propagation_policy): This is a comment
+            argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,PrunePropagationPolicy=background
+
+  env:
+    HELLO: "{{ $cndi.get_prompt_response(greet_who) }}"
+
+  readme:
+    project_name: "# {{ $cndi.get_prompt_response(project_name) }}"

--- a/src/use-template/tests/mock/templates/comment-mock.yaml
+++ b/src/use-template/tests/mock/templates/comment-mock.yaml
@@ -1,3 +1,15 @@
+blocks:
+  - name: block_with_comment
+    content:
+      apiVersion: example.com/v1
+      kind: SomeResource
+      metadata:
+        name: my-thing
+        namespace: my-namespace
+        annotations:
+          argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,PrunePropagationPolicy=background
+          $cndi.comment(why_propagation_policy): This is a comment
+
 prompts:
   - name: greet_who
     default: World
@@ -17,15 +29,7 @@ outputs:
           - name: my-node
 
     cluster_manifests:
-      arbitrary-resource:
-        apiVersion: example.com/v1
-        kind: SomeResource
-        metadata:
-          name: my-thing
-          namespace: my-namespace
-          annotations:
-            $cndi.comment(why_propagation_policy): This is a comment
-            argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,PrunePropagationPolicy=background
+      $cndi.get_block(block_with_comment): {}
 
   env:
     HELLO: "{{ $cndi.get_prompt_response(greet_who) }}"

--- a/src/use-template/tests/mock/templates/extra_files-mock.yaml
+++ b/src/use-template/tests/mock/templates/extra_files-mock.yaml
@@ -7,12 +7,10 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
     project_name: "{{ $cndi.get_prompt_response(project_name) }}"
     provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
-    # this is a Template comment
     infrastructure:
       cndi:
         nodes:

--- a/src/use-template/tests/mock/templates/extra_files_invalid-mock.yaml
+++ b/src/use-template/tests/mock/templates/extra_files_invalid-mock.yaml
@@ -7,12 +7,10 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
     project_name: "{{ $cndi.get_prompt_response(project_name) }}"
     provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
-    # this is a Template comment
     infrastructure:
       cndi:
         nodes:

--- a/src/use-template/tests/mock/templates/get_block-mock.yaml
+++ b/src/use-template/tests/mock/templates/get_block-mock.yaml
@@ -3,6 +3,13 @@ blocks:
     content:
       hostname: "{{ $cndi.get_prompt_response(fns_hostname) }}"
 
+  - name: unconditional_block
+    content:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: my-thing
+
 prompts:
   - name: enable_fns_ingress
     default: true
@@ -46,3 +53,5 @@ outputs:
               - "{{ $cndi.get_prompt_response(enable_fns_ingress) }}"
               - ==
               - true
+    cluster_manifests:
+      $cndi.get_block(unconditional_block): true

--- a/src/use-template/tests/mock/templates/get_block-mock.yaml
+++ b/src/use-template/tests/mock/templates/get_block-mock.yaml
@@ -54,4 +54,4 @@ outputs:
               - ==
               - true
     cluster_manifests:
-      $cndi.get_block(unconditional_block): true
+      $cndi.get_block(unconditional_block): {}

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -250,7 +250,7 @@ Deno.test(
 );
 
 Deno.test(
-  "template execution: a template should be able to insert a block using $cndi.get_block(block_name)",
+  "template execution: a template should be able to insert a blocks using $cndi.get_block(block_name)",
   mySanity,
   async () => {
     const fns_hostname = "fns.example.com";
@@ -271,6 +271,7 @@ Deno.test(
     const template = templateResult[1] as UseTemplateResult;
     const config = YAML.parse(template.files["cndi_config.yaml"]) as CNDIConfig;
     assert(config?.infrastructure?.cndi?.functions?.hostname === fns_hostname);
+    assert(config?.cluster_manifests?.kind === "Namespace");
   },
 );
 

--- a/src/use-template/tests/template-execution.test.ts
+++ b/src/use-template/tests/template-execution.test.ts
@@ -2,6 +2,7 @@ import { path, YAML } from "deps";
 import { useTemplate, UseTemplateResult } from "../mod.ts";
 import { assert, parseDotEnv } from "test-deps";
 import { CNDIConfig } from "src/types.ts";
+import getProjectRoot from "get-project-root";
 
 const mySanity = { sanitizeResources: false, sanitizeOps: false };
 
@@ -36,6 +37,26 @@ Deno.test(
     const template = templateResult[1] as UseTemplateResult;
     assert(!!template);
     assert(!template.files["README.md"].includes("airflow"));
+  },
+);
+
+Deno.test(
+  "template execution: '$cndi.comment' calls should be processed in cndi_config.yaml",
+  mySanity,
+  async () => {
+    const [_, template] = await useTemplate(
+      `${getProjectRoot()}/src/use-template/tests/mock/templates/comment-mock.yaml`,
+      {
+        interactive: false,
+        overrides: {
+          deployment_target_provider: "aws",
+        },
+      },
+    );
+    const configStr = template?.files["cndi_config.yaml"];
+    assert(!!configStr);
+    assert(!configStr.includes("$cndi.comment"));
+    assert(configStr.includes("# This is a comment"));
   },
 );
 

--- a/templates/basic.yaml
+++ b/templates/basic.yaml
@@ -24,12 +24,10 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
     project_name: "{{ $cndi.get_prompt_response(project_name) }}"
     provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
-    # this is a Template comment
     infrastructure:
       cndi:
         cert_manager:

--- a/templates/gpu-operator.yaml
+++ b/templates/gpu-operator.yaml
@@ -56,12 +56,10 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
     project_name: "{{ $cndi.get_prompt_response(project_name) }}"
     provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
-    # this is a Template comment
     infrastructure:
       cndi:
         cert_manager:

--- a/templates/kafka.yaml
+++ b/templates/kafka.yaml
@@ -213,12 +213,10 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
     project_name: "{{ $cndi.get_prompt_response(project_name) }}"
     provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
-    # this is a Template comment
     infrastructure:
       cndi:
         cert_manager:

--- a/templates/proxy.yaml
+++ b/templates/proxy.yaml
@@ -53,12 +53,10 @@ prompts:
 
 outputs:
   cndi_config:
-    # source_control_platform: github ?
     cndi_version: v2
     project_name: "{{ $cndi.get_prompt_response(project_name) }}"
     provider: "{{ $cndi.get_prompt_response(deployment_target_provider) }}"
     distribution: "{{ $cndi.get_prompt_response(deployment_target_distribution) }}"
-    # this is a Template comment
     infrastructure:
       cndi:
         cert_manager:


### PR DESCRIPTION

# Description

- [x] fix comments by inserting them last so they don't get stripped by other operations that call YAML.parse
- [x] ensure blocks are inserted in the case where they look like `$cndi.get_block(foo): {}` with the "body" of the macro call on the same line (eg. `{}`)
- [x] add test to validate comments are inserted
- [x] add test to validate blocks are still inserted in the "one-line" style call

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
