### PR TITLE
[Bug]: Deno to v2.1.4 to fix Windows compiled binaries

### DIFF
--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.3"
+          deno-version: "v2.1.4"
       - name: deno build-win
         run: deno task build-win
       - name: win cndi --help

--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.4"
+          deno-version: "v2.1.5"
       - name: deno build-win
         run: deno task build-win
       - name: win cndi --help

--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.5"
+          deno-version: "v2.1.4"
       - name: deno build-linux
         run: deno task build-linux
       - name: linux cndi --help
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.5"
+          deno-version: "v2.1.4"
       - name: deno build-mac
         run: deno task build-mac
       - name: mac cndi --help
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.5"
+          deno-version: "v2.1.4"
       - name: deno build-win
         run: deno task build-win
       - name: win cndi --help

--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.0.0"
+          deno-version: "v2.1.0"
       - name: deno build-win
         run: deno task build-win
       - name: win cndi --help

--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.5"
+          deno-version: "v2.0.0"
       - name: deno build-win
         run: deno task build-win
       - name: win cndi --help

--- a/.github/workflows/bin-build.yaml
+++ b/.github/workflows/bin-build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.0"
+          deno-version: "v2.1.3"
       - name: deno build-win
         run: deno task build-win
       - name: win cndi --help

--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.1.5"
+          deno-version: "v2.1.4"
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main-latest.yaml
+++ b/.github/workflows/main-latest.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.1.5
+          deno-version: v2.1.4
 
       - run: deno lint
 
@@ -31,7 +31,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.1.5
+          deno-version: v2.1.4
 
       - run: deno task build
 

--- a/.github/workflows/main-pull.yml
+++ b/.github/workflows/main-pull.yml
@@ -12,7 +12,7 @@ jobs:
       - name: use deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.1.5
+          deno-version: v2.1.4
 
       - name: Check formatting
         run: deno fmt --check

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "version": "2.25.4",
-  "deno_version": "2.1.5",
+  "deno_version": "2.1.4",
   "tasks": {
     "tar-win": "tar -czvf dist/release-archives/cndi-win.tar.gz -C dist/win/in .",
     "tar-linux": "tar -czvf dist/release-archives/cndi-linux.tar.gz -C dist/linux/in .",

--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -56,7 +56,7 @@ export default async function cndi() {
 
   try {
     ensureDirSync(stagingDirectory);
-  } catch (_errorEnsuringDirectory) {
+  } catch (errorEnsuringDirectory) {
     const err = new ErrOut([
       ccolors.error(`Could not create staging directory`),
       ccolors.key_name(`"${stagingDirectory}"`),
@@ -64,6 +64,7 @@ export default async function cndi() {
       label,
       code: 10,
       id: "error-ensuring-stagingDirectory",
+      cause: errorEnsuringDirectory as Error,
     });
     await err.out();
     return;

--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -56,7 +56,7 @@ export default async function cndi() {
 
   try {
     ensureDirSync(stagingDirectory);
-  } catch (errorEnsuringDirectory) {
+  } catch (_errorEnsuringDirectory) {
     const err = new ErrOut([
       ccolors.error(`Could not create staging directory`),
       ccolors.key_name(`"${stagingDirectory}"`),
@@ -64,7 +64,6 @@ export default async function cndi() {
       label,
       code: 10,
       id: "error-ensuring-stagingDirectory",
-      cause: errorEnsuringDirectory as Error,
     });
     await err.out();
     return;


### PR DESCRIPTION
# Description

For some reason binaries compiled for Windows using Deno [`v2.1.5`](https://github.com/denoland/deno/releases/tag/v2.1.5) seem to throw errors like what would happen if you tried to run Typescript in a Javascript engine.

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
