### PR TITLE
[Enhancement]: Template aliases

### DIFF
--- a/src/known-templates.ts
+++ b/src/known-templates.ts
@@ -3,7 +3,13 @@
 export const POLYSEAM_TEMPLATE_DIRECTORY_URL =
   "https://raw.githubusercontent.com/polyseam/cndi/main/templates/";
 
-export const KNOWN_TEMPLATES = [
+type KnownTemplate = {
+  name: string;
+  url: string;
+  aliases?: string[];
+};
+
+export const KNOWN_TEMPLATES: KnownTemplate[] = [
   {
     name: "basic",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/basic.yaml`,
@@ -15,12 +21,12 @@ export const KNOWN_TEMPLATES = [
   {
     name: "cnpg",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/cnpg.yaml`,
-    aliases: ['postgres']
+    aliases: ["postgres"],
   },
   {
     name: "kafka",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/kafka.yaml`,
-    aliases: ['strimzi']
+    aliases: ["strimzi"],
   },
   {
     name: "wordpress",
@@ -37,7 +43,7 @@ export const KNOWN_TEMPLATES = [
   {
     name: "fns",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/fns.yaml`,
-    aliases: ['functions']
+    aliases: ["functions"],
   },
   {
     name: "neo4j",

--- a/src/known-templates.ts
+++ b/src/known-templates.ts
@@ -15,10 +15,12 @@ export const KNOWN_TEMPLATES = [
   {
     name: "cnpg",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/cnpg.yaml`,
+    aliases: ['postgres']
   },
   {
     name: "kafka",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/kafka.yaml`,
+    aliases: ['strimzi']
   },
   {
     name: "wordpress",
@@ -35,6 +37,7 @@ export const KNOWN_TEMPLATES = [
   {
     name: "fns",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/fns.yaml`,
+    aliases: ['functions']
   },
   {
     name: "neo4j",

--- a/src/known-templates.ts
+++ b/src/known-templates.ts
@@ -21,7 +21,7 @@ export const KNOWN_TEMPLATES: KnownTemplate[] = [
   {
     name: "cnpg",
     url: `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/cnpg.yaml`,
-    aliases: ["postgres"],
+    aliases: ["pg", "postgres", "postgresql"],
   },
   {
     name: "kafka",

--- a/src/use-template/mod.ts
+++ b/src/use-template/mod.ts
@@ -16,7 +16,10 @@ import type {
   PromptType,
 } from "./types.ts";
 
-import { POLYSEAM_TEMPLATE_DIRECTORY_URL } from "known-templates";
+import {
+  KNOWN_TEMPLATES,
+  POLYSEAM_TEMPLATE_DIRECTORY_URL,
+} from "known-templates";
 
 import {
   findPositionOfCNDICallEndToken,
@@ -417,8 +420,20 @@ async function getTemplateBodyStringForIdentifier(
       }
     } else {
       // Bare Name
+      const found = KNOWN_TEMPLATES.find(
+        (kt) => {
+          // check if the template identifier matches a name or an alias
+          if (kt.name === templateIdentifier) return true;
+          if (kt?.aliases) return kt.aliases.includes(templateIdentifier);
+        },
+      );
+
+      // construct a URL to enable --template 'foo' where 'foo' is in /templates but not in KNOWN_TEMPLATES
+      const preReleaseTemplateURL =
+        `${POLYSEAM_TEMPLATE_DIRECTORY_URL}/${templateIdentifier}.yaml`;
+
       templateIdentifierURL = new URL(
-        POLYSEAM_TEMPLATE_DIRECTORY_URL + templateIdentifier + ".yaml",
+        found?.url || preReleaseTemplateURL,
       );
     }
   }


### PR DESCRIPTION
# Related issue

<!-- Please link the primary issue(s) related to this work and other relevant issues -->
<!-- If you are an internal CNDI contributor, please ensure that the associated issue status is set throughout the lifecycle of this Pull Request -->
<!-- It should be "In Progress" when this PR is submitted as a Draft -->
<!-- It should be "In Review" when this PR is marked as ready for review -->

Issue #1099

# Description

- [x] KNOWN_TEMPLATES now includes `aliases?: string[]` to support `-t cnpg` and `-t postgres`
- [x] `use-template` now knows to check for alias matches 

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
