### PR TITLE
[Fix]: kubeseal writes `SealedSecret` manifests as JSON despite `.yaml` filename suffix

### DIFF
--- a/src/outputs/sealed-secret-manifest.ts
+++ b/src/outputs/sealed-secret-manifest.ts
@@ -324,6 +324,7 @@ const getSealedSecretManifestWithKSC = async (
       `--secret-file=${secretPath}`,
       `--scope=cluster-wide`,
       `--allow-empty-data`,
+      `--format=yaml`,
     ],
     stderr: "piped",
     stdout: "piped",


### PR DESCRIPTION
# Description

- [x] `cndi ow` writes SealedSecret manifests as YAML in accordance with their file names

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
