### PR TITLE
[Bug]: `--responses-file` ignoring non-string values

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.27.4",
+  "version": "2.27.5",
   "deno_version": "2.1.9",
   "tasks": {
     "tar-win-amd64": "tar -czvf dist/release-archives/cndi-win-amd64.tar.gz -C dist/win-amd64/in .",

--- a/docs/error-code-reference.json
+++ b/docs/error-code-reference.json
@@ -76,7 +76,7 @@
   },
   {
     "code": 401,
-    "message": "failed to load `./cndi_responses.yaml` during 'cndi init'",
+    "message": "failed to load custom `cndi_responses.yaml` during 'cndi init'",
     "discussion_link": "https://github.com/orgs/polyseam/discussions/889"
   },
   {
@@ -560,7 +560,7 @@
   },
   {
     "code": 1502,
-    "message": "failed to read `./cndi_responses.yaml` during 'cndi create'",
+    "message": "failed to read custom `cndi_responses.yaml` during 'cndi create'",
     "discussion_link": "https://github.com/orgs/polyseam/discussions/898"
   },
   {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -177,7 +177,7 @@ const createCommand = new Command()
         );
         await err.out();
         return;
-      } else {
+      } else if (!(errLoadingResponsesFile instanceof Deno.errors.NotFound)) {
         console.error(
           label,
           ccolors.error("Error loading"),

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -158,7 +158,6 @@ const createCommand = new Command()
     let responsesFileText = "";
 
     try {
-      console.log("options.responsesFile", options.responsesFile);
       responsesFileText = await Deno.readTextFile(options.responsesFile);
     } catch (errLoadingResponsesFile) {
       if (errLoadingResponsesFile instanceof Deno.errors.NotFound) {
@@ -188,9 +187,7 @@ const createCommand = new Command()
           CNDITemplatePromptResponsePrimitive
         >;
         for (const [key, value] of Object.entries(parsed)) {
-          if (typeof value === "string") {
-            responses[key] = value;
-          }
+          responses[key] = value;
         }
       } catch (errorParsingResponses) {
         const err = new ErrOut(

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -69,7 +69,7 @@ type EchoCreateOptions = {
   skipPush?: boolean;
 };
 
-const DEFAULT_RESPONSES_FILE_PATH = path.join(
+const defaultResponsesFilePath = path.join(
   Deno.cwd(),
   "cndi_responses.yaml",
 );
@@ -90,7 +90,7 @@ const echoCreate = (options: EchoCreateOptions, slug?: string) => {
     : "";
   const cndiCreateSkipPush = options.skipPush ? " --skip-push" : "";
   const cndiCreateResponsesFile =
-    options.responsesFile === DEFAULT_RESPONSES_FILE_PATH
+    options.responsesFile === defaultResponsesFilePath
       ? ""
       : ` --responses-file ${options.responsesFile}`;
   console.log(
@@ -117,7 +117,7 @@ const createCommand = new Command()
     "-r, --responses-file <responses_file:string>",
     "Path to YAML 'responses file' to supply to Template prompts.",
     {
-      default: DEFAULT_RESPONSES_FILE_PATH,
+      default: defaultResponsesFilePath,
     },
   )
   .option("--skip-push", "Skip pushing to remote repository")

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -160,8 +160,23 @@ const createCommand = new Command()
     try {
       responsesFileText = await Deno.readTextFile(options.responsesFile);
     } catch (errLoadingResponsesFile) {
-      if (errLoadingResponsesFile instanceof Deno.errors.NotFound) {
-        // no responses file found, continue with defaults
+      if (options.responsesFile !== defaultResponsesFilePath) {
+        // user specified a responses file that doesn't exist
+        const err = new ErrOut(
+          [
+            ccolors.error("Error reading"),
+            ccolors.key_name(options.responsesFile),
+            ccolors.error("as responses file"),
+          ],
+          {
+            label,
+            code: 1503,
+            id: "create/!isValidYAML(responsesFile)",
+            cause: errLoadingResponsesFile as Error,
+          },
+        );
+        await err.out();
+        return;
       } else {
         console.error(
           label,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -165,7 +165,7 @@ const initCommand = new Command()
         );
         await err.out();
         return;
-      } else {
+      } else if (!(errLoadingResponsesFile instanceof Deno.errors.NotFound)) {
         console.error(
           label,
           ccolors.error("Error loading"),

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -148,8 +148,23 @@ const initCommand = new Command()
     try {
       responsesFileText = await Deno.readTextFile(options.responsesFile);
     } catch (errLoadingResponsesFile) {
-      if (errLoadingResponsesFile instanceof Deno.errors.NotFound) {
-        // no responses file found, continue with defaults
+      if (options.responsesFile !== defaultResponsesFilePath) {
+        // user specified a responses file that doesn't exist
+        const err = new ErrOut(
+          [
+            ccolors.error("Error reading"),
+            ccolors.key_name(options.responsesFile),
+            ccolors.error("as responses file"),
+          ],
+          {
+            label,
+            code: 401,
+            id: "init/!isValidYAML(responsesFile)",
+            cause: errLoadingResponsesFile as Error,
+          },
+        );
+        await err.out();
+        return;
       } else {
         console.error(
           label,
@@ -182,11 +197,11 @@ const initCommand = new Command()
           [
             ccolors.error("Error parsing"),
             ccolors.key_name(options.responsesFile),
-            ccolors.error("as responses file"),
+            ccolors.error("as yaml responses file"),
           ],
           {
             label,
-            code: 1503,
+            code: 402,
             id: "init/!isValidYAML(responsesFile)",
             cause: errorParsingResponses as Error,
           },


### PR DESCRIPTION
- [x] fix issue where non-string responseFile entries were ignored
- [x] updated deno patch `2.1.7` -> `2.1.9`
 
# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
