### PR TITLE
[Bug]: Terraform Variables not ingested in Windows

### DIFF
--- a/src/getTF_VARs.ts
+++ b/src/getTF_VARs.ts
@@ -150,37 +150,37 @@ export async function getTF_VARs(
         ),
       ];
     }
-    env.set("TF_VAR_argocd_admin_password", argocd_admin_password);
-    env.set("TF_VAR_sealed_secrets_public_key", sealed_secrets_public_key);
+    env.set("TF_VAR_ARGOCD_ADMIN_PASSWORD", argocd_admin_password);
+    env.set("TF_VAR_SEALED_SECRETS_PUBLIC_KEY", sealed_secrets_public_key);
     env.set(
-      "TF_VAR_sealed_secrets_private_key",
+      "TF_VAR_SEALED_SECRETS_PRIVATE_KEY",
       sealed_secrets_private_key,
     );
   }
 
   if (git_ssh_private_key) {
-    env.set("TF_VAR_git_ssh_private_key", git_ssh_private_key);
+    env.set("TF_VAR_GIT_SSH_PRIVATE_KEY", git_ssh_private_key);
   } else {
-    git_username && env.set("TF_VAR_git_username", git_username);
-    git_token && env.set("TF_VAR_git_token", git_token);
+    git_username && env.set("TF_VAR_GIT_USERNAME", git_username);
+    git_token && env.set("TF_VAR_GIT_TOKEN", git_token);
   }
 
   const ssh_public_key = Deno.env.get("SSH_PUBLIC_KEY");
 
   // only required for microk8s
   if (ssh_public_key) {
-    env.set("TF_VAR_ssh_public_key", ssh_public_key);
+    env.set("TF_VAR_SSH_PUBLIC_KEY", ssh_public_key);
   } else {
-    env.set("TF_VAR_ssh_public_key", "");
+    env.set("TF_VAR_SSH_PUBLIC_KEY", "");
   }
 
-  env.set("TF_VAR_git_repo", git_repo);
+  env.set("TF_VAR_GIT_REPO", git_repo);
 
   // aks module requires cred be set explicitly
   const azurerm_client_id = Deno.env.get("ARM_CLIENT_ID") || "";
   const azurerm_client_secret = Deno.env.get("ARM_CLIENT_SECRET") || "";
-  env.set("TF_VAR_arm_client_id", azurerm_client_id);
-  env.set("TF_VAR_arm_client_secret", azurerm_client_secret);
+  env.set("TF_VAR_ARM_CLIENT_ID", azurerm_client_id);
+  env.set("TF_VAR_ARM_CLIENT_SECRET", azurerm_client_secret);
 
   return [undefined, Object.fromEntries(env)];
 }

