### PR TITLE
feat: show help when cndi is ran without subcommands

### DIFF
--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -78,6 +78,11 @@ export default async function cndi() {
     .description("Cloud-Native Data Infrastructure")
     .meta("kubeseal", `v${KUBESEAL_VERSION}`)
     .meta("terraform", `v${TERRAFORM_VERSION}`)
+    .action(async function () {
+      this.showHelp();
+      await emitExitEvent(0);
+      Deno.exit(0);
+    })
     .globalOption("--welcome", "a new user has arrived!", {
       hidden: true,
     })

--- a/src/tests/commands/global.test.ts
+++ b/src/tests/commands/global.test.ts
@@ -1,0 +1,20 @@
+import { assert } from "test-deps";
+
+import { runCndi } from "src/tests/helpers/run-cndi.ts";
+
+Deno.env.set("CNDI_TELEMETRY", "debug");
+
+Deno.test(
+  "'cndi' should show help message when no subcommands are provided",
+  async (t) => {
+    const cwd = await Deno.makeTempDir();
+
+    await t.step("setup", async () => {
+      const { output } = await runCndi({
+        args: [],
+        cwd,
+      });
+      assert(output.includes("Usage:"));
+    });
+  },
+);


### PR DESCRIPTION
# Description

- [x] when `cndi` is called without arguments it displays the `--help` info

<!-- Please write a summary of the changes made here: -->
<!-- You may describe the before and after behavioural changes of a feature after the changes has been made. -->

# Test Instructions

<!-- Write instructions to help the reviewer test the changes -->
<!-- ie: To test this bug fix, click on the signup button and verify you are taken to the signup page -->

# Code of Conduct

By submitting this Pull Request, you agree to follow our
[Code of Conduct](https://github.com/polyseam/cndi/blob/main/CODE_OF_CONDUCT.md)

- [x] I agree to follow this CNDI's Code of Conduct

# Notes (Optional)

<!-- Additional notes that add context or help reviewers -->
