### PR TITLE
feat: log the number of responses pulled during init/create

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -234,8 +234,8 @@ const createCommand = new Command()
         console.error(
           label,
           ccolors.error("Error loading"),
-          ccolors.key_name("cndi_responses.yaml"),
-          ccolors.error("file"),
+          ccolors.key_name(options.responsesFile),
+          ccolors.error("as responses file"),
         );
         ccolors.caught(errLoadingResponsesFile as Error, 1502);
         console.log(
@@ -257,8 +257,8 @@ const createCommand = new Command()
       const err = new ErrOut(
         [
           ccolors.error("Error parsing"),
-          ccolors.key_name("cndi_responses.yaml"),
-          ccolors.error("file"),
+          ccolors.key_name(options.responsesFile),
+          ccolors.error("as responses file"),
         ],
         {
           label,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -271,7 +271,19 @@ const createCommand = new Command()
       return;
     }
 
-    if (responses) {
+    const responseCount = Object.keys(responses).length;
+
+    if (responseCount) {
+      console.log();
+      console.log(
+        ccolors.key_name("cndi"),
+        "is pulling",
+        ccolors.success(responseCount.toString()),
+        "responses from",
+        ccolors.success(options.responsesFile) +
+          "!",
+      );
+      console.log();
       overrides = responses as Record<
         string,
         CNDITemplatePromptResponsePrimitive

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -171,8 +171,24 @@ const initCommand = new Command()
       }
 
       try {
-        const responses = YAML.parse(responseFileText);
-        if (responses) {
+        const responses = YAML.parse(responseFileText) as Record<
+          string,
+          CNDITemplatePromptResponsePrimitive
+        >;
+
+        const responseCount = Object.keys(responses).length;
+
+        if (responseCount) {
+          console.log();
+          console.log(
+            ccolors.key_name("cndi"),
+            "is pulling",
+            ccolors.success(responseCount.toString()),
+            "responses from",
+            ccolors.success(options.responsesFile) +
+              "!",
+          );
+          console.log();
           overrides = responses as Record<
             string,
             CNDITemplatePromptResponsePrimitive


### PR DESCRIPTION
# Description

- [x] added message which notes when `cndi` is pulling in values from a `responses_file`
- [x] fix error message to use `responses_file` name if it is non-default 

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