--- a/src/outputs/cndi-run-workflow.ts
+++ b/src/outputs/cndi-run-workflow.ts
@@ -210,8 +210,8 @@ const getEnv = (
   for (
     const key of Object.keys(config?.infrastructure?.terraform?.variable || {})
   ) {
-    const envKey = `TF_VAR_${key.toLowerCase()}`;
-    const envVal = `\${{ secrets.TF_VAR_${key.toLowerCase()} }}`;
+    const envKey = `TF_VAR_${key.toUpperCase()}`;
+    const envVal = `\${{ secrets.TF_VAR_${key.toUpperCase()} }}`;
     injectEnv[envKey] = envVal;
   }
 

--- a/src/outputs/terraform/CNDICoreTerraformStack.ts
+++ b/src/outputs/terraform/CNDICoreTerraformStack.ts
@@ -29,14 +29,14 @@ export class CNDITerraformStack extends TerraformStack {
       cndi_project_name,
     );
 
-    this.variables.git_repo = new TerraformVariable(this, "git_repo", {
+    this.variables.git_repo = new TerraformVariable(this, "GIT_REPO", {
       type: "string",
       description: "repository URL to access",
     });
 
     this.variables.argocd_admin_password = new TerraformVariable(
       this,
-      "argocd_admin_password",
+      "ARGOCD_ADMIN_PASSWORD",
       {
         type: "string",
         description: "password for accessing the argo ui",
@@ -45,7 +45,7 @@ export class CNDITerraformStack extends TerraformStack {
 
     this.variables.sealed_secrets_private_key = new TerraformVariable(
       this,
-      "sealed_secrets_private_key",
+      "SEALED_SECRETS_PRIVATE_KEY",
       {
         type: "string",
         description: "private key for decrypting sealed secrets",
@@ -54,7 +54,7 @@ export class CNDITerraformStack extends TerraformStack {
 
     this.variables.sealed_secrets_public_key = new TerraformVariable(
       this,
-      "sealed_secrets_public_key",
+      "SEALED_SECRETS_PUBLIC_KEY",
       {
         type: "string",
         description: "public key for encrypting sealed secrets",
@@ -63,7 +63,7 @@ export class CNDITerraformStack extends TerraformStack {
 
     this.variables.ssh_public_key = new TerraformVariable(
       this,
-      "ssh_public_key",
+      "SSH_PUBLIC_KEY",
       {
         type: "string",
         description: "public key for accessing cluster nodes",
@@ -73,20 +73,20 @@ export class CNDITerraformStack extends TerraformStack {
     if (useSshRepoAuth()) {
       this.variables.git_ssh_private_key = new TerraformVariable(
         this,
-        "git_ssh_private_key",
+        "GIT_SSH_PRIVATE_KEY",
         {
           type: "string",
           description: "private key for accessing cluster repository",
         },
       );
     } else {
-      this.variables.git_token = new TerraformVariable(this, "git_token", {
+      this.variables.git_token = new TerraformVariable(this, "GIT_TOKEN", {
         type: "string",
         description: "password for accessing cluster repository",
       });
       this.variables.git_username = new TerraformVariable(
         this,
-        "git_username",
+        "GIT_USERNAME",
         {
           type: "string",
           description: "username for accessing cluster repository",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -577,12 +577,12 @@ function getUserDataTemplateFileString(
   doBase64Encode?: boolean,
 ) {
   let leaderString =
-    `templatefile("microk8s-cloud-init-leader.yml.tftpl",{"bootstrap_token": "\${local.bootstrap_token}", "git_repo": "\${var.git_repo}", "git_token": "\${var.git_token}", "git_username": "\${var.git_username}", "sealed_secrets_private_key": "\${base64encode(var.sealed_secrets_private_key)}", "sealed_secrets_public_key": "\${base64encode(var.sealed_secrets_public_key)}", "argocd_admin_password": "\${var.argocd_admin_password}"})`;
+    `templatefile("microk8s-cloud-init-leader.yml.tftpl",{"bootstrap_token": "\${local.bootstrap_token}", "git_repo": "\${var.GIT_REPO}", "git_token": "\${var.GIT_TOKEN}", "git_username": "\${var.GIT_USERNAME}", "sealed_secrets_private_key": "\${base64encode(var.SEALED_SECRETS_PRIVATE_KEY)}", "sealed_secrets_public_key": "\${base64encode(var.SEALED_SECRETS_PUBLIC_KEY)}", "argocd_admin_password": "\${var.ARGOCD_ADMIN_PASSWORD}"})`;
   if (useSshRepoAuth()) {
     // this value contains base64 encoded values for git_repo and git_ssh_private_key
     // it's required in order to support multiline values in cloud-init
     leaderString =
-      `templatefile("microk8s-cloud-init-leader.yml.tftpl",{"bootstrap_token": "\${local.bootstrap_token}", "git_repo_encoded": "\${base64encode(var.git_repo)}", "git_repo": "\${var.git_repo}", "git_ssh_private_key": "\${base64encode(var.git_ssh_private_key)}", "sealed_secrets_private_key": "\${base64encode(var.sealed_secrets_private_key)}", "sealed_secrets_public_key": "\${base64encode(var.sealed_secrets_public_key)}", "argocd_admin_password": "\${var.argocd_admin_password}"})`;
+      `templatefile("microk8s-cloud-init-leader.yml.tftpl",{"bootstrap_token": "\${local.bootstrap_token}", "git_repo_encoded": "\${base64encode(var.GIT_REPO)}", "git_repo": "\${var.GIT_REPO}", "git_ssh_private_key": "\${base64encode(var.GIT_SSH_PRIVATE_KEY)}", "sealed_secrets_private_key": "\${base64encode(var.SEALED_SECRETS_PRIVATE_KEY)}", "sealed_secrets_public_key": "\${base64encode(var.SEALED_SECRETS_PUBLIC_KEY)}", "argocd_admin_password": "\${var.ARGOCD_ADMIN_PASSWORD}"})`;
   }
   let workerString =
     `templatefile("microk8s-cloud-init-worker.yml.tftpl",{"bootstrap_token": "\${local.bootstrap_token}", "leader_node_ip": "\${local.leader_node_ip}"})`;

--- a/templates/clusterless-basic.yaml
+++ b/templates/clusterless-basic.yaml
@@ -18,12 +18,12 @@ outputs:
     infrastructure:
       terraform:
         variable:
-          visitor:
+          VISITOR:
             type: "string"
             description: "The name of the visitor"
         output:
           greeting:
-            value: "Hello, ${upper(var.visitor)}!"
+            value: "Hello, ${upper(var.VISITOR)}!"
 
   env:
     $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/common/git-credentials-{{ $cndi.get_prompt_response(git_credentials_mode) }}-env.yaml):
@@ -35,7 +35,7 @@ outputs:
     $cndi.get_block(https://raw.githubusercontent.com/polyseam/cndi/main/blocks/common/clusterless/env.yaml):
       {}
     $cndi.comment(configure_greeter): "Change who you are greeting:"
-    TF_VAR_visitor: "{{ $cndi.get_prompt_response(visitor) }}"
+    TF_VAR_VISITOR: "{{ $cndi.get_prompt_response(visitor) }}"
 
   readme:
     project_name: "# {{ $cndi.get_prompt_response(project_name) }}"


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #1103

# Description

Until now CNDI assumed that every terraform variable name would be lowercase, however when passing values from the environment on a windows machine, environment variables were always inserted as uppercase. The easiest fix is to just reflect every terraform variable as `TF_VAR_MY_VAL` instead of `TF_VAR_my_val`.

That's what this PR does.

This change should be functionally transparent to the user, because we were always choosing how to reflect these values anyway.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
