### PR TITLE
[Build]: do not emit telemetry during build workflow

### DIFF
--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -10,6 +10,8 @@ env: # this is a Read-Only token for Public Repositories see: https://github.com
 jobs:
   bin-build-test-ubuntu:
     runs-on: ubuntu-latest
+    env:
+      CNDI_TELEMETRY: "none"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Deno

--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -7,11 +7,10 @@ on:
       - "main"
 env: # this is a Read-Only token for Public Repositories see: https://github.com/polyseam/cndi/pull/863
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  CNDI_TELEMETRY: "none"
 jobs:
   bin-build-test-ubuntu:
     runs-on: ubuntu-latest
-    env:
-      CNDI_TELEMETRY: "none"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Deno


### PR DESCRIPTION
issue #1074 

# Description

- [x] disabled telemetry during `bin-build` workflows

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
