### PR TITLE
[Fix]: validate `project_name` when prompted by Template

### DIFF
--- a/blocks/common/cluster/core-prompts.yaml
+++ b/blocks/common/cluster/core-prompts.yaml
@@ -4,6 +4,8 @@
     Please name your CNDI project:
   type: Input
   default: "my-cndi-project"
+  validators:
+    - is_slug
 
 - name: deployment_target_provider
   type: Select

--- a/blocks/common/clusterless/core-prompts.yaml
+++ b/blocks/common/clusterless/core-prompts.yaml
@@ -5,6 +5,8 @@
     Please name your CNDI project:
   type: Input
   default: "my-cndi-project"
+  validators:
+    - is_slug
 
 - name: deployment_target_provider
   type: Select

--- a/docs/error-code-reference.json
+++ b/docs/error-code-reference.json
@@ -285,6 +285,11 @@
     "discussion_link": "https://github.com/orgs/polyseam/discussions/568"
   },
   {
+    "code": 903,
+    "message": "cndi_config invalid: 'project_name' failed validation",
+    "discussion_link": "https://github.com/orgs/polyseam/discussions/1126"
+  },
+  {
     "code": 905,
     "message": "cndi_config invalid: contains at least one node with a missing 'name'",
     "discussion_link": "https://github.com/orgs/polyseam/discussions/571"


### PR DESCRIPTION
# Description

- [x] ensure `project_name` is validated during Template prompts

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
