### PR TITLE
[Enhancement]: make `AL2023_x86_64_NVIDIA` default `amiType`

### DIFF
--- a/src/outputs/terraform/aws/AWSEKSStack.ts
+++ b/src/outputs/terraform/aws/AWSEKSStack.ts
@@ -588,7 +588,7 @@ export default class AWSEKSTerraformStack extends AWSCoreTerraformStack {
           clusterName: eksm.clusterNameOutput,
           // deno-lint-ignore no-explicit-any
           subnetIds: privateSubnetIds! as any,
-          amiType: "AL2_x86_64",
+          amiType: "AL2023_x86_64_NVIDIA",
           instanceTypes: [instanceType],
           nodeGroupName,
           nodeRoleArn: eksNodeGroupRole.arn,


### PR DESCRIPTION
# Description

- [x] made `AL2023_x86_64_NVIDIA` the default amiType so GPU acceleration works by default

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
