### PR TITLE
[Bug]: `loki-chunks-cache` too memory intensive; 8gb -> 1gb

### DIFF
--- a/src/outputs/core-applications/loki.application.yaml.ts
+++ b/src/outputs/core-applications/loki.application.yaml.ts
@@ -15,6 +15,9 @@ export default function getKubeLokiApplicationManifest(
   const releaseName = "loki";
 
   const defaultLokiValues = {
+    chunksCache: {
+      allocatedMemory: 1024,
+    },
     loki: {
       auth_enabled: false,
       commonConfig: {


### PR DESCRIPTION
# Description

- [x] fix issue where `loki-chunks-cache` was too demanding on memory by reducing the memory allocated from 8gb to 1gb

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
