### PR TITLE
build: copy binaries into release with prev. naming scheme

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -37,6 +37,18 @@ jobs:
       - name: Build
         run: deno task build
 
+      # this ensures `cndi upgrade` works for users with cndi@<v2.27
+      # it's a waste of disk space for GitHub and we should remove it when we are certain all users have upgraded
+      - name: duplicate macos archive for backwards compatibility
+        # assumes the user will be on apple silicon despite the previous macos version being amd64
+        run: cp ./dist/release-archives/cndi-mac-arm64.tar.gz ./dist/release-archives/cndi-mac.tar.gz
+
+      - name: duplicate linux archive for backwards compatibility
+        run: cp ./dist/release-archives/cndi-linux-amd64.tar.gz ./dist/release-archives/cndi-linux.tar.gz
+
+      - name: duplicate windows archive for backwards compatibility
+        run: cp ./dist/release-archives/cndi-win-amd64.tar.gz ./dist/release-archives/cndi-win.tar.gz
+
       - name: Install cndi dependency binaries
         run: mkdir -p /home/runner/.cndi/bin && cp ./dist/linux-amd64/in/* /home/runner/.cndi/bin
 


### PR DESCRIPTION
# Description

- [x] added build step to gh-release Workflow which automatically ensures old (<`v2.27.0`) `cndi upgrade` calls still hit valid archives

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
