### PR TITLE
[Bug]: `cndi ow` could prevent user from overriding provider in ext-dns values

### DIFF
--- a/src/actions/overwrite.worker.ts
+++ b/src/actions/overwrite.worker.ts
@@ -442,7 +442,7 @@ self.onmessage = async (message: OverwriteWorkerMessage) => {
             "applications",
             "cert-manager.application.yaml",
           ),
-          getCertManagerApplicationManifest(),
+          getCertManagerApplicationManifest(config),
         );
         if (errStagingCertManApplication) {
           await self.postMessage(
@@ -499,7 +499,7 @@ self.onmessage = async (message: OverwriteWorkerMessage) => {
             "applications",
             "reloader.application.yaml",
           ),
-          getReloaderApplicationManifest(),
+          getReloaderApplicationManifest(config),
         );
         if (errStagingReloaderApp) {
           await self.postMessage(errStagingReloaderApp.owWorkerErrorMessage);

--- a/src/outputs/core-applications/cert-manager.application.yaml.ts
+++ b/src/outputs/core-applications/cert-manager.application.yaml.ts
@@ -1,5 +1,6 @@
 import { getYAMLString } from "src/utils.ts";
 import { CERT_MANAGER_CHART_VERSION } from "consts";
+import { CNDIConfig } from "src/types.ts";
 
 const DEFAULT_DESTINATION_SERVER = "https://kubernetes.default.svc";
 const DEFAULT_ARGOCD_API_VERSION = "argoproj.io/v1alpha1";
@@ -7,8 +8,12 @@ const DEFAULT_HELM_VERSION = "v3";
 const DEFAULT_PROJECT = "default";
 const DEFAULT_FINALIZERS = ["resources-finalizer.argocd.argoproj.io"];
 
-export default function getCertManagerApplicationManifest(): string {
+export default function getCertManagerApplicationManifest(
+  cndi_config: CNDIConfig,
+): string {
   const releaseName = "cert-manager";
+  const userValues = cndi_config?.infrastructure?.cndi?.cert_manager?.values ||
+    {};
 
   const manifest = {
     apiVersion: DEFAULT_ARGOCD_API_VERSION,
@@ -23,9 +28,9 @@ export default function getCertManagerApplicationManifest(): string {
       source: {
         repoURL: "https://charts.jetstack.io",
         chart: "cert-manager",
-        helm: { // installCRDs?
+        helm: {
           version: DEFAULT_HELM_VERSION,
-          values: getYAMLString({ installCRDs: true }),
+          values: getYAMLString({ installCRDs: true, ...userValues }),
         },
         targetRevision: CERT_MANAGER_CHART_VERSION,
       },

--- a/src/outputs/core-applications/external-dns.application.yaml.ts
+++ b/src/outputs/core-applications/external-dns.application.yaml.ts
@@ -2,6 +2,7 @@ import { getYAMLString } from "src/utils.ts";
 import { CNDIConfig } from "src/types.ts";
 import type { CNDIProvider, ExternalDNSProvider } from "src/types.ts";
 import { EXTERNAL_DNS_CHART_VERSION } from "consts";
+import { deepMerge } from "deps";
 
 const DEFAULT_DESTINATION_SERVER = "https://kubernetes.default.svc";
 const DEFAULT_ARGOCD_API_VERSION = "argoproj.io/v1alpha1";
@@ -39,14 +40,10 @@ export default function getExternalDNSApplicationManifest(
     "oci",
   ];
 
-  type ExternalDNSValues = {
-    provider: ExternalDNSProvider;
-    domainFilters: Array<string>;
-    [key: string]: unknown;
-    extraEnvVarsSecret?: string;
-  };
+  const userValues = cndi_config?.infrastructure?.cndi?.external_dns?.values ||
+    {};
 
-  const values: ExternalDNSValues = {
+  const values = deepMerge({
     txtOwnerId: cndi_config?.project_name || "external-dns",
     txtSuffix: "txt",
     policy: "sync",
@@ -54,8 +51,7 @@ export default function getExternalDNSApplicationManifest(
     provider: externalDNSProvider,
     domainFilters: domain_filters,
     excludeDomains: EXCLUDED_FROM_EXTERNAL_DNS,
-    ...cndi_config?.infrastructure?.cndi?.external_dns?.values || {},
-  };
+  }, userValues);
 
   if (externalDNSCannotUseEnvVars.includes(externalDNSProvider)) {
     // this dns provider uses another method for authentication, probably volume mounts

--- a/src/outputs/core-applications/external-dns.application.yaml.ts
+++ b/src/outputs/core-applications/external-dns.application.yaml.ts
@@ -51,10 +51,10 @@ export default function getExternalDNSApplicationManifest(
     txtSuffix: "txt",
     policy: "sync",
     interval: "30s",
-    ...cndi_config?.infrastructure?.cndi?.external_dns?.values || {},
     provider: externalDNSProvider,
     domainFilters: domain_filters,
     excludeDomains: EXCLUDED_FROM_EXTERNAL_DNS,
+    ...cndi_config?.infrastructure?.cndi?.external_dns?.values || {},
   };
 
   if (externalDNSCannotUseEnvVars.includes(externalDNSProvider)) {

--- a/src/outputs/core-applications/reloader.application.yaml.ts
+++ b/src/outputs/core-applications/reloader.application.yaml.ts
@@ -1,5 +1,6 @@
 import { getYAMLString } from "src/utils.ts";
 import { RELOADER_CHART_VERSION } from "consts";
+import { CNDIConfig } from "src/types.ts";
 
 const DEFAULT_DESTINATION_SERVER = "https://kubernetes.default.svc";
 const DEFAULT_ARGOCD_API_VERSION = "argoproj.io/v1alpha1";
@@ -7,8 +8,11 @@ const DEFAULT_HELM_VERSION = "v3";
 const DEFAULT_PROJECT = "default";
 const DEFAULT_FINALIZERS = ["resources-finalizer.argocd.argoproj.io"];
 
-export default function getReloaderApplicationManifest(): string {
+export default function getReloaderApplicationManifest(
+  cndi_config: CNDIConfig,
+): string {
   const releaseName = "reloader";
+  const values = cndi_config?.infrastructure?.cndi?.reloader?.values || {};
 
   const manifest = {
     apiVersion: DEFAULT_ARGOCD_API_VERSION,
@@ -23,9 +27,9 @@ export default function getReloaderApplicationManifest(): string {
       source: {
         repoURL: "https://stakater.github.io/stakater-charts",
         chart: "reloader",
-        helm: { // installCRDs?
+        helm: {
           version: DEFAULT_HELM_VERSION,
-          values: getYAMLString({}),
+          values: getYAMLString(values),
         },
         targetRevision: RELOADER_CHART_VERSION,
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -322,11 +322,11 @@ export type CNDIInfrastructure = {
       nginx: {
         public: {
           enabled?: boolean; // default: true
-          values: Record<string, unknown>;
+          values?: Record<string, unknown>;
         };
         private: {
           enabled?: boolean; // default: false
-          values: Record<string, unknown>;
+          values?: Record<string, unknown>;
         };
       };
     };
@@ -334,15 +334,17 @@ export type CNDIInfrastructure = {
       enabled?: boolean; // default: true
       provider: ExternalDNSProvider;
       domain_filters: Array<string>;
-      values: Record<string, unknown>;
+      values?: Record<string, unknown>;
     };
     reloader: {
       enabled?: boolean; // default: true
+      values?: Record<string, unknown>;
     };
     cert_manager?: {
       enabled?: boolean; // default: true
       email: string;
       self_signed?: boolean;
+      values?: Record<string, unknown>;
     };
     nodes: Array<CNDINodeSpec>;
     microk8s: {


### PR DESCRIPTION
# Description

- [x] ensure that a user's `infrastructure.cndi.external_dns.values` object is prioritized over system values
- [x] allow the user to pass in values to cert_manager in cndi_config
- [x] allow the user to pass in values to reloader in cndi_config 
<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
