### PR TITLE
[Enhancement] limit `project_name` to 48 character strings

### DIFF
--- a/blocks/common/cluster/core-prompts.yaml
+++ b/blocks/common/cluster/core-prompts.yaml
@@ -6,6 +6,7 @@
   default: "my-cndi-project"
   validators:
     - is_slug
+    - max_length: 32
 
 - name: deployment_target_provider
   type: Select

--- a/blocks/common/cluster/core-prompts.yaml
+++ b/blocks/common/cluster/core-prompts.yaml
@@ -6,7 +6,7 @@
   default: "my-cndi-project"
   validators:
     - is_slug
-    - max_length: 32
+    - max_length: 48
 
 - name: deployment_target_provider
   type: Select

--- a/blocks/common/clusterless/core-prompts.yaml
+++ b/blocks/common/clusterless/core-prompts.yaml
@@ -7,6 +7,7 @@
   default: "my-cndi-project"
   validators:
     - is_slug
+    - max_length: 48
 
 - name: deployment_target_provider
   type: Select

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,3 +52,5 @@ export const EFFECT_VALUES = [
   PREFER_NO_SCHEDULE,
   NO_EXECUTE,
 ] as const;
+
+export const PROJECT_NAME_MAX_LENGTH = 48;

--- a/src/outputs/terraform/CNDICoreTerraformStack.ts
+++ b/src/outputs/terraform/CNDICoreTerraformStack.ts
@@ -9,6 +9,7 @@ import {
 import { useSshRepoAuth } from "src/utils.ts";
 import { CNDIConfig } from "src/types.ts";
 import { ccolors } from "deps";
+import { PROJECT_NAME_MAX_LENGTH } from "consts";
 
 export class CNDITerraformStack extends TerraformStack {
   variables: Record<string, TerraformVariable> = {};
@@ -26,13 +27,13 @@ export class CNDITerraformStack extends TerraformStack {
 
     if (
       cndi_config && cndi_config.project_name &&
-      cndi_config.project_name.length > 32
+      cndi_config.project_name.length > PROJECT_NAME_MAX_LENGTH
     ) {
       // should be unreachable, validated upstream
       this.locals.cndi_project_name = new TerraformLocal(
         this,
         "cndi_project_name",
-        cndi_project_name.substring(0, 32),
+        cndi_project_name.substring(0, 48),
       );
       console.log();
       console.log(
@@ -42,7 +43,7 @@ export class CNDITerraformStack extends TerraformStack {
         ccolors.warn(
           `is too long.`,
         ),
-        ccolors.warn(`truncating to 32 characters.`),
+        ccolors.warn(`truncating to ${PROJECT_NAME_MAX_LENGTH} characters.`),
       );
       console.log();
     } else {

--- a/src/outputs/terraform/CNDICoreTerraformStack.ts
+++ b/src/outputs/terraform/CNDICoreTerraformStack.ts
@@ -8,6 +8,7 @@ import {
 
 import { useSshRepoAuth } from "src/utils.ts";
 import { CNDIConfig } from "src/types.ts";
+import { ccolors } from "deps";
 
 export class CNDITerraformStack extends TerraformStack {
   variables: Record<string, TerraformVariable> = {};
@@ -23,11 +24,34 @@ export class CNDITerraformStack extends TerraformStack {
 
     const cndi_project_name = cndi_config.project_name!;
 
-    this.locals.cndi_project_name = new TerraformLocal(
-      this,
-      "cndi_project_name",
-      cndi_project_name,
-    );
+    if (
+      cndi_config && cndi_config.project_name &&
+      cndi_config.project_name.length > 32
+    ) {
+      // should be unreachable, validated upstream
+      this.locals.cndi_project_name = new TerraformLocal(
+        this,
+        "cndi_project_name",
+        cndi_project_name.substring(0, 32),
+      );
+      console.log();
+      console.log(
+        ccolors.key_name("cndi_config.yaml[project_name]"),
+        ccolors.warn("value"),
+        ccolors.user_input(`"${cndi_project_name}"`),
+        ccolors.warn(
+          `is too long.`,
+        ),
+        ccolors.warn(`truncating to 32 characters.`),
+      );
+      console.log();
+    } else {
+      this.locals.cndi_project_name = new TerraformLocal(
+        this,
+        "cndi_project_name",
+        cndi_project_name,
+      );
+    }
 
     this.variables.git_repo = new TerraformVariable(this, "GIT_REPO", {
       type: "string",

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -190,7 +190,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
       `cndi_azurerm_kubernetes_cluster`,
       {
         location: this.locals.arm_region.asString,
-        name: `cndi-aks-cluster-${project_name}`,
+        name: `cndi-aks-${project_name}`,
         kubernetesVersion: DEFAULT_K8S_VERSION,
         resourceGroupName: this.rg.name,
         defaultNodePool: {
@@ -200,7 +200,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
         },
         tags,
         skuTier: "Free",
-        dnsPrefix: `cndi-aks-${project_name}`,
+        dnsPrefix: `cndi-${project_name}`,
         networkProfile: {
           loadBalancerSku: "standard",
           // Azure CNI= networkPlugin: "azure"

--- a/src/outputs/terraform/azure/AzureAKSStack.ts
+++ b/src/outputs/terraform/azure/AzureAKSStack.ts
@@ -53,6 +53,10 @@ const AKSStackLabel = ccolors.faded(
   "\nsrc/outputs/terraform/azure/AzureAKSStack.ts:",
 );
 
+// https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/aks-common-issues-faq#what-naming-restrictions-are-enforced-for-aks-resources-and-parameters-
+
+// cluster names must be between 1-63 chars, letters, numbers, underscores, and hyphens
+
 // TODO: ensure that splicing project_name into tags.Name is safe
 export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
   constructor(scope: Construct, name: string, cndi_config: CNDIConfig) {
@@ -222,7 +226,7 @@ export default class AzureAKSTerraformStack extends AzureCoreTerraformStack {
         identity: {
           type: "SystemAssigned",
         },
-        nodeResourceGroup: `rg-${project_name}-cluster-resources`,
+        nodeResourceGroup: `nrg-cndi-${project_name}`,
       },
     );
 

--- a/src/outputs/terraform/azure/AzureCoreStack.ts
+++ b/src/outputs/terraform/azure/AzureCoreStack.ts
@@ -3,7 +3,6 @@ import { CNDIConfig } from "src/types.ts";
 import { CNDITerraformStack } from "../CNDICoreTerraformStack.ts";
 
 const DEFAULT_ARM_REGION = "eastus";
-// const CNDI_MAJOR_VERSION = "v2";
 
 export default class AzureCoreTerraformStack extends CNDITerraformStack {
   rg: CDKTFProviderAzure.resourceGroup.ResourceGroup;
@@ -32,7 +31,7 @@ export default class AzureCoreTerraformStack extends CNDITerraformStack {
       "cndi_azurerm_resource_group",
       {
         location: this.locals.arm_region.asString,
-        name: `rg-${this.locals.cndi_project_name.asString}`,
+        name: `rg-cndi-${this.locals.cndi_project_name.asString}`,
         tags: { CNDIProject: this.locals.cndi_project_name.asString },
       },
     );

--- a/src/use-template/util/validation.ts
+++ b/src/use-template/util/validation.ts
@@ -58,6 +58,14 @@ export const BuiltInValidators: Record<string, CNDIValidator> = {
     }
     return `'${val}' is not a valid URL`;
   },
+  max_length: ({ value, arg }: CNDIValidatorInput) => {
+    const len = arg as number;
+    if ((value as string).length <= len) {
+      return null;
+    }
+
+    return `must be at most ${len} characters long`;
+  },
   min_length: ({ value, type, arg }: CNDIValidatorInput) => {
     const len = arg as number;
     if ((value as string).length >= len) {

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -128,6 +128,26 @@ export default function validateConfig(
         label,
       },
     );
+  } else if (config.project_name?.length > 32) {
+    // project_name must be less than 32 characters
+    // because it is used downstream when provisioning infrastructure
+    console.log();
+    return new ErrOut(
+      [
+        ccolors.error("cndi_config file found was at "),
+        ccolors.user_input(`"${pathToConfig}"\n`),
+        ccolors.error("but the"),
+        ccolors.key_name('"project_name"'),
+        ccolors.error("is too long"),
+        ccolors.error("it must be 32 characters or less"),
+      ],
+      {
+        code: 904,
+        id: "validate/cndi_config/project_name.length>32",
+        metadata: { config },
+        label,
+      },
+    );
   }
 
   if (!config?.provider) {

--- a/src/validate/cndiConfig.ts
+++ b/src/validate/cndiConfig.ts
@@ -15,6 +15,7 @@ import {
   NO_EXECUTE,
   NO_SCHEDULE,
   PREFER_NO_SCHEDULE,
+  PROJECT_NAME_MAX_LENGTH,
 } from "consts";
 
 import { ErrOut } from "errout";
@@ -128,8 +129,8 @@ export default function validateConfig(
         label,
       },
     );
-  } else if (config.project_name?.length > 32) {
-    // project_name must be less than 32 characters
+  } else if (config.project_name?.length > PROJECT_NAME_MAX_LENGTH) {
+    // project_name must be less than 48 characters
     // because it is used downstream when provisioning infrastructure
     console.log();
     return new ErrOut(
@@ -139,11 +140,14 @@ export default function validateConfig(
         ccolors.error("but the"),
         ccolors.key_name('"project_name"'),
         ccolors.error("is too long"),
-        ccolors.error("it must be 32 characters or less"),
+        ccolors.error(
+          `it must be ${PROJECT_NAME_MAX_LENGTH} characters or less`,
+        ),
       ],
       {
         code: 904,
-        id: "validate/cndi_config/project_name.length>32",
+        id:
+          `validate/cndi_config/project_name.length>${PROJECT_NAME_MAX_LENGTH}`,
         metadata: { config },
         label,
       },


### PR DESCRIPTION
# Description

- [x] `project_name` length is validated to be 48 chars or fewer during `ow`
- [x] `project_name` validated in prompts during `create`
- [x] `prompt.max_length` added to validators

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
