### PR TITLE
[Bug]: missing error message for failure to seal Secret.data as base64

### DIFF
--- a/docs/error-code-reference.json
+++ b/docs/error-code-reference.json
@@ -205,6 +205,11 @@
     "discussion_link": "https://github.com/orgs/polyseam/discussions/"
   },
   {
+    "code": 706,
+    "message": "Secret.data was loaded from env and is not a base64 encoded string",
+    "discussion_link": "https://github.com/orgs/polyseam/discussions/1083"
+  },
+  {
     "code": 800,
     "message": "failed to stage all aws terraform objects during 'cndi overwrite'",
     "discussion_link": "https://github.com/orgs/polyseam/discussions/551"


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #1083 

# Description

- [x] added improved error message for when user supplies `Secret` manifest with `.data` but the value to seal is not a parseable base64 encoded string

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
