### PR TITLE
provide backwards compatible TF_VAR vals

### DIFF
--- a/src/getTF_VARs.ts
+++ b/src/getTF_VARs.ts
@@ -4,6 +4,8 @@ import { ErrOut } from "errout";
 
 const label = ccolors.faded("\nsrc/setTF_VARs.ts:");
 
+const BACKWARDS_COMPATIBILITY = true;
+
 export async function getTF_VARs(
   projectDir: string,
 ): Promise<PxResult<Record<string, string>>> {
@@ -181,6 +183,17 @@ export async function getTF_VARs(
   const azurerm_client_secret = Deno.env.get("ARM_CLIENT_SECRET") || "";
   env.set("TF_VAR_ARM_CLIENT_ID", azurerm_client_id);
   env.set("TF_VAR_ARM_CLIENT_SECRET", azurerm_client_secret);
+
+  // We want to set TF_VAR_UPPERCASED and TF_VAR_lowercase for backwards compatibility <= 2.25.3
+  if (BACKWARDS_COMPATIBILITY) {
+    for (const [key, value] of env.entries()) {
+      const components = key.split("TF_VAR_");
+      if (components && components.length > 1) {
+        const newKey = `TF_VAR_${components[1].toLowerCase()}`;
+        env.set(newKey, value);
+      }
+    }
+  }
 
   return [undefined, Object.fromEntries(env)];
 }


### PR DESCRIPTION
# Description

Just a quick patch which ensures terraform variables are set as both `TF_VAR_FOO` and `TF_VAR_foo` to ensure compatibility with cndi versions `<=2.25.3` and versions `>2.25.3`

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
